### PR TITLE
funnel: thicker back wall, bigger opening

### DIFF
--- a/openscad/funnel.scad
+++ b/openscad/funnel.scad
@@ -26,21 +26,26 @@
 
 magnet_radius = 5.5;  // Use 10x2mm magnets. 5.5 radius is good for hotgluing.  Use ~5 when just pushing magnets in.
 
+inner_bottom_radius = 10;
+outer_bottom_radius = inner_bottom_radius + 2;
+inner_top_radius = 31;
+outer_top_radius = inner_top_radius + 2;
+
 $fn=100;
 
 translate([0,0,40]) rotate([0,180,0])  // rotate & move for printing
 difference() {
   hull() {
-    cylinder(h=40, r1=11, r2=30);
-    translate([0,-11,0]) cylinder(h=40, r1=11, r2=30);
+    cylinder(h=40, r1=outer_bottom_radius, r2=outer_top_radius);
+    translate([0,-11,0]) cylinder(h=40, r1=outer_bottom_radius, r2=outer_top_radius);
   }
   difference() {
     hull() {
-      cylinder(h=41, r1=9, r2=28);
-      translate([0,-11,-.5]) cylinder(h=41, r1=9, r2=28);
+      cylinder(h=41, r1=inner_bottom_radius, r2=inner_top_radius);
+      translate([0,-11,-.5]) cylinder(h=41, r1=inner_bottom_radius, r2=inner_top_radius);
     }
     // back wall
-    translate([-40,-3.5,0]) cube(80);
+    translate([-40,-4.0,0]) cube(80);
   }
   // Cut the back
   translate([-40,0,-1]) cube(80);
@@ -48,6 +53,6 @@ difference() {
   // magnets
   translate([0, 0.3, 10]) rotate(a=[90,0,0]) cylinder(h=3, r=magnet_radius);
   translate([0, 0.3, 30]) rotate(a=[90,0,0]) cylinder(h=3, r=magnet_radius);
-  translate([15, 0.3, 30]) rotate(a=[90,0,0]) cylinder(h=3, r=magnet_radius);
-  translate([-15, 0.3, 30]) rotate(a=[90,0,0]) cylinder(h=3, r=magnet_radius);
+  translate([16, 0.3, 30]) rotate(a=[90,0,0]) cylinder(h=3, r=magnet_radius);
+  translate([-16, 0.3, 30]) rotate(a=[90,0,0]) cylinder(h=3, r=magnet_radius);
 }

--- a/stl/funnel.stl
+++ b/stl/funnel.stl
@@ -1,4314 +1,4300 @@
 solid OpenSCAD_Model
-  facet normal 0.907145 -0.0191093 -0.420384
+  facet normal 0.889852 -0.0207208 -0.455778
     outer loop
-      vertex -9.23171 -11 40
-      vertex -27.6103 -3.5 0
-      vertex -9.07372 -3.5 40
+      vertex -10.2561 -11 40
+      vertex -30.5809 -4 0
+      vertex -10.0931 -4 40
     endloop
   endfacet
-  facet normal 0.907145 -0.0191105 -0.420384
+  facet normal 0.889852 -0.0207208 -0.455778
     outer loop
-      vertex -27.6103 -3.5 0
-      vertex -9.23171 -11 40
-      vertex -27.7683 -11 0
+      vertex -30.5809 -4 0
+      vertex -10.2561 -11 40
+      vertex -30.7439 -11 0
     endloop
   endfacet
-  facet normal 0.412004 0.808461 -0.42029
+  facet normal -0.889695 0.0279688 -0.455697
     outer loop
-      vertex -11.8232 -36.1255 0
-      vertex -4.4283 -19.0995 40
-      vertex -3.93067 -19.3531 40
+      vertex 30.6835 -12.9228 0
+      vertex 10.2359 -11.644 40
+      vertex 10.2554 -11.0237 40
     endloop
   endfacet
-  facet normal 0.411088 0.808915 -0.420313
+  facet normal -0.889402 0.035108 -0.455776
     outer loop
-      vertex -4.4283 -19.0995 40
-      vertex -11.8232 -36.1255 0
-      vertex -11.8293 -36.1224 0
+      vertex 10.2359 -11.644 40
+      vertex 30.6835 -12.9228 0
+      vertex 30.6832 -12.9304 0
     endloop
   endfacet
-  facet normal -0.903362 0.085397 -0.420291
+  facet normal 0.0262372 0.889737 -0.455719
     outer loop
-      vertex 27.55 -14.4734 0
-      vertex 9.15891 -12.157 40
-      vertex 9.21147 -11.601 40
+      vertex 0 -41.7439 0
+      vertex -0.0237379 -21.2554 40
+      vertex 0 -21.2561 40
     endloop
   endfacet
-  facet normal -0.902726 0.0915809 -0.420356
+  facet normal 0.027948 0.889696 -0.455697
     outer loop
-      vertex 9.15891 -12.157 40
-      vertex 27.55 -14.4734 0
-      vertex 27.5493 -14.4803 0
+      vertex -0.0237379 -21.2554 40
+      vertex 0 -41.7439 0
+      vertex -1.92277 -41.6835 0
     endloop
   endfacet
-  facet normal 0.885552 0.197872 -0.420291
+  facet normal -0.766721 0.452179 -0.455712
     outer loop
-      vertex -8.94168 -13.2958 40
-      vertex -27.2749 -16.21 0
-      vertex -8.94635 -13.2749 40
+      vertex 26.9411 -25.811 0
+      vertex 8.9754 -15.9614 40
+      vertex 8.98749 -15.9409 40
     endloop
   endfacet
-  facet normal 0.885541 0.197924 -0.42029
+  facet normal -0.766164 0.453137 -0.455697
     outer loop
-      vertex -27.2749 -16.21 0
-      vertex -8.94168 -13.2958 40
-      vertex -26.8959 -17.9057 0
+      vertex 8.9754 -15.9614 40
+      vertex 26.9411 -25.811 0
+      vertex 25.9618 -27.4668 0
     endloop
   endfacet
-  facet normal -0.461862 0.78105 -0.42029
+  facet normal 0.499104 0.737023 -0.455733
     outer loop
-      vertex 13.3775 -35.3335 0
-      vertex 4.46587 -19.0789 40
-      vertex 14.8731 -34.4491 0
+      vertex -16.4797 -36.9536 0
+      vertex -6.02838 -19.2974 40
+      vertex -6.00874 -19.3107 40
     endloop
   endfacet
-  facet normal -0.461357 0.781345 -0.420297
+  facet normal 0.500327 0.736216 -0.455696
     outer loop
-      vertex 4.46587 -19.0789 40
-      vertex 13.3775 -35.3335 0
-      vertex 4.44741 -19.0898 40
+      vertex -6.02838 -19.2974 40
+      vertex -16.4797 -36.9536 0
+      vertex -18.0708 -35.8723 0
     endloop
   endfacet
-  facet normal 0.781411 0.461244 -0.420299
+  facet normal 0.35561 0.816032 -0.455668
     outer loop
-      vertex -8.07889 -15.4659 40
-      vertex -24.3335 -24.3775 0
-      vertex -8.08981 -15.4474 40
+      vertex -11.3176 -39.585 0
+      vertex -3.79732 -20.5264 40
+      vertex -3.77552 -20.5359 40
     endloop
   endfacet
-  facet normal 0.78105 0.461862 -0.42029
+  facet normal 0.353515 0.816924 -0.455699
     outer loop
-      vertex -24.3335 -24.3775 0
-      vertex -8.07889 -15.4659 40
-      vertex -23.4491 -25.8731 0
+      vertex -3.79732 -20.5264 40
+      vertex -11.3176 -39.585 0
+      vertex -13.0831 -38.821 0
     endloop
   endfacet
-  facet normal 0.903338 0.0856687 -0.420287
+  facet normal 0.816975 0.353398 -0.4557
     outer loop
-      vertex -9.21147 -11.601 40
-      vertex -27.7135 -12.7436 0
-      vertex -9.21349 -11.5797 40
+      vertex -9.52645 -14.7973 40
+      vertex -28.585 -22.3176 0
+      vertex -9.53588 -14.7755 40
     endloop
   endfacet
-  facet normal 0.903363 0.0853855 -0.42029
+  facet normal 0.816925 0.353515 -0.455698
     outer loop
-      vertex -27.7135 -12.7436 0
-      vertex -9.21147 -11.601 40
-      vertex -27.55 -14.4734 0
+      vertex -28.585 -22.3176 0
+      vertex -9.52645 -14.7973 40
+      vertex -27.821 -24.0831 0
     endloop
   endfacet
-  facet normal 0.906934 0.0288185 -0.420286
+  facet normal 0.816917 0.353533 -0.455699
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -27.7683 -11 0
-      vertex -9.23171 -11 40
+      vertex -9.27999 -15.3668 40
+      vertex -27.821 -24.0831 0
+      vertex -9.52645 -14.7973 40
     endloop
   endfacet
-  facet normal 0.906942 0.0285133 -0.42029
+  facet normal 0.813855 0.360422 -0.455781
     outer loop
-      vertex -27.7683 -11 0
-      vertex -9.23103 -11.0214 40
-      vertex -27.7137 -12.7367 0
+      vertex -27.821 -24.0831 0
+      vertex -9.27999 -15.3668 40
+      vertex -27.8179 -24.0901 0
     endloop
   endfacet
-  facet normal -0.0263286 0.90702 -0.420263
+  facet normal -0.501821 0.735226 -0.455652
     outer loop
-      vertex 1.73669 -38.7137 0
-      vertex 0.579663 -20.2135 40
-      vertex 1.74358 -38.7135 0
+      vertex 16.4734 -36.9579 0
+      vertex 6.00874 -19.3107 40
+      vertex 16.4797 -36.9536 0
     endloop
   endfacet
-  facet normal -0.0284323 0.906945 -0.420289
+  facet normal -0.500326 0.736216 -0.455697
     outer loop
-      vertex 0.579663 -20.2135 40
-      vertex 1.73669 -38.7137 0
-      vertex 0.0214407 -20.231 40
+      vertex 6.00874 -19.3107 40
+      vertex 16.4734 -36.9579 0
+      vertex 5.49549 -19.6595 40
     endloop
   endfacet
-  facet normal -0.896168 0.142283 -0.420283
+  facet normal -0.500327 0.736216 -0.455696
     outer loop
-      vertex 27.5483 -14.4871 0
-      vertex 9.06819 -12.7298 40
-      vertex 9.07154 -12.7087 40
+      vertex 16.4797 -36.9536 0
+      vertex 6.02838 -19.2974 40
+      vertex 18.0708 -35.8723 0
     endloop
   endfacet
-  facet normal -0.896212 0.141988 -0.42029
+  facet normal -0.499104 0.737023 -0.455733
     outer loop
-      vertex 9.06819 -12.7298 40
-      vertex 27.5483 -14.4871 0
-      vertex 27.2764 -16.2033 0
+      vertex 6.02838 -19.2974 40
+      vertex 16.4797 -36.9536 0
+      vertex 6.00874 -19.3107 40
     endloop
   endfacet
-  facet normal -0.896221 0.14193 -0.42029
+  facet normal 0.889736 0.0262791 -0.455718
     outer loop
-      vertex 27.5493 -14.4803 0
-      vertex 9.07154 -12.7087 40
-      vertex 9.15891 -12.157 40
+      vertex -10.2554 -11.0237 40
+      vertex -30.7439 -11 0
+      vertex -10.2561 -11 40
     endloop
   endfacet
-  facet normal -0.897636 0.132005 -0.420504
+  facet normal 0.889696 0.0279476 -0.455697
     outer loop
-      vertex 9.07154 -12.7087 40
-      vertex 27.5493 -14.4803 0
-      vertex 27.5483 -14.4871 0
+      vertex -30.7439 -11 0
+      vertex -10.2554 -11.0237 40
+      vertex -30.6835 -12.9228 0
     endloop
   endfacet
-  facet normal -0.0285134 0.906941 -0.420291
+  facet normal 0.500326 0.736216 -0.455697
     outer loop
-      vertex 0 -38.7683 0
-      vertex 0.0214407 -20.231 40
-      vertex 1.73669 -38.7137 0
+      vertex -16.4734 -36.9579 0
+      vertex -6.00874 -19.3107 40
+      vertex -5.49549 -19.6595 40
     endloop
   endfacet
-  facet normal -0.0296091 0.906913 -0.420277
+  facet normal 0.501821 0.735226 -0.455652
     outer loop
-      vertex 0.0214407 -20.231 40
-      vertex 0 -38.7683 0
-      vertex 0 -20.2317 40
+      vertex -6.00874 -19.3107 40
+      vertex -16.4734 -36.9579 0
+      vertex -16.4797 -36.9536 0
     endloop
   endfacet
-  facet normal 0.253745 0.871192 -0.420282
+  facet normal -0.407354 0.791431 -0.455741
     outer loop
-      vertex -6.90569 -37.8959 0
-      vertex -2.31643 -19.9357 40
-      vertex -2.29583 -19.9417 40
+      vertex 14.8042 -37.9446 0
+      vertex 4.94091 -19.9875 40
+      vertex 14.811 -37.9411 0
     endloop
   endfacet
-  facet normal 0.253172 0.871355 -0.42029
+  facet normal -0.404082 0.793131 -0.455698
     outer loop
-      vertex -2.31643 -19.9357 40
-      vertex -6.90569 -37.8959 0
-      vertex -8.57425 -37.4111 0
+      vertex 4.94091 -19.9875 40
+      vertex 14.8042 -37.9446 0
+      vertex 4.38799 -20.2692 40
     endloop
   endfacet
-  facet normal 0.750475 0.510043 -0.420289
+  facet normal -0.027948 0.889696 -0.455697
     outer loop
-      vertex -7.48067 -16.4085 40
-      vertex -23.4455 -25.879 0
-      vertex -7.79459 -15.9466 40
+      vertex 0 -41.7439 0
+      vertex 0.0237379 -21.2554 40
+      vertex 1.92277 -41.6835 0
     endloop
   endfacet
-  facet normal 0.754926 0.503284 -0.420466
+  facet normal -0.0262372 0.889737 -0.455719
     outer loop
-      vertex -23.4455 -25.879 0
-      vertex -7.48067 -16.4085 40
-      vertex -23.4417 -25.8847 0
+      vertex 0.0237379 -21.2554 40
+      vertex 0 -41.7439 0
+      vertex 0 -21.2561 40
     endloop
   endfacet
-  facet normal 0.554871 0.717944 -0.420327
+  facet normal 0.453445 0.765984 -0.455693
     outer loop
-      vertex -16.3272 -33.4608 0
-      vertex -5.88451 -18.1132 40
-      vertex -5.86756 -18.1263 40
+      vertex -14.811 -37.9411 0
+      vertex -4.96135 -19.9754 40
+      vertex -4.94091 -19.9875 40
     endloop
   endfacet
-  facet normal 0.556143 0.716981 -0.420289
+  facet normal 0.453137 0.766164 -0.455698
     outer loop
-      vertex -5.88451 -18.1132 40
-      vertex -16.3272 -33.4608 0
-      vertex -17.7002 -32.3958 0
+      vertex -4.96135 -19.9754 40
+      vertex -14.811 -37.9411 0
+      vertex -16.4668 -36.9618 0
     endloop
   endfacet
-  facet normal 0.871369 0.253126 -0.420289
+  facet normal 0.886185 0.0837701 -0.455696
     outer loop
-      vertex -8.77987 -13.8528 40
-      vertex -26.4111 -19.5743 0
-      vertex -8.93569 -13.3164 40
+      vertex -10.1775 -12.2618 40
+      vertex -30.6832 -12.9304 0
+      vertex -10.2359 -11.644 40
     endloop
   endfacet
-  facet normal 0.871989 0.251027 -0.420262
+  facet normal 0.88644 0.0805855 -0.455774
     outer loop
-      vertex -26.4111 -19.5743 0
-      vertex -8.77987 -13.8528 40
-      vertex -26.4092 -19.5809 0
+      vertex -30.6832 -12.9304 0
+      vertex -10.1775 -12.2618 40
+      vertex -30.6825 -12.9381 0
     endloop
   endfacet
-  facet normal 0.896168 0.142283 -0.420283
+  facet normal 0.837378 0.301907 -0.455688
     outer loop
-      vertex -9.06819 -12.7298 40
-      vertex -27.5483 -14.4871 0
-      vertex -9.07154 -12.7087 40
+      vertex -9.53588 -14.7755 40
+      vertex -29.2366 -20.5076 0
+      vertex -9.54392 -14.7532 40
     endloop
   endfacet
-  facet normal 0.896212 0.141988 -0.42029
+  facet normal 0.837516 0.301506 -0.455698
     outer loop
-      vertex -27.5483 -14.4871 0
-      vertex -9.06819 -12.7298 40
-      vertex -27.2764 -16.2033 0
+      vertex -29.2366 -20.5076 0
+      vertex -9.53588 -14.7755 40
+      vertex -28.585 -22.3176 0
     endloop
   endfacet
-  facet normal 0.906942 0.0284932 -0.42029
+  facet normal 0.353456 0.816951 -0.455698
     outer loop
-      vertex -9.21349 -11.5797 40
-      vertex -27.7137 -12.7367 0
-      vertex -9.23103 -11.0214 40
+      vertex -13.0831 -38.821 0
+      vertex -4.36683 -20.28 40
+      vertex -3.79732 -20.5264 40
     endloop
   endfacet
-  facet normal 0.907022 0.0262905 -0.420263
+  facet normal 0.360422 0.813855 -0.455781
     outer loop
-      vertex -27.7137 -12.7367 0
-      vertex -9.21349 -11.5797 40
-      vertex -27.7135 -12.7436 0
+      vertex -4.36683 -20.28 40
+      vertex -13.0831 -38.821 0
+      vertex -13.0901 -38.8179 0
     endloop
   endfacet
-  facet normal 0.139624 0.896557 -0.420346
+  facet normal 0.736863 0.499346 -0.455726
     outer loop
-      vertex -3.4871 -38.5483 0
-      vertex -1.72985 -20.0682 40
-      vertex -1.70866 -20.0715 40
+      vertex -8.29736 -17.0284 40
+      vertex -25.9536 -27.4797 0
+      vertex -8.31071 -17.0087 40
     endloop
   endfacet
-  facet normal 0.141991 0.896211 -0.42029
+  facet normal 0.736216 0.500327 -0.455697
     outer loop
-      vertex -1.72985 -20.0682 40
-      vertex -3.4871 -38.5483 0
-      vertex -5.20326 -38.2764 0
+      vertex -25.9536 -27.4797 0
+      vertex -8.29736 -17.0284 40
+      vertex -24.8723 -29.0708 0
     endloop
   endfacet
-  facet normal 0.0284323 0.906945 -0.420289
+  facet normal -0.816975 0.353398 -0.4557
     outer loop
-      vertex -1.73669 -38.7137 0
-      vertex -0.579663 -20.2135 40
-      vertex -0.0214407 -20.231 40
+      vertex 28.585 -22.3176 0
+      vertex 9.52645 -14.7973 40
+      vertex 9.53588 -14.7755 40
     endloop
   endfacet
-  facet normal 0.0263286 0.90702 -0.420263
+  facet normal -0.816925 0.353515 -0.455698
     outer loop
-      vertex -0.579663 -20.2135 40
-      vertex -1.73669 -38.7137 0
-      vertex -1.74358 -38.7135 0
+      vertex 9.52645 -14.7973 40
+      vertex 28.585 -22.3176 0
+      vertex 27.821 -24.0831 0
     endloop
   endfacet
-  facet normal -0.141991 0.896211 -0.42029
+  facet normal 0.404663 0.79284 -0.455689
     outer loop
-      vertex 3.4871 -38.5483 0
-      vertex 1.72985 -20.0682 40
-      vertex 5.20326 -38.2764 0
+      vertex -13.0901 -38.8179 0
+      vertex -4.38799 -20.2692 40
+      vertex -4.36683 -20.28 40
     endloop
   endfacet
-  facet normal -0.139624 0.896557 -0.420346
+  facet normal 0.404084 0.79313 -0.455698
     outer loop
-      vertex 1.72985 -20.0682 40
-      vertex 3.4871 -38.5483 0
-      vertex 1.70866 -20.0715 40
+      vertex -4.38799 -20.2692 40
+      vertex -13.0901 -38.8179 0
+      vertex -14.8042 -37.9446 0
     endloop
   endfacet
-  facet normal -0.472599 0.774538 -0.420406
+  facet normal 0.702355 0.546861 -0.455675
     outer loop
-      vertex 14.8731 -34.4491 0
-      vertex 4.9466 -18.7946 40
-      vertex 14.879 -34.4455 0
+      vertex -8.2828 -17.0471 40
+      vertex -24.8723 -29.0708 0
+      vertex -8.29736 -17.0284 40
     endloop
   endfacet
-  facet normal -0.461895 0.78103 -0.420291
+  facet normal 0.703352 0.54556 -0.455698
     outer loop
-      vertex 4.9466 -18.7946 40
-      vertex 14.8731 -34.4491 0
-      vertex 4.46587 -19.0789 40
+      vertex -24.8723 -29.0708 0
+      vertex -8.2828 -17.0471 40
+      vertex -23.6933 -30.5908 0
     endloop
   endfacet
-  facet normal -0.68061 0.600104 -0.420291
+  facet normal -0.301506 0.837516 -0.455698
     outer loop
-      vertex 20.2468 -30.0035 0
-      vertex 6.72962 -17.3195 40
-      vertex 7.09897 -16.9006 40
+      vertex 9.5076 -40.2366 0
+      vertex 3.77552 -20.5359 40
+      vertex 11.3176 -39.585 0
     endloop
   endfacet
-  facet normal -0.679626 0.601207 -0.420308
+  facet normal -0.300091 0.838004 -0.455735
     outer loop
-      vertex 6.72962 -17.3195 40
-      vertex 20.2468 -30.0035 0
-      vertex 20.2422 -30.0087 0
+      vertex 3.77552 -20.5359 40
+      vertex 9.5076 -40.2366 0
+      vertex 3.75318 -20.5439 40
     endloop
   endfacet
-  facet normal -0.197397 0.885653 -0.420302
+  facet normal 0.191266 0.869324 -0.455733
     outer loop
-      vertex 5.20326 -38.2764 0
-      vertex 2.2749 -19.9464 40
-      vertex 5.20999 -38.2749 0
+      vertex -5.76083 -41.1993 0
+      vertex -1.94498 -21.0693 40
+      vertex -1.9218 -21.0744 40
     endloop
   endfacet
-  facet normal -0.19789 0.885548 -0.42029
+  facet normal 0.194157 0.868703 -0.455696
     outer loop
-      vertex 2.2749 -19.9464 40
-      vertex 5.20326 -38.2764 0
-      vertex 1.72985 -20.0682 40
+      vertex -1.94498 -21.0693 40
+      vertex -5.76083 -41.1993 0
+      vertex -7.63822 -40.7797 0
     endloop
   endfacet
-  facet normal -0.307379 0.853742 -0.42029
+  facet normal 0.300091 0.838004 -0.455735
     outer loop
-      vertex 8.58087 -37.4092 0
-      vertex 2.87294 -19.7726 40
-      vertex 10.2157 -36.8206 0
+      vertex -9.5076 -40.2366 0
+      vertex -3.77552 -20.5359 40
+      vertex -3.75318 -20.5439 40
     endloop
   endfacet
-  facet normal -0.308535 0.853332 -0.420274
+  facet normal 0.301506 0.837516 -0.455698
     outer loop
-      vertex 2.87294 -19.7726 40
-      vertex 8.58087 -37.4092 0
-      vertex 2.85275 -19.7799 40
+      vertex -3.77552 -20.5359 40
+      vertex -9.5076 -40.2366 0
+      vertex -11.3176 -39.585 0
     endloop
   endfacet
-  facet normal -0.302696 0.855445 -0.420226
+  facet normal -0.793113 0.404116 -0.455699
     outer loop
-      vertex 10.2157 -36.8206 0
-      vertex 3.39842 -19.5834 40
-      vertex 10.2222 -36.8183 0
+      vertex 26.9446 -25.8042 0
+      vertex 8.98749 -15.9409 40
+      vertex 9.26921 -15.388 40
     endloop
   endfacet
-  facet normal -0.30739 0.853738 -0.42029
+  facet normal -0.791431 0.407354 -0.455742
     outer loop
-      vertex 3.39842 -19.5834 40
-      vertex 10.2157 -36.8206 0
-      vertex 2.87294 -19.7726 40
+      vertex 8.98749 -15.9409 40
+      vertex 26.9446 -25.8042 0
+      vertex 26.9411 -25.811 0
     endloop
   endfacet
-  facet normal 0.751195 0.508956 -0.420321
+  facet normal -0.0814254 0.886374 -0.455754
     outer loop
-      vertex -7.46861 -16.4263 40
-      vertex -23.4417 -25.8847 0
-      vertex -7.48067 -16.4085 40
+      vertex 1.93043 -41.6832 0
+      vertex 1.26179 -21.1775 40
+      vertex 1.93805 -41.6825 0
     endloop
   endfacet
-  facet normal 0.750473 0.510046 -0.42029
+  facet normal -0.0837695 0.886185 -0.455696
     outer loop
-      vertex -23.4417 -25.8847 0
-      vertex -7.46861 -16.4263 40
-      vertex -22.465 -27.3218 0
+      vertex 1.26179 -21.1775 40
+      vertex 1.93043 -41.6832 0
+      vertex 0.643985 -21.2359 40
     endloop
   endfacet
-  facet normal 0.68061 0.600104 -0.420291
+  facet normal -0.360422 0.813855 -0.455781
     outer loop
-      vertex -6.72962 -17.3195 40
-      vertex -20.2468 -30.0035 0
-      vertex -7.09897 -16.9006 40
+      vertex 13.0831 -38.821 0
+      vertex 4.36683 -20.28 40
+      vertex 13.0901 -38.8179 0
     endloop
   endfacet
-  facet normal 0.679626 0.601207 -0.420308
+  facet normal -0.353456 0.816951 -0.455698
     outer loop
-      vertex -20.2468 -30.0035 0
-      vertex -6.72962 -17.3195 40
-      vertex -20.2422 -30.0087 0
+      vertex 4.36683 -20.28 40
+      vertex 13.0831 -38.821 0
+      vertex 3.79732 -20.5264 40
     endloop
   endfacet
-  facet normal 0.198813 0.885352 -0.420268
+  facet normal -0.248339 0.854791 -0.455698
     outer loop
-      vertex -5.20999 -38.2749 0
-      vertex -2.29583 -19.9417 40
-      vertex -2.2749 -19.9464 40
+      vertex 7.65305 -40.7759 0
+      vertex 3.16931 -20.7541 40
+      vertex 9.50039 -40.2392 0
     endloop
   endfacet
-  facet normal 0.197924 0.885541 -0.42029
+  facet normal -0.250872 0.854087 -0.45563
     outer loop
-      vertex -2.29583 -19.9417 40
-      vertex -5.20999 -38.2749 0
-      vertex -6.90569 -37.8959 0
+      vertex 3.16931 -20.7541 40
+      vertex 7.65305 -40.7759 0
+      vertex 3.1465 -20.7608 40
     endloop
   endfacet
-  facet normal 0.0846069 0.903432 -0.420299
+  facet normal -0.854829 0.2482 -0.455702
     outer loop
-      vertex -1.74358 -38.7135 0
-      vertex -0.601019 -20.2115 40
-      vertex -0.579663 -20.2135 40
+      vertex 29.7759 -18.6531 0
+      vertex 9.75413 -14.1693 40
+      vertex 9.76075 -14.1465 40
     endloop
   endfacet
-  facet normal 0.0853836 0.903364 -0.42029
+  facet normal -0.854789 0.248344 -0.455698
     outer loop
-      vertex -0.601019 -20.2115 40
-      vertex -1.74358 -38.7135 0
-      vertex -3.47342 -38.55 0
+      vertex 9.75413 -14.1693 40
+      vertex 29.7759 -18.6531 0
+      vertex 29.2392 -20.5004 0
     endloop
   endfacet
-  facet normal 0.0296091 0.906913 -0.420277
+  facet normal -0.0348334 0.889414 -0.455773
     outer loop
-      vertex 0 -38.7683 0
-      vertex -0.0214407 -20.231 40
-      vertex 0 -20.2317 40
+      vertex 1.92277 -41.6835 0
+      vertex 0.643985 -21.2359 40
+      vertex 1.93043 -41.6832 0
     endloop
   endfacet
-  facet normal 0.0285134 0.906941 -0.420291
+  facet normal -0.0279712 0.889695 -0.455697
     outer loop
-      vertex -0.0214407 -20.231 40
-      vertex 0 -38.7683 0
-      vertex -1.73669 -38.7137 0
+      vertex 0.643985 -21.2359 40
+      vertex 1.92277 -41.6835 0
+      vertex 0.0237379 -21.2554 40
     endloop
   endfacet
-  facet normal -0.0853836 0.903364 -0.42029
+  facet normal -0.0837517 0.886186 -0.455698
     outer loop
-      vertex 1.74358 -38.7135 0
-      vertex 0.601019 -20.2115 40
-      vertex 3.47342 -38.55 0
+      vertex 1.93805 -41.6825 0
+      vertex 1.28543 -21.1752 40
+      vertex 3.85323 -41.5015 0
     endloop
   endfacet
-  facet normal -0.0846069 0.903432 -0.420299
+  facet normal -0.0861997 0.885983 -0.455635
     outer loop
-      vertex 0.601019 -20.2115 40
-      vertex 1.74358 -38.7135 0
-      vertex 0.579663 -20.2135 40
+      vertex 1.28543 -21.1752 40
+      vertex 1.93805 -41.6825 0
+      vertex 1.26179 -21.1775 40
     endloop
   endfacet
-  facet normal -0.250328 0.872195 -0.420252
+  facet normal 0.885971 0.0863447 -0.455631
     outer loop
-      vertex 8.57425 -37.4111 0
-      vertex 2.85275 -19.7799 40
-      vertex 8.58087 -37.4092 0
+      vertex -10.1752 -12.2854 40
+      vertex -30.6825 -12.9381 0
+      vertex -10.1775 -12.2618 40
     endloop
   endfacet
-  facet normal -0.253131 0.871368 -0.420289
+  facet normal 0.886185 0.0837552 -0.455698
     outer loop
-      vertex 2.85275 -19.7799 40
-      vertex 8.57425 -37.4111 0
-      vertex 2.31643 -19.9357 40
+      vertex -30.6825 -12.9381 0
+      vertex -10.1752 -12.2854 40
+      vertex -30.5015 -14.8532 0
     endloop
   endfacet
-  facet normal -0.253172 0.871355 -0.42029
+  facet normal 0.404082 0.793131 -0.455698
     outer loop
-      vertex 6.90569 -37.8959 0
-      vertex 2.31643 -19.9357 40
-      vertex 8.57425 -37.4111 0
+      vertex -14.8042 -37.9446 0
+      vertex -4.94091 -19.9875 40
+      vertex -4.38799 -20.2692 40
     endloop
   endfacet
-  facet normal -0.253745 0.871192 -0.420282
+  facet normal 0.407354 0.791431 -0.455741
     outer loop
-      vertex 2.31643 -19.9357 40
-      vertex 6.90569 -37.8959 0
-      vertex 2.29583 -19.9417 40
+      vertex -4.94091 -19.9875 40
+      vertex -14.8042 -37.9446 0
+      vertex -14.811 -37.9411 0
     endloop
   endfacet
-  facet normal -0.871369 0.253126 -0.420289
+  facet normal -0.793443 0.403459 -0.455707
     outer loop
-      vertex 26.4111 -19.5743 0
-      vertex 8.77987 -13.8528 40
-      vertex 8.93569 -13.3164 40
+      vertex 27.8179 -24.0901 0
+      vertex 9.26921 -15.388 40
+      vertex 9.27999 -15.3668 40
     endloop
   endfacet
-  facet normal -0.871989 0.251027 -0.420262
+  facet normal -0.79313 0.404084 -0.455698
     outer loop
-      vertex 8.77987 -13.8528 40
-      vertex 26.4111 -19.5743 0
-      vertex 26.4092 -19.5809 0
+      vertex 9.26921 -15.388 40
+      vertex 27.8179 -24.0901 0
+      vertex 26.9446 -25.8042 0
     endloop
   endfacet
-  facet normal -0.808355 0.412219 -0.420283
+  facet normal 0.139282 0.87917 -0.455698
     outer loop
-      vertex 25.1224 -22.8293 0
-      vertex 8.08981 -15.4474 40
-      vertex 8.09955 -15.4283 40
+      vertex -3.85323 -41.5015 0
+      vertex -1.89834 -21.0781 40
+      vertex -1.28543 -21.1752 40
     endloop
   endfacet
-  facet normal -0.808479 0.411968 -0.42029
+  facet normal 0.139365 0.879158 -0.455696
     outer loop
-      vertex 8.08981 -15.4474 40
-      vertex 25.1224 -22.8293 0
-      vertex 24.3335 -24.3775 0
+      vertex -1.89834 -21.0781 40
+      vertex -3.85323 -41.5015 0
+      vertex -3.8608 -41.5003 0
     endloop
   endfacet
-  facet normal -0.885538 0.197934 -0.42029
+  facet normal 0.854829 0.2482 -0.455702
     outer loop
-      vertex 27.2764 -16.2033 0
-      vertex 8.94635 -13.2749 40
-      vertex 9.06819 -12.7298 40
+      vertex -9.75413 -14.1693 40
+      vertex -29.7759 -18.6531 0
+      vertex -9.76075 -14.1465 40
     endloop
   endfacet
-  facet normal -0.885474 0.19824 -0.420283
+  facet normal 0.854789 0.248344 -0.455698
     outer loop
-      vertex 8.94635 -13.2749 40
-      vertex 27.2764 -16.2033 0
-      vertex 27.2749 -16.21 0
+      vertex -29.7759 -18.6531 0
+      vertex -9.75413 -14.1693 40
+      vertex -29.2392 -20.5004 0
     endloop
   endfacet
-  facet normal -0.832775 0.360338 -0.420289
+  facet normal -0.889852 -0.0207208 -0.455778
     outer loop
-      vertex 25.1282 -22.8168 0
-      vertex 8.3531 -14.9307 40
-      vertex 8.5749 -14.4181 40
+      vertex 30.7439 -11 0
+      vertex 10.0931 -4 40
+      vertex 30.5809 -4 0
     endloop
   endfacet
-  facet normal -0.836085 0.352723 -0.420176
+  facet normal -0.889852 -0.0207208 -0.455778
     outer loop
-      vertex 8.3531 -14.9307 40
-      vertex 25.1282 -22.8168 0
-      vertex 25.1255 -22.8232 0
+      vertex 10.0931 -4 40
+      vertex 30.7439 -11 0
+      vertex 10.2561 -11 40
     endloop
   endfacet
-  facet normal -0.751195 0.508956 -0.420321
+  facet normal -0.889736 0.0262791 -0.455718
     outer loop
-      vertex 23.4417 -25.8847 0
-      vertex 7.46861 -16.4263 40
-      vertex 7.48067 -16.4085 40
+      vertex 30.7439 -11 0
+      vertex 10.2554 -11.0237 40
+      vertex 10.2561 -11 40
     endloop
   endfacet
-  facet normal -0.750473 0.510046 -0.42029
+  facet normal -0.889696 0.0279476 -0.455697
     outer loop
-      vertex 7.46861 -16.4263 40
-      vertex 23.4417 -25.8847 0
-      vertex 22.465 -27.3218 0
+      vertex 10.2554 -11.0237 40
+      vertex 30.7439 -11 0
+      vertex 30.6835 -12.9228 0
     endloop
   endfacet
-  facet normal -0.556143 0.716981 -0.420289
+  facet normal 0.588622 0.66773 -0.455698
     outer loop
-      vertex 16.3272 -33.4608 0
-      vertex 5.88451 -18.1132 40
-      vertex 17.7002 -32.3958 0
+      vertex -19.6026 -34.6835 0
+      vertex -7.02078 -18.4764 40
+      vertex -7.00297 -18.4921 40
     endloop
   endfacet
-  facet normal -0.554871 0.717944 -0.420327
+  facet normal 0.588663 0.667695 -0.455696
     outer loop
-      vertex 5.88451 -18.1132 40
-      vertex 16.3272 -33.4608 0
-      vertex 5.86756 -18.1263 40
+      vertex -7.02078 -18.4764 40
+      vertex -19.6026 -34.6835 0
+      vertex -21.0456 -33.4113 0
     endloop
   endfacet
-  facet normal -0.131815 0.897662 -0.420509
+  facet normal -0.197268 0.867981 -0.455735
     outer loop
-      vertex 3.48029 -38.5493 0
-      vertex 1.70866 -20.0715 40
-      vertex 3.4871 -38.5483 0
+      vertex 7.63822 -40.7797 0
+      vertex 2.55059 -20.9339 40
+      vertex 7.6457 -40.778 0
     endloop
   endfacet
-  facet normal -0.141998 0.896211 -0.420289
+  facet normal -0.194218 0.868688 -0.455698
     outer loop
-      vertex 1.70866 -20.0715 40
-      vertex 3.48029 -38.5493 0
-      vertex 1.15704 -20.1589 40
+      vertex 2.55059 -20.9339 40
+      vertex 7.63822 -40.7797 0
+      vertex 1.94498 -21.0693 40
     endloop
   endfacet
-  facet normal -0.906934 0.0288185 -0.420286
+  facet normal -0.629397 0.629443 -0.455697
     outer loop
-      vertex 27.7683 -11 0
-      vertex 9.23103 -11.0214 40
-      vertex 9.23171 -11 40
+      vertex 21.0456 -33.4113 0
+      vertex 7.47637 -18.0208 40
+      vertex 22.4113 -32.0457 0
     endloop
   endfacet
-  facet normal -0.906942 0.0285133 -0.42029
+  facet normal -0.629428 0.629414 -0.455696
     outer loop
-      vertex 9.23103 -11.0214 40
-      vertex 27.7683 -11 0
-      vertex 27.7137 -12.7367 0
+      vertex 7.47637 -18.0208 40
+      vertex 21.0456 -33.4113 0
+      vertex 7.02078 -18.4764 40
     endloop
   endfacet
-  facet normal 0.360356 0.832767 -0.420289
+  facet normal 0.703382 0.545522 -0.455696
     outer loop
-      vertex -11.8168 -36.1282 0
-      vertex -3.93067 -19.3531 40
-      vertex -3.4181 -19.5749 40
+      vertex -7.90246 -17.5375 40
+      vertex -23.6933 -30.5908 0
+      vertex -8.2828 -17.0471 40
     endloop
   endfacet
-  facet normal 0.352723 0.836085 -0.420176
+  facet normal 0.705128 0.543295 -0.455659
     outer loop
-      vertex -3.93067 -19.3531 40
-      vertex -11.8168 -36.1282 0
-      vertex -11.8232 -36.1255 0
+      vertex -23.6933 -30.5908 0
+      vertex -7.90246 -17.5375 40
+      vertex -23.6886 -30.5969 0
     endloop
   endfacet
-  facet normal 0.253131 0.871368 -0.420289
+  facet normal 0.889695 0.0279688 -0.455697
     outer loop
-      vertex -8.57425 -37.4111 0
-      vertex -2.85275 -19.7799 40
-      vertex -2.31643 -19.9357 40
+      vertex -10.2359 -11.644 40
+      vertex -30.6835 -12.9228 0
+      vertex -10.2554 -11.0237 40
     endloop
   endfacet
-  facet normal 0.250328 0.872195 -0.420252
+  facet normal 0.889402 0.035108 -0.455776
     outer loop
-      vertex -2.85275 -19.7799 40
-      vertex -8.57425 -37.4111 0
-      vertex -8.58087 -37.4092 0
+      vertex -30.6835 -12.9228 0
+      vertex -10.2359 -11.644 40
+      vertex -30.6832 -12.9304 0
     endloop
   endfacet
-  facet normal 0.410694 0.80911 -0.420324
+  facet normal 0.138672 0.879258 -0.455713
     outer loop
-      vertex -11.8293 -36.1224 0
-      vertex -4.44741 -19.0898 40
-      vertex -4.4283 -19.0995 40
+      vertex -3.8608 -41.5003 0
+      vertex -1.9218 -21.0744 40
+      vertex -1.89834 -21.0781 40
     endloop
   endfacet
-  facet normal 0.411968 0.808479 -0.42029
+  facet normal 0.139277 0.879171 -0.455698
     outer loop
-      vertex -4.44741 -19.0898 40
-      vertex -11.8293 -36.1224 0
-      vertex -13.3775 -35.3335 0
+      vertex -1.9218 -21.0744 40
+      vertex -3.8608 -41.5003 0
+      vertex -5.76083 -41.1993 0
     endloop
   endfacet
-  facet normal 0.680936 0.599731 -0.420295
+  facet normal 0.0861997 0.885983 -0.455635
     outer loop
-      vertex -7.09897 -16.9006 40
-      vertex -21.3958 -28.7002 0
-      vertex -7.11315 -16.8845 40
+      vertex -1.93805 -41.6825 0
+      vertex -1.28543 -21.1752 40
+      vertex -1.26179 -21.1775 40
     endloop
   endfacet
-  facet normal 0.680647 0.600064 -0.42029
+  facet normal 0.0837517 0.886186 -0.455698
     outer loop
-      vertex -21.3958 -28.7002 0
-      vertex -7.09897 -16.9006 40
-      vertex -20.2468 -30.0035 0
+      vertex -1.28543 -21.1752 40
+      vertex -1.93805 -41.6825 0
+      vertex -3.85323 -41.5015 0
     endloop
   endfacet
-  facet normal 0.716148 0.55724 -0.420257
+  facet normal -0.139365 0.879158 -0.455696
     outer loop
-      vertex -7.11315 -16.8845 40
-      vertex -22.4608 -27.3272 0
-      vertex -7.1263 -16.8676 40
+      vertex 3.85323 -41.5015 0
+      vertex 1.89834 -21.0781 40
+      vertex 3.8608 -41.5003 0
     endloop
   endfacet
-  facet normal 0.716981 0.556143 -0.42029
+  facet normal -0.139282 0.87917 -0.455698
     outer loop
-      vertex -22.4608 -27.3272 0
-      vertex -7.11315 -16.8845 40
-      vertex -21.3958 -28.7002 0
+      vertex 1.89834 -21.0781 40
+      vertex 3.85323 -41.5015 0
+      vertex 1.28543 -21.1752 40
     endloop
   endfacet
-  facet normal 0.781017 0.461916 -0.420291
+  facet normal -0.194157 0.868703 -0.455696
     outer loop
-      vertex -7.79459 -15.9466 40
-      vertex -23.4491 -25.8731 0
-      vertex -8.07889 -15.4659 40
+      vertex 5.76083 -41.1993 0
+      vertex 1.94498 -21.0693 40
+      vertex 7.63822 -40.7797 0
     endloop
   endfacet
-  facet normal 0.774538 0.472599 -0.420407
+  facet normal -0.191266 0.869324 -0.455733
     outer loop
-      vertex -23.4491 -25.8731 0
-      vertex -7.79459 -15.9466 40
-      vertex -23.4455 -25.879 0
+      vertex 1.94498 -21.0693 40
+      vertex 5.76083 -41.1993 0
+      vertex 1.9218 -21.0744 40
     endloop
   endfacet
-  facet normal 0.641637 0.641606 -0.420291
+  facet normal -0.588663 0.667695 -0.455696
     outer loop
-      vertex -6.31954 -17.7296 40
-      vertex -20.2422 -30.0087 0
-      vertex -6.72962 -17.3195 40
+      vertex 19.6026 -34.6835 0
+      vertex 7.02078 -18.4764 40
+      vertex 21.0456 -33.4113 0
     endloop
   endfacet
-  facet normal 0.641621 0.641621 -0.42029
+  facet normal -0.588622 0.66773 -0.455698
     outer loop
-      vertex -20.2422 -30.0087 0
-      vertex -6.31954 -17.7296 40
-      vertex -19.0087 -31.2422 0
+      vertex 7.02078 -18.4764 40
+      vertex 19.6026 -34.6835 0
+      vertex 7.00297 -18.4921 40
     endloop
   endfacet
-  facet normal 0.832836 0.360191 -0.420293
+  facet normal -0.766161 0.453141 -0.455697
     outer loop
-      vertex -8.5749 -14.4181 40
-      vertex -25.8183 -21.2222 0
-      vertex -8.58342 -14.3984 40
+      vertex 25.9618 -27.4668 0
+      vertex 8.65951 -16.4955 40
+      vertex 8.9754 -15.9614 40
     endloop
   endfacet
-  facet normal 0.832751 0.360392 -0.42029
+  facet normal -0.766343 0.452839 -0.455693
     outer loop
-      vertex -25.8183 -21.2222 0
-      vertex -8.5749 -14.4181 40
-      vertex -25.1282 -22.8168 0
+      vertex 8.65951 -16.4955 40
+      vertex 25.9618 -27.4668 0
+      vertex 25.9579 -27.4734 0
     endloop
   endfacet
-  facet normal 0.871303 0.253355 -0.420288
+  facet normal -0.868681 0.194248 -0.455699
     outer loop
-      vertex -8.93569 -13.3164 40
-      vertex -26.8959 -17.9057 0
-      vertex -8.94168 -13.2958 40
+      vertex 29.7797 -18.6382 0
+      vertex 9.93388 -13.5506 40
+      vertex 10.0693 -12.945 40
     endloop
   endfacet
-  facet normal 0.871357 0.253167 -0.42029
+  facet normal -0.868097 0.196769 -0.45573
     outer loop
-      vertex -26.8959 -17.9057 0
-      vertex -8.93569 -13.3164 40
-      vertex -26.4111 -19.5743 0
+      vertex 9.93388 -13.5506 40
+      vertex 29.7797 -18.6382 0
+      vertex 29.778 -18.6457 0
     endloop
   endfacet
-  facet normal 0.19789 0.885548 -0.42029
+  facet normal 0.667709 0.588646 -0.455698
     outer loop
-      vertex -5.20326 -38.2764 0
-      vertex -2.2749 -19.9464 40
-      vertex -1.72985 -20.0682 40
+      vertex -7.49208 -18.003 40
+      vertex -23.6886 -30.5969 0
+      vertex -7.90246 -17.5375 40
     endloop
   endfacet
-  facet normal 0.197397 0.885653 -0.420302
+  facet normal 0.663431 0.593596 -0.455524
     outer loop
-      vertex -2.2749 -19.9464 40
-      vertex -5.20326 -38.2764 0
-      vertex -5.20999 -38.2749 0
+      vertex -23.6886 -30.5969 0
+      vertex -7.49208 -18.003 40
+      vertex -23.6835 -30.6026 0
     endloop
   endfacet
-  facet normal -0.411088 0.808915 -0.420313
+  facet normal 0.248303 0.854801 -0.455697
     outer loop
-      vertex 11.8232 -36.1255 0
-      vertex 4.4283 -19.0995 40
-      vertex 11.8293 -36.1224 0
+      vertex -7.6457 -40.778 0
+      vertex -3.1465 -20.7608 40
+      vertex -2.55059 -20.9339 40
     endloop
   endfacet
-  facet normal -0.412004 0.808461 -0.42029
+  facet normal 0.244526 0.855839 -0.455792
     outer loop
-      vertex 4.4283 -19.0995 40
-      vertex 11.8232 -36.1255 0
-      vertex 3.93067 -19.3531 40
+      vertex -3.1465 -20.7608 40
+      vertex -7.6457 -40.778 0
+      vertex -7.65305 -40.7759 0
     endloop
   endfacet
-  facet normal -0.832836 0.360191 -0.420293
+  facet normal -0.54556 0.703352 -0.455697
     outer loop
-      vertex 25.8183 -21.2222 0
-      vertex 8.5749 -14.4181 40
-      vertex 8.58342 -14.3984 40
+      vertex 18.0708 -35.8723 0
+      vertex 6.04715 -19.2828 40
+      vertex 19.5908 -34.6933 0
     endloop
   endfacet
-  facet normal -0.832751 0.360392 -0.42029
+  facet normal -0.546521 0.702616 -0.455681
     outer loop
-      vertex 8.5749 -14.4181 40
-      vertex 25.8183 -21.2222 0
-      vertex 25.1282 -22.8168 0
+      vertex 6.04715 -19.2828 40
+      vertex 18.0708 -35.8723 0
+      vertex 6.02838 -19.2974 40
     endloop
   endfacet
-  facet normal -0.808484 0.411959 -0.42029
+  facet normal 0.837514 0.301513 -0.455698
     outer loop
-      vertex 25.1255 -22.8232 0
-      vertex 8.09955 -15.4283 40
-      vertex 8.3531 -14.9307 40
+      vertex -9.54392 -14.7532 40
+      vertex -29.2392 -20.5004 0
+      vertex -9.75413 -14.1693 40
     endloop
   endfacet
-  facet normal -0.808915 0.411088 -0.420313
+  facet normal 0.83723 0.302333 -0.455676
     outer loop
-      vertex 8.09955 -15.4283 40
-      vertex 25.1255 -22.8232 0
-      vertex 25.1224 -22.8293 0
+      vertex -29.2392 -20.5004 0
+      vertex -9.54392 -14.7532 40
+      vertex -29.2366 -20.5076 0
     endloop
   endfacet
-  facet normal -0.853747 0.307365 -0.42029
+  facet normal -0.543295 0.705128 -0.455659
     outer loop
-      vertex 25.8206 -21.2157 0
-      vertex 8.58342 -14.3984 40
-      vertex 8.77261 -13.8729 40
+      vertex 19.5908 -34.6933 0
+      vertex 6.53748 -18.9025 40
+      vertex 19.5969 -34.6886 0
     endloop
   endfacet
-  facet normal -0.855445 0.302696 -0.420226
+  facet normal -0.545535 0.703372 -0.455696
     outer loop
-      vertex 8.58342 -14.3984 40
-      vertex 25.8206 -21.2157 0
-      vertex 25.8183 -21.2222 0
+      vertex 6.53748 -18.9025 40
+      vertex 19.5908 -34.6933 0
+      vertex 6.04715 -19.2828 40
     endloop
   endfacet
-  facet normal -0.510046 0.750473 -0.42029
+  facet normal -0.816917 0.353533 -0.455699
     outer loop
-      vertex 14.8847 -34.4417 0
-      vertex 5.42626 -18.4686 40
-      vertex 16.3218 -33.465 0
+      vertex 27.821 -24.0831 0
+      vertex 9.27999 -15.3668 40
+      vertex 9.52645 -14.7973 40
     endloop
   endfacet
-  facet normal -0.511307 0.749635 -0.420254
+  facet normal -0.813855 0.360422 -0.455781
     outer loop
-      vertex 5.42626 -18.4686 40
-      vertex 14.8847 -34.4417 0
-      vertex 5.40852 -18.4807 40
+      vertex 9.27999 -15.3668 40
+      vertex 27.821 -24.0831 0
+      vertex 27.8179 -24.0901 0
     endloop
   endfacet
-  facet normal -0.680936 0.599731 -0.420295
+  facet normal 0.667385 0.589024 -0.455684
     outer loop
-      vertex 21.3958 -28.7002 0
-      vertex 7.09897 -16.9006 40
-      vertex 7.11315 -16.8845 40
+      vertex -7.47637 -18.0208 40
+      vertex -23.6835 -30.6026 0
+      vertex -7.49208 -18.003 40
     endloop
   endfacet
-  facet normal -0.680647 0.600064 -0.42029
+  facet normal 0.667715 0.58864 -0.455697
     outer loop
-      vertex 7.09897 -16.9006 40
-      vertex 21.3958 -28.7002 0
-      vertex 20.2468 -30.0035 0
+      vertex -23.6835 -30.6026 0
+      vertex -7.47637 -18.0208 40
+      vertex -22.4113 -32.0457 0
     endloop
   endfacet
-  facet normal -0.781411 0.461244 -0.420299
+  facet normal 0.736194 0.500359 -0.455697
     outer loop
-      vertex 24.3335 -24.3775 0
-      vertex 8.07889 -15.4659 40
-      vertex 8.08981 -15.4474 40
+      vertex -8.31071 -17.0087 40
+      vertex -25.9579 -27.4734 0
+      vertex -8.65951 -16.4955 40
     endloop
   endfacet
-  facet normal -0.78105 0.461862 -0.42029
+  facet normal 0.735226 0.501821 -0.455652
     outer loop
-      vertex 8.07889 -15.4659 40
-      vertex 24.3335 -24.3775 0
-      vertex 23.4491 -25.8731 0
+      vertex -25.9579 -27.4734 0
+      vertex -8.31071 -17.0087 40
+      vertex -25.9536 -27.4797 0
     endloop
   endfacet
-  facet normal -0.750475 0.510043 -0.420289
+  facet normal 0.194218 0.868688 -0.455698
     outer loop
-      vertex 23.4455 -25.879 0
-      vertex 7.48067 -16.4085 40
-      vertex 7.79459 -15.9466 40
+      vertex -7.63822 -40.7797 0
+      vertex -2.55059 -20.9339 40
+      vertex -1.94498 -21.0693 40
     endloop
   endfacet
-  facet normal -0.754926 0.503284 -0.420466
+  facet normal 0.197268 0.867981 -0.455735
     outer loop
-      vertex 7.48067 -16.4085 40
-      vertex 23.4455 -25.879 0
-      vertex 23.4417 -25.8847 0
+      vertex -2.55059 -20.9339 40
+      vertex -7.63822 -40.7797 0
+      vertex -7.6457 -40.778 0
     endloop
   endfacet
-  facet normal -0.0919765 0.902684 -0.42036
+  facet normal 0.793443 0.403459 -0.455707
     outer loop
-      vertex 3.47342 -38.55 0
-      vertex 1.15704 -20.1589 40
-      vertex 3.48029 -38.5493 0
+      vertex -9.26921 -15.388 40
+      vertex -27.8179 -24.0901 0
+      vertex -9.27999 -15.3668 40
     endloop
   endfacet
-  facet normal -0.0854581 0.903356 -0.420292
+  facet normal 0.79313 0.404084 -0.455698
     outer loop
-      vertex 1.15704 -20.1589 40
-      vertex 3.47342 -38.55 0
-      vertex 0.601019 -20.2115 40
+      vertex -27.8179 -24.0901 0
+      vertex -9.26921 -15.388 40
+      vertex -26.9446 -25.8042 0
     endloop
   endfacet
-  facet normal -0.411968 0.808479 -0.42029
+  facet normal -0.452839 0.766343 -0.455693
     outer loop
-      vertex 11.8293 -36.1224 0
-      vertex 4.44741 -19.0898 40
-      vertex 13.3775 -35.3335 0
+      vertex 16.4668 -36.9618 0
+      vertex 5.49549 -19.6595 40
+      vertex 16.4734 -36.9579 0
     endloop
   endfacet
-  facet normal -0.410694 0.80911 -0.420324
+  facet normal -0.453127 0.76617 -0.455697
     outer loop
-      vertex 4.44741 -19.0898 40
-      vertex 11.8293 -36.1224 0
-      vertex 4.4283 -19.0995 40
+      vertex 5.49549 -19.6595 40
+      vertex 16.4668 -36.9618 0
+      vertex 4.96135 -19.9754 40
     endloop
   endfacet
-  facet normal -0.907145 -0.0191105 -0.420384
+  facet normal -0.30196 0.837359 -0.455687
     outer loop
-      vertex 27.7683 -11 0
-      vertex 9.07372 -3.5 40
-      vertex 27.6103 -3.5 0
+      vertex 9.50039 -40.2392 0
+      vertex 3.75318 -20.5439 40
+      vertex 9.5076 -40.2366 0
     endloop
   endfacet
-  facet normal -0.907145 -0.0191093 -0.420384
+  facet normal -0.301514 0.837513 -0.455698
     outer loop
-      vertex 9.07372 -3.5 40
-      vertex 27.7683 -11 0
-      vertex 9.23171 -11 40
+      vertex 3.75318 -20.5439 40
+      vertex 9.50039 -40.2392 0
+      vertex 3.16931 -20.7541 40
     endloop
   endfacet
-  facet normal 0.308535 0.853332 -0.420274
+  facet normal -0.667709 0.588646 -0.455698
     outer loop
-      vertex -8.58087 -37.4092 0
-      vertex -2.87294 -19.7726 40
-      vertex -2.85275 -19.7799 40
+      vertex 23.6886 -30.5969 0
+      vertex 7.49208 -18.003 40
+      vertex 7.90246 -17.5375 40
     endloop
   endfacet
-  facet normal 0.307379 0.853742 -0.42029
+  facet normal -0.663431 0.593596 -0.455524
     outer loop
-      vertex -2.87294 -19.7726 40
-      vertex -8.58087 -37.4092 0
-      vertex -10.2157 -36.8206 0
+      vertex 7.49208 -18.003 40
+      vertex 23.6886 -30.5969 0
+      vertex 23.6835 -30.6026 0
     endloop
   endfacet
-  facet normal 0.556138 0.716984 -0.42029
+  facet normal 0.0837695 0.886185 -0.455696
     outer loop
-      vertex -16.3218 -33.465 0
-      vertex -5.86756 -18.1263 40
-      vertex -5.42626 -18.4686 40
+      vertex -1.93043 -41.6832 0
+      vertex -1.26179 -21.1775 40
+      vertex -0.643985 -21.2359 40
     endloop
   endfacet
-  facet normal 0.557091 0.71626 -0.420262
+  facet normal 0.0814254 0.886374 -0.455754
     outer loop
-      vertex -5.86756 -18.1263 40
-      vertex -16.3218 -33.465 0
-      vertex -16.3272 -33.4608 0
+      vertex -1.26179 -21.1775 40
+      vertex -1.93043 -41.6832 0
+      vertex -1.93805 -41.6825 0
     endloop
   endfacet
-  facet normal 0.511307 0.749635 -0.420254
+  facet normal 0.0279712 0.889695 -0.455697
     outer loop
-      vertex -14.8847 -34.4417 0
-      vertex -5.42626 -18.4686 40
-      vertex -5.40852 -18.4807 40
+      vertex -1.92277 -41.6835 0
+      vertex -0.643985 -21.2359 40
+      vertex -0.0237379 -21.2554 40
     endloop
   endfacet
-  facet normal 0.510046 0.750473 -0.42029
+  facet normal 0.0348334 0.889414 -0.455773
     outer loop
-      vertex -5.42626 -18.4686 40
-      vertex -14.8847 -34.4417 0
-      vertex -16.3218 -33.465 0
+      vertex -0.643985 -21.2359 40
+      vertex -1.92277 -41.6835 0
+      vertex -1.93043 -41.6832 0
     endloop
   endfacet
-  facet normal 0.461357 0.781345 -0.420297
+  facet normal -0.453137 0.766164 -0.455698
     outer loop
-      vertex -13.3775 -35.3335 0
-      vertex -4.46587 -19.0789 40
-      vertex -4.44741 -19.0898 40
+      vertex 14.811 -37.9411 0
+      vertex 4.96135 -19.9754 40
+      vertex 16.4668 -36.9618 0
     endloop
   endfacet
-  facet normal 0.461862 0.78105 -0.42029
+  facet normal -0.453445 0.765984 -0.455693
     outer loop
-      vertex -4.46587 -19.0789 40
-      vertex -13.3775 -35.3335 0
-      vertex -14.8731 -34.4491 0
+      vertex 4.96135 -19.9754 40
+      vertex 14.811 -37.9411 0
+      vertex 4.94091 -19.9875 40
     endloop
   endfacet
-  facet normal 0.600421 0.680336 -0.420284
+  facet normal -0.139277 0.879171 -0.455698
     outer loop
-      vertex -17.7002 -32.3958 0
-      vertex -5.9006 -18.099 40
-      vertex -5.88451 -18.1132 40
+      vertex 3.8608 -41.5003 0
+      vertex 1.9218 -21.0744 40
+      vertex 5.76083 -41.1993 0
     endloop
   endfacet
-  facet normal 0.600064 0.680647 -0.42029
+  facet normal -0.138672 0.879258 -0.455713
     outer loop
-      vertex -5.9006 -18.099 40
-      vertex -17.7002 -32.3958 0
-      vertex -19.0035 -31.2468 0
+      vertex 1.9218 -21.0744 40
+      vertex 3.8608 -41.5003 0
+      vertex 1.89834 -21.0781 40
     endloop
   endfacet
-  facet normal 0.808484 0.411959 -0.42029
+  facet normal -0.885971 0.0863447 -0.455631
     outer loop
-      vertex -8.09955 -15.4283 40
-      vertex -25.1255 -22.8232 0
-      vertex -8.3531 -14.9307 40
+      vertex 30.6825 -12.9381 0
+      vertex 10.1752 -12.2854 40
+      vertex 10.1775 -12.2618 40
     endloop
   endfacet
-  facet normal 0.808915 0.411088 -0.420313
+  facet normal -0.886185 0.0837552 -0.455698
     outer loop
-      vertex -25.1255 -22.8232 0
-      vertex -8.09955 -15.4283 40
-      vertex -25.1224 -22.8293 0
+      vertex 10.1752 -12.2854 40
+      vertex 30.6825 -12.9381 0
+      vertex 30.5015 -14.8532 0
     endloop
   endfacet
-  facet normal 0.808355 0.412219 -0.420283
+  facet normal -0.837514 0.301513 -0.455698
     outer loop
-      vertex -8.08981 -15.4474 40
-      vertex -25.1224 -22.8293 0
-      vertex -8.09955 -15.4283 40
+      vertex 29.2392 -20.5004 0
+      vertex 9.54392 -14.7532 40
+      vertex 9.75413 -14.1693 40
     endloop
   endfacet
-  facet normal 0.808479 0.411968 -0.42029
+  facet normal -0.83723 0.302333 -0.455676
     outer loop
-      vertex -25.1224 -22.8293 0
-      vertex -8.08981 -15.4474 40
-      vertex -24.3335 -24.3775 0
+      vertex 9.54392 -14.7532 40
+      vertex 29.2392 -20.5004 0
+      vertex 29.2366 -20.5076 0
     endloop
   endfacet
-  facet normal 0.716977 0.556148 -0.420289
+  facet normal -0.837378 0.301907 -0.455688
     outer loop
-      vertex -7.1263 -16.8676 40
-      vertex -22.465 -27.3218 0
-      vertex -7.46861 -16.4263 40
+      vertex 29.2366 -20.5076 0
+      vertex 9.53588 -14.7755 40
+      vertex 9.54392 -14.7532 40
     endloop
   endfacet
-  facet normal 0.716261 0.557092 -0.420261
+  facet normal -0.837516 0.301506 -0.455698
     outer loop
-      vertex -22.465 -27.3218 0
-      vertex -7.1263 -16.8676 40
-      vertex -22.4608 -27.3272 0
+      vertex 9.53588 -14.7755 40
+      vertex 29.2366 -20.5076 0
+      vertex 28.585 -22.3176 0
     endloop
   endfacet
-  facet normal 0.600117 0.680599 -0.420291
+  facet normal 0.87917 0.139284 -0.455698
     outer loop
-      vertex -19.0035 -31.2468 0
-      vertex -6.31954 -17.7296 40
-      vertex -5.9006 -18.099 40
+      vertex -10.0781 -12.8983 40
+      vertex -30.5015 -14.8532 0
+      vertex -10.1752 -12.2854 40
     endloop
   endfacet
-  facet normal 0.601207 0.679626 -0.420308
+  facet normal 0.879236 0.138827 -0.45571
     outer loop
-      vertex -6.31954 -17.7296 40
-      vertex -19.0035 -31.2468 0
-      vertex -19.0087 -31.2422 0
+      vertex -30.5015 -14.8532 0
+      vertex -10.0781 -12.8983 40
+      vertex -30.5003 -14.8608 0
     endloop
   endfacet
-  facet normal 0.885538 0.197934 -0.42029
+  facet normal -0.87917 0.139284 -0.455698
     outer loop
-      vertex -8.94635 -13.2749 40
-      vertex -27.2764 -16.2033 0
-      vertex -9.06819 -12.7298 40
+      vertex 30.5015 -14.8532 0
+      vertex 10.0781 -12.8983 40
+      vertex 10.1752 -12.2854 40
     endloop
   endfacet
-  facet normal 0.885474 0.19824 -0.420283
+  facet normal -0.879236 0.138827 -0.45571
     outer loop
-      vertex -27.2764 -16.2033 0
-      vertex -8.94635 -13.2749 40
-      vertex -27.2749 -16.21 0
+      vertex 10.0781 -12.8983 40
+      vertex 30.5015 -14.8532 0
+      vertex 30.5003 -14.8608 0
     endloop
   endfacet
-  facet normal 0.141998 0.896211 -0.420289
+  facet normal -0.593596 0.663431 -0.455524
     outer loop
-      vertex -3.48029 -38.5493 0
-      vertex -1.70866 -20.0715 40
-      vertex -1.15704 -20.1589 40
+      vertex 19.5969 -34.6886 0
+      vertex 7.00297 -18.4921 40
+      vertex 19.6026 -34.6835 0
     endloop
   endfacet
-  facet normal 0.131815 0.897662 -0.420509
+  facet normal -0.588669 0.667689 -0.455697
     outer loop
-      vertex -1.70866 -20.0715 40
-      vertex -3.48029 -38.5493 0
-      vertex -3.4871 -38.5483 0
+      vertex 7.00297 -18.4921 40
+      vertex 19.5969 -34.6886 0
+      vertex 6.53748 -18.9025 40
     endloop
   endfacet
-  facet normal 0.0854581 0.903356 -0.420292
+  facet normal 0.453127 0.76617 -0.455697
     outer loop
-      vertex -3.47342 -38.55 0
-      vertex -1.15704 -20.1589 40
-      vertex -0.601019 -20.2115 40
+      vertex -16.4668 -36.9618 0
+      vertex -5.49549 -19.6595 40
+      vertex -4.96135 -19.9754 40
     endloop
   endfacet
-  facet normal 0.0919765 0.902684 -0.42036
+  facet normal 0.452839 0.766343 -0.455693
     outer loop
-      vertex -1.15704 -20.1589 40
-      vertex -3.47342 -38.55 0
-      vertex -3.48029 -38.5493 0
+      vertex -5.49549 -19.6595 40
+      vertex -16.4668 -36.9618 0
+      vertex -16.4734 -36.9579 0
     endloop
   endfacet
-  facet normal -0.197924 0.885541 -0.42029
+  facet normal -0.353515 0.816924 -0.455699
     outer loop
-      vertex 5.20999 -38.2749 0
-      vertex 2.29583 -19.9417 40
-      vertex 6.90569 -37.8959 0
+      vertex 11.3176 -39.585 0
+      vertex 3.79732 -20.5264 40
+      vertex 13.0831 -38.821 0
     endloop
   endfacet
-  facet normal -0.198813 0.885352 -0.420268
+  facet normal -0.35561 0.816032 -0.455668
     outer loop
-      vertex 2.29583 -19.9417 40
-      vertex 5.20999 -38.2749 0
-      vertex 2.2749 -19.9464 40
+      vertex 3.79732 -20.5264 40
+      vertex 11.3176 -39.585 0
+      vertex 3.77552 -20.5359 40
     endloop
   endfacet
-  facet normal -0.871303 0.253355 -0.420288
+  facet normal 0.629428 0.629414 -0.455696
     outer loop
-      vertex 26.8959 -17.9057 0
-      vertex 8.93569 -13.3164 40
-      vertex 8.94168 -13.2958 40
+      vertex -21.0456 -33.4113 0
+      vertex -7.47637 -18.0208 40
+      vertex -7.02078 -18.4764 40
     endloop
   endfacet
-  facet normal -0.871357 0.253167 -0.42029
+  facet normal 0.629397 0.629443 -0.455697
     outer loop
-      vertex 8.93569 -13.3164 40
-      vertex 26.8959 -17.9057 0
-      vertex 26.4111 -19.5743 0
+      vertex -7.47637 -18.0208 40
+      vertex -21.0456 -33.4113 0
+      vertex -22.4113 -32.0457 0
     endloop
   endfacet
-  facet normal -0.885552 0.197872 -0.420291
+  facet normal 0.250872 0.854087 -0.45563
     outer loop
-      vertex 27.2749 -16.21 0
-      vertex 8.94168 -13.2958 40
-      vertex 8.94635 -13.2749 40
+      vertex -7.65305 -40.7759 0
+      vertex -3.16931 -20.7541 40
+      vertex -3.1465 -20.7608 40
     endloop
   endfacet
-  facet normal -0.885541 0.197924 -0.42029
+  facet normal 0.248339 0.854791 -0.455698
     outer loop
-      vertex 8.94168 -13.2958 40
-      vertex 27.2749 -16.21 0
-      vertex 26.8959 -17.9057 0
+      vertex -3.16931 -20.7541 40
+      vertex -7.65305 -40.7759 0
+      vertex -9.50039 -40.2392 0
     endloop
   endfacet
-  facet normal -0.853431 0.308254 -0.420278
+  facet normal 0.301514 0.837513 -0.455698
     outer loop
-      vertex 26.4092 -19.5809 0
-      vertex 8.77261 -13.8729 40
-      vertex 8.77987 -13.8528 40
+      vertex -9.50039 -40.2392 0
+      vertex -3.75318 -20.5439 40
+      vertex -3.16931 -20.7541 40
     endloop
   endfacet
-  facet normal -0.85374 0.307384 -0.42029
+  facet normal 0.30196 0.837359 -0.455687
     outer loop
-      vertex 8.77261 -13.8729 40
-      vertex 26.4092 -19.5809 0
-      vertex 25.8206 -21.2157 0
+      vertex -3.75318 -20.5439 40
+      vertex -9.50039 -40.2392 0
+      vertex -9.5076 -40.2366 0
     endloop
   endfacet
-  facet normal -0.641637 0.641606 -0.420291
+  facet normal 0.546521 0.702616 -0.455681
     outer loop
-      vertex 20.2422 -30.0087 0
-      vertex 6.31954 -17.7296 40
-      vertex 6.72962 -17.3195 40
+      vertex -18.0708 -35.8723 0
+      vertex -6.04715 -19.2828 40
+      vertex -6.02838 -19.2974 40
     endloop
   endfacet
-  facet normal -0.641621 0.641621 -0.42029
+  facet normal 0.54556 0.703352 -0.455697
     outer loop
-      vertex 6.31954 -17.7296 40
-      vertex 20.2422 -30.0087 0
-      vertex 19.0087 -31.2422 0
+      vertex -6.04715 -19.2828 40
+      vertex -18.0708 -35.8723 0
+      vertex -19.5908 -34.6933 0
     endloop
   endfacet
-  facet normal -0.557091 0.71626 -0.420262
+  facet normal 0.793113 0.404116 -0.455699
     outer loop
-      vertex 16.3218 -33.465 0
-      vertex 5.86756 -18.1263 40
-      vertex 16.3272 -33.4608 0
+      vertex -8.98749 -15.9409 40
+      vertex -26.9446 -25.8042 0
+      vertex -9.26921 -15.388 40
     endloop
   endfacet
-  facet normal -0.556138 0.716984 -0.42029
+  facet normal 0.791431 0.407354 -0.455742
     outer loop
-      vertex 5.86756 -18.1263 40
-      vertex 16.3218 -33.465 0
-      vertex 5.42626 -18.4686 40
+      vertex -26.9446 -25.8042 0
+      vertex -8.98749 -15.9409 40
+      vertex -26.9411 -25.811 0
     endloop
   endfacet
-  facet normal -0.716148 0.55724 -0.420257
+  facet normal 0.766721 0.452179 -0.455712
     outer loop
-      vertex 22.4608 -27.3272 0
-      vertex 7.11315 -16.8845 40
-      vertex 7.1263 -16.8676 40
+      vertex -8.9754 -15.9614 40
+      vertex -26.9411 -25.811 0
+      vertex -8.98749 -15.9409 40
     endloop
   endfacet
-  facet normal -0.716981 0.556143 -0.42029
+  facet normal 0.766164 0.453137 -0.455697
     outer loop
-      vertex 7.11315 -16.8845 40
-      vertex 22.4608 -27.3272 0
-      vertex 21.3958 -28.7002 0
+      vertex -26.9411 -25.811 0
+      vertex -8.9754 -15.9614 40
+      vertex -25.9618 -27.4668 0
     endloop
   endfacet
-  facet normal -0.716977 0.556148 -0.420289
+  facet normal -0.244526 0.855839 -0.455792
     outer loop
-      vertex 22.465 -27.3218 0
-      vertex 7.1263 -16.8676 40
-      vertex 7.46861 -16.4263 40
+      vertex 7.6457 -40.778 0
+      vertex 3.1465 -20.7608 40
+      vertex 7.65305 -40.7759 0
     endloop
   endfacet
-  facet normal -0.716261 0.557092 -0.420261
+  facet normal -0.248303 0.854801 -0.455697
     outer loop
-      vertex 7.1263 -16.8676 40
-      vertex 22.465 -27.3218 0
-      vertex 22.4608 -27.3272 0
+      vertex 3.1465 -20.7608 40
+      vertex 7.6457 -40.778 0
+      vertex 2.55059 -20.9339 40
     endloop
   endfacet
-  facet normal -0.781017 0.461916 -0.420291
+  facet normal -0.703382 0.545522 -0.455696
     outer loop
-      vertex 23.4491 -25.8731 0
-      vertex 7.79459 -15.9466 40
-      vertex 8.07889 -15.4659 40
+      vertex 23.6933 -30.5908 0
+      vertex 7.90246 -17.5375 40
+      vertex 8.2828 -17.0471 40
     endloop
   endfacet
-  facet normal -0.774538 0.472599 -0.420407
+  facet normal -0.705128 0.543295 -0.455659
     outer loop
-      vertex 7.79459 -15.9466 40
-      vertex 23.4491 -25.8731 0
-      vertex 23.4455 -25.879 0
+      vertex 7.90246 -17.5375 40
+      vertex 23.6933 -30.5908 0
+      vertex 23.6886 -30.5969 0
     endloop
   endfacet
-  facet normal -0.601207 0.679626 -0.420308
+  facet normal -0.404084 0.79313 -0.455698
     outer loop
-      vertex 19.0035 -31.2468 0
-      vertex 6.31954 -17.7296 40
-      vertex 19.0087 -31.2422 0
+      vertex 13.0901 -38.8179 0
+      vertex 4.38799 -20.2692 40
+      vertex 14.8042 -37.9446 0
     endloop
   endfacet
-  facet normal -0.600117 0.680599 -0.420291
+  facet normal -0.404663 0.79284 -0.455689
     outer loop
-      vertex 6.31954 -17.7296 40
-      vertex 19.0035 -31.2468 0
-      vertex 5.9006 -18.099 40
+      vertex 4.38799 -20.2692 40
+      vertex 13.0901 -38.8179 0
+      vertex 4.36683 -20.28 40
     endloop
   endfacet
-  facet normal -0.600064 0.680647 -0.42029
+  facet normal -0.886185 0.0837701 -0.455696
     outer loop
-      vertex 17.7002 -32.3958 0
-      vertex 5.9006 -18.099 40
-      vertex 19.0035 -31.2468 0
+      vertex 30.6832 -12.9304 0
+      vertex 10.1775 -12.2618 40
+      vertex 10.2359 -11.644 40
     endloop
   endfacet
-  facet normal -0.600421 0.680336 -0.420284
+  facet normal -0.88644 0.0805855 -0.455774
     outer loop
-      vertex 5.9006 -18.099 40
-      vertex 17.7002 -32.3958 0
-      vertex 5.88451 -18.1132 40
+      vertex 10.1775 -12.2618 40
+      vertex 30.6832 -12.9304 0
+      vertex 30.6825 -12.9381 0
     endloop
   endfacet
-  facet normal -0.352723 0.836085 -0.420176
+  facet normal 0.869358 0.191109 -0.455735
     outer loop
-      vertex 11.8168 -36.1282 0
-      vertex 3.93067 -19.3531 40
-      vertex 11.8232 -36.1255 0
+      vertex -10.0693 -12.945 40
+      vertex -30.1993 -16.7608 0
+      vertex -10.0744 -12.9218 40
     endloop
   endfacet
-  facet normal -0.360356 0.832767 -0.420289
+  facet normal 0.868703 0.194156 -0.455696
     outer loop
-      vertex 3.93067 -19.3531 40
-      vertex 11.8168 -36.1282 0
-      vertex 3.4181 -19.5749 40
+      vertex -30.1993 -16.7608 0
+      vertex -10.0693 -12.945 40
+      vertex -29.7797 -18.6382 0
     endloop
   endfacet
-  facet normal -0.360392 0.832751 -0.42029
+  facet normal 0.879292 0.138442 -0.455719
     outer loop
-      vertex 10.2222 -36.8183 0
-      vertex 3.4181 -19.5749 40
-      vertex 11.8168 -36.1282 0
+      vertex -10.0744 -12.9218 40
+      vertex -30.5003 -14.8608 0
+      vertex -10.0781 -12.8983 40
     endloop
   endfacet
-  facet normal -0.359785 0.833009 -0.420298
+  facet normal 0.879171 0.139279 -0.455698
     outer loop
-      vertex 3.4181 -19.5749 40
-      vertex 10.2222 -36.8183 0
-      vertex 3.39842 -19.5834 40
+      vertex -30.5003 -14.8608 0
+      vertex -10.0744 -12.9218 40
+      vertex -30.1993 -16.7608 0
     endloop
   endfacet
-  facet normal 0.359785 0.833009 -0.420298
+  facet normal 0.868681 0.194248 -0.455699
     outer loop
-      vertex -10.2222 -36.8183 0
-      vertex -3.4181 -19.5749 40
-      vertex -3.39842 -19.5834 40
+      vertex -9.93388 -13.5506 40
+      vertex -29.7797 -18.6382 0
+      vertex -10.0693 -12.945 40
     endloop
   endfacet
-  facet normal 0.360392 0.832751 -0.42029
+  facet normal 0.868097 0.196769 -0.45573
     outer loop
-      vertex -3.4181 -19.5749 40
-      vertex -10.2222 -36.8183 0
-      vertex -11.8168 -36.1282 0
+      vertex -29.7797 -18.6382 0
+      vertex -9.93388 -13.5506 40
+      vertex -29.778 -18.6457 0
     endloop
   endfacet
-  facet normal 0.30739 0.853738 -0.42029
+  facet normal 0.588669 0.667689 -0.455697
     outer loop
-      vertex -10.2157 -36.8206 0
-      vertex -3.39842 -19.5834 40
-      vertex -2.87294 -19.7726 40
+      vertex -19.5969 -34.6886 0
+      vertex -7.00297 -18.4921 40
+      vertex -6.53748 -18.9025 40
     endloop
   endfacet
-  facet normal 0.302696 0.855445 -0.420226
+  facet normal 0.593596 0.663431 -0.455524
     outer loop
-      vertex -3.39842 -19.5834 40
-      vertex -10.2157 -36.8206 0
-      vertex -10.2222 -36.8183 0
+      vertex -7.00297 -18.4921 40
+      vertex -19.5969 -34.6886 0
+      vertex -19.6026 -34.6835 0
     endloop
   endfacet
-  facet normal 0.510006 0.7505 -0.42029
+  facet normal 0.545535 0.703372 -0.455696
     outer loop
-      vertex -14.879 -34.4455 0
-      vertex -5.40852 -18.4807 40
-      vertex -4.9466 -18.7946 40
+      vertex -19.5908 -34.6933 0
+      vertex -6.53748 -18.9025 40
+      vertex -6.04715 -19.2828 40
     endloop
   endfacet
-  facet normal 0.503284 0.754927 -0.420465
+  facet normal 0.543295 0.705128 -0.455659
     outer loop
-      vertex -5.40852 -18.4807 40
-      vertex -14.879 -34.4455 0
-      vertex -14.8847 -34.4417 0
+      vertex -6.53748 -18.9025 40
+      vertex -19.5908 -34.6933 0
+      vertex -19.5969 -34.6886 0
     endloop
   endfacet
-  facet normal 0.461895 0.78103 -0.420291
+  facet normal 0.854789 0.248346 -0.455697
     outer loop
-      vertex -14.8731 -34.4491 0
-      vertex -4.9466 -18.7946 40
-      vertex -4.46587 -19.0789 40
+      vertex -9.76075 -14.1465 40
+      vertex -29.778 -18.6457 0
+      vertex -9.93388 -13.5506 40
     endloop
   endfacet
-  facet normal 0.472599 0.774538 -0.420406
+  facet normal 0.856256 0.242992 -0.455829
     outer loop
-      vertex -4.9466 -18.7946 40
-      vertex -14.8731 -34.4491 0
-      vertex -14.879 -34.4455 0
+      vertex -29.778 -18.6457 0
+      vertex -9.76075 -14.1465 40
+      vertex -29.7759 -18.6531 0
     endloop
   endfacet
-  facet normal 0.853431 0.308254 -0.420278
+  facet normal -0.667385 0.589024 -0.455684
     outer loop
-      vertex -8.77261 -13.8729 40
-      vertex -26.4092 -19.5809 0
-      vertex -8.77987 -13.8528 40
+      vertex 23.6835 -30.6026 0
+      vertex 7.47637 -18.0208 40
+      vertex 7.49208 -18.003 40
     endloop
   endfacet
-  facet normal 0.85374 0.307384 -0.42029
+  facet normal -0.667715 0.58864 -0.455697
     outer loop
-      vertex -26.4092 -19.5809 0
-      vertex -8.77261 -13.8729 40
-      vertex -25.8206 -21.2157 0
+      vertex 7.47637 -18.0208 40
+      vertex 23.6835 -30.6026 0
+      vertex 22.4113 -32.0457 0
     endloop
   endfacet
-  facet normal 0.853747 0.307365 -0.42029
+  facet normal 0.766161 0.453141 -0.455697
     outer loop
-      vertex -8.58342 -14.3984 40
-      vertex -25.8206 -21.2157 0
-      vertex -8.77261 -13.8729 40
+      vertex -8.65951 -16.4955 40
+      vertex -25.9618 -27.4668 0
+      vertex -8.9754 -15.9614 40
     endloop
   endfacet
-  facet normal 0.855445 0.302696 -0.420226
+  facet normal 0.766343 0.452839 -0.455693
     outer loop
-      vertex -25.8206 -21.2157 0
-      vertex -8.58342 -14.3984 40
-      vertex -25.8183 -21.2222 0
+      vertex -25.9618 -27.4668 0
+      vertex -8.65951 -16.4955 40
+      vertex -25.9579 -27.4734 0
     endloop
   endfacet
-  facet normal -0.503284 0.754927 -0.420465
+  facet normal -0.854789 0.248346 -0.455697
     outer loop
-      vertex 14.879 -34.4455 0
-      vertex 5.40852 -18.4807 40
-      vertex 14.8847 -34.4417 0
+      vertex 29.778 -18.6457 0
+      vertex 9.76075 -14.1465 40
+      vertex 9.93388 -13.5506 40
     endloop
   endfacet
-  facet normal -0.510006 0.7505 -0.42029
+  facet normal -0.856256 0.242992 -0.455829
     outer loop
-      vertex 5.40852 -18.4807 40
-      vertex 14.879 -34.4455 0
-      vertex 4.9466 -18.7946 40
+      vertex 9.76075 -14.1465 40
+      vertex 29.778 -18.6457 0
+      vertex 29.7759 -18.6531 0
     endloop
   endfacet
-  facet normal -0.903338 0.0856687 -0.420287
+  facet normal -0.736194 0.500359 -0.455697
     outer loop
-      vertex 27.7135 -12.7436 0
-      vertex 9.21147 -11.601 40
-      vertex 9.21349 -11.5797 40
+      vertex 25.9579 -27.4734 0
+      vertex 8.31071 -17.0087 40
+      vertex 8.65951 -16.4955 40
     endloop
   endfacet
-  facet normal -0.903363 0.0853855 -0.42029
+  facet normal -0.735226 0.501821 -0.455652
     outer loop
-      vertex 9.21147 -11.601 40
-      vertex 27.7135 -12.7436 0
-      vertex 27.55 -14.4734 0
+      vertex 8.31071 -17.0087 40
+      vertex 25.9579 -27.4734 0
+      vertex 25.9536 -27.4797 0
     endloop
   endfacet
-  facet normal -0.906942 0.0284932 -0.42029
+  facet normal -0.879292 0.138442 -0.455719
     outer loop
-      vertex 27.7137 -12.7367 0
-      vertex 9.21349 -11.5797 40
-      vertex 9.23103 -11.0214 40
+      vertex 30.5003 -14.8608 0
+      vertex 10.0744 -12.9218 40
+      vertex 10.0781 -12.8983 40
     endloop
   endfacet
-  facet normal -0.907022 0.0262905 -0.420263
+  facet normal -0.879171 0.139279 -0.455698
     outer loop
-      vertex 9.21349 -11.5797 40
-      vertex 27.7137 -12.7367 0
-      vertex 27.7135 -12.7436 0
+      vertex 10.0744 -12.9218 40
+      vertex 30.5003 -14.8608 0
+      vertex 30.1993 -16.7608 0
     endloop
   endfacet
-  facet normal 0.903362 0.085397 -0.420291
+  facet normal -0.869358 0.191109 -0.455735
     outer loop
-      vertex -9.15891 -12.157 40
-      vertex -27.55 -14.4734 0
-      vertex -9.21147 -11.601 40
+      vertex 30.1993 -16.7608 0
+      vertex 10.0693 -12.945 40
+      vertex 10.0744 -12.9218 40
     endloop
   endfacet
-  facet normal 0.902726 0.0915809 -0.420356
+  facet normal -0.868703 0.194156 -0.455696
     outer loop
-      vertex -27.55 -14.4734 0
-      vertex -9.15891 -12.157 40
-      vertex -27.5493 -14.4803 0
+      vertex 10.0693 -12.945 40
+      vertex 30.1993 -16.7608 0
+      vertex 29.7797 -18.6382 0
     endloop
   endfacet
-  facet normal 0.896221 0.14193 -0.42029
+  facet normal -0.736863 0.499346 -0.455726
     outer loop
-      vertex -9.07154 -12.7087 40
-      vertex -27.5493 -14.4803 0
-      vertex -9.15891 -12.157 40
+      vertex 25.9536 -27.4797 0
+      vertex 8.29736 -17.0284 40
+      vertex 8.31071 -17.0087 40
     endloop
   endfacet
-  facet normal 0.897636 0.132005 -0.420504
+  facet normal -0.736216 0.500327 -0.455697
     outer loop
-      vertex -27.5493 -14.4803 0
-      vertex -9.07154 -12.7087 40
-      vertex -27.5483 -14.4871 0
+      vertex 8.29736 -17.0284 40
+      vertex 25.9536 -27.4797 0
+      vertex 24.8723 -29.0708 0
     endloop
   endfacet
-  facet normal 0.832775 0.360338 -0.420289
+  facet normal -0.702355 0.546861 -0.455675
     outer loop
-      vertex -8.3531 -14.9307 40
-      vertex -25.1282 -22.8168 0
-      vertex -8.5749 -14.4181 40
+      vertex 24.8723 -29.0708 0
+      vertex 8.2828 -17.0471 40
+      vertex 8.29736 -17.0284 40
     endloop
   endfacet
-  facet normal 0.836085 0.352723 -0.420176
+  facet normal -0.703352 0.54556 -0.455698
     outer loop
-      vertex -25.1282 -22.8168 0
-      vertex -8.3531 -14.9307 40
-      vertex -25.1255 -22.8232 0
+      vertex 8.2828 -17.0471 40
+      vertex 24.8723 -29.0708 0
+      vertex 23.6933 -30.5908 0
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 9.07372 -3.5 40
-      vertex 11 -11 40
-      vertex 11 0 40
+      vertex 10.0931 -4 40
+      vertex 12 -11 40
+      vertex 12 0 40
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex 9.23171 -11 40
-      vertex 11 -11 40
-      vertex 9.07372 -3.5 40
+      vertex 10.2561 -11 40
+      vertex 12 -11 40
+      vertex 10.0931 -4 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.23103 -11.0214 40
-      vertex 11 -11 40
-      vertex 9.23171 -11 40
+      vertex 10.2554 -11.0237 40
+      vertex 12 -11 40
+      vertex 10.2561 -11 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 11 -11 40
-      vertex 9.23103 -11.0214 40
-      vertex 10.9783 -11.6907 40
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.21147 -11.601 40
-      vertex 10.9783 -11.6907 40
-      vertex 9.21349 -11.5797 40
+      vertex 12 -11 40
+      vertex 10.2554 -11.0237 40
+      vertex 11.9763 -11.7535 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.9783 -11.6907 40
-      vertex 9.21147 -11.601 40
-      vertex 10.9133 -12.3787 40
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.15891 -12.157 40
-      vertex 10.9133 -12.3787 40
-      vertex 9.21147 -11.601 40
+      vertex 10.1775 -12.2618 40
+      vertex 11.9763 -11.7535 40
+      vertex 10.2359 -11.644 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.07154 -12.7087 40
-      vertex 10.9133 -12.3787 40
-      vertex 9.15891 -12.157 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.9133 -12.3787 40
-      vertex 9.07154 -12.7087 40
-      vertex 10.8052 -13.0612 40
+      vertex 11.9763 -11.7535 40
+      vertex 10.1775 -12.2618 40
+      vertex 11.9054 -12.504 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 9.06819 -12.7298 40
-      vertex 10.8052 -13.0612 40
-      vertex 9.07154 -12.7087 40
+      vertex 10.1752 -12.2854 40
+      vertex 11.9054 -12.504 40
+      vertex 10.1775 -12.2618 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.0781 -12.8983 40
+      vertex 11.9054 -12.504 40
+      vertex 10.1752 -12.2854 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9054 -12.504 40
+      vertex 10.0781 -12.8983 40
+      vertex 11.7874 -13.2486 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 9.21349 -11.5797 40
-      vertex 10.9783 -11.6907 40
-      vertex 9.23103 -11.0214 40
+      vertex 10.2359 -11.644 40
+      vertex 11.9763 -11.7535 40
+      vertex 10.2554 -11.0237 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 11 0 40
-      vertex -9.07372 -3.5 40
-      vertex 9.07372 -3.5 40
+      vertex 12 0 40
+      vertex -10.0931 -4 40
+      vertex 10.0931 -4 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -8.07889 -15.4659 40
-      vertex -9.63937 -16.2993 40
-      vertex -9.28761 -16.8941 40
+      vertex -12 -11 40
+      vertex -10.2561 -11 40
+      vertex -10.0931 -4 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -11 -11 40
-      vertex -9.23171 -11 40
-      vertex -9.07372 -3.5 40
+      vertex -10.2561 -11 40
+      vertex -10.8579 -16.1094 40
+      vertex -10.5157 -16.781 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -11 -11 40
-      vertex -10.9783 -11.6907 40
+      vertex -10.2561 -11 40
+      vertex -11.1573 -15.4175 40
+      vertex -10.8579 -16.1094 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -9.9531 -15.6836 40
-      vertex -9.63937 -16.2993 40
+      vertex -10.2561 -11 40
+      vertex -11.4127 -14.7082 40
+      vertex -11.1573 -15.4175 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -10.2275 -15.0494 40
-      vertex -9.9531 -15.6836 40
+      vertex -10.2561 -11 40
+      vertex -11.623 -13.9843 40
+      vertex -11.4127 -14.7082 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -10.4616 -14.3992 40
-      vertex -10.2275 -15.0494 40
+      vertex -10.2561 -11 40
+      vertex -11.7874 -13.2486 40
+      vertex -11.623 -13.9843 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -10.6544 -13.7356 40
-      vertex -10.4616 -14.3992 40
+      vertex -10.2561 -11 40
+      vertex -11.9054 -12.504 40
+      vertex -11.7874 -13.2486 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -10.8052 -13.0612 40
-      vertex -10.6544 -13.7356 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -10.9133 -12.3787 40
-      vertex -10.8052 -13.0612 40
+      vertex -10.2561 -11 40
+      vertex -11.9763 -11.7535 40
+      vertex -11.9054 -12.504 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -11 0 40
-      vertex -9.07372 -3.5 40
-      vertex 11 0 40
+      vertex -12 0 40
+      vertex -10.0931 -4 40
+      vertex 12 0 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -11 -11 40
-      vertex -9.07372 -3.5 40
-      vertex -11 0 40
+      vertex -12 -11 40
+      vertex -10.0931 -4 40
+      vertex -12 0 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -10.9783 -11.6907 40
-      vertex -10.9133 -12.3787 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.94635 -13.2749 40
-      vertex 10.8052 -13.0612 40
-      vertex 9.06819 -12.7298 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.8052 -13.0612 40
-      vertex 8.94635 -13.2749 40
-      vertex 10.6544 -13.7356 40
+      vertex -10.2561 -11 40
+      vertex -12 -11 40
+      vertex -11.9763 -11.7535 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 8.94168 -13.2958 40
-      vertex 10.6544 -13.7356 40
-      vertex 8.94635 -13.2749 40
+      vertex 10.0744 -12.9218 40
+      vertex 11.7874 -13.2486 40
+      vertex 10.0781 -12.8983 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 8.93569 -13.3164 40
-      vertex 10.6544 -13.7356 40
-      vertex 8.94168 -13.2958 40
+      vertex 10.0693 -12.945 40
+      vertex 11.7874 -13.2486 40
+      vertex 10.0744 -12.9218 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.6544 -13.7356 40
-      vertex 8.93569 -13.3164 40
-      vertex 10.4616 -14.3992 40
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 8.77987 -13.8528 40
-      vertex 10.4616 -14.3992 40
-      vertex 8.93569 -13.3164 40
+      vertex 11.7874 -13.2486 40
+      vertex 10.0693 -12.945 40
+      vertex 11.623 -13.9843 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 8.77261 -13.8729 40
-      vertex 10.4616 -14.3992 40
-      vertex 8.77987 -13.8528 40
+      vertex 9.93388 -13.5506 40
+      vertex 11.623 -13.9843 40
+      vertex 10.0693 -12.945 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.4616 -14.3992 40
-      vertex 8.77261 -13.8729 40
-      vertex 10.2275 -15.0494 40
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 8.58342 -14.3984 40
-      vertex 10.2275 -15.0494 40
-      vertex 8.77261 -13.8729 40
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 8.5749 -14.4181 40
-      vertex 10.2275 -15.0494 40
-      vertex 8.58342 -14.3984 40
+      vertex 9.76075 -14.1465 40
+      vertex 11.623 -13.9843 40
+      vertex 9.93388 -13.5506 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.2275 -15.0494 40
-      vertex 8.5749 -14.4181 40
-      vertex 9.9531 -15.6836 40
+      vertex 11.623 -13.9843 40
+      vertex 9.76075 -14.1465 40
+      vertex 11.4127 -14.7082 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 8.3531 -14.9307 40
-      vertex 9.9531 -15.6836 40
-      vertex 8.5749 -14.4181 40
+      vertex 9.75413 -14.1693 40
+      vertex 11.4127 -14.7082 40
+      vertex 9.76075 -14.1465 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.54392 -14.7532 40
+      vertex 11.4127 -14.7082 40
+      vertex 9.75413 -14.1693 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4127 -14.7082 40
+      vertex 9.54392 -14.7532 40
+      vertex 11.1573 -15.4175 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 8.09955 -15.4283 40
-      vertex 9.9531 -15.6836 40
-      vertex 8.3531 -14.9307 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.9531 -15.6836 40
-      vertex 8.09955 -15.4283 40
-      vertex 9.63937 -16.2993 40
+      vertex 9.53588 -14.7755 40
+      vertex 11.1573 -15.4175 40
+      vertex 9.54392 -14.7532 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 8.08981 -15.4474 40
-      vertex 9.63937 -16.2993 40
-      vertex 8.09955 -15.4283 40
+      vertex 9.52645 -14.7973 40
+      vertex 11.1573 -15.4175 40
+      vertex 9.53588 -14.7755 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.1573 -15.4175 40
+      vertex 9.52645 -14.7973 40
+      vertex 10.8579 -16.1094 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 8.07889 -15.4659 40
-      vertex 9.63937 -16.2993 40
-      vertex 8.08981 -15.4474 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.63937 -16.2993 40
-      vertex 8.07889 -15.4659 40
-      vertex 9.28761 -16.8941 40
+      vertex 9.27999 -15.3668 40
+      vertex 10.8579 -16.1094 40
+      vertex 9.52645 -14.7973 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 7.79459 -15.9466 40
-      vertex 9.28761 -16.8941 40
-      vertex 8.07889 -15.4659 40
+      vertex 9.26921 -15.388 40
+      vertex 10.8579 -16.1094 40
+      vertex 9.27999 -15.3668 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.8579 -16.1094 40
+      vertex 9.26921 -15.388 40
+      vertex 10.5157 -16.781 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 7.48067 -16.4085 40
-      vertex 9.28761 -16.8941 40
-      vertex 7.79459 -15.9466 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.28761 -16.8941 40
-      vertex 7.48067 -16.4085 40
-      vertex 8.89919 -17.4656 40
+      vertex 8.98749 -15.9409 40
+      vertex 10.5157 -16.781 40
+      vertex 9.26921 -15.388 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 7.46861 -16.4263 40
-      vertex 8.89919 -17.4656 40
-      vertex 7.48067 -16.4085 40
+      vertex 8.9754 -15.9614 40
+      vertex 10.5157 -16.781 40
+      vertex 8.98749 -15.9409 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5157 -16.781 40
+      vertex 8.9754 -15.9614 40
+      vertex 10.1319 -17.4299 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 7.1263 -16.8676 40
-      vertex 8.89919 -17.4656 40
-      vertex 7.46861 -16.4263 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.89919 -17.4656 40
-      vertex 7.1263 -16.8676 40
-      vertex 8.47565 -18.0117 40
+      vertex 8.65951 -16.4955 40
+      vertex 10.1319 -17.4299 40
+      vertex 8.9754 -15.9614 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 7.11315 -16.8845 40
-      vertex 8.47565 -18.0117 40
-      vertex 7.1263 -16.8676 40
+      vertex 8.31071 -17.0087 40
+      vertex 10.1319 -17.4299 40
+      vertex 8.65951 -16.4955 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.1319 -17.4299 40
+      vertex 8.31071 -17.0087 40
+      vertex 9.7082 -18.0534 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 7.09897 -16.9006 40
-      vertex 8.47565 -18.0117 40
-      vertex 7.11315 -16.8845 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.47565 -18.0117 40
-      vertex 7.09897 -16.9006 40
-      vertex 8.01865 -18.53 40
+      vertex 8.29736 -17.0284 40
+      vertex 9.7082 -18.0534 40
+      vertex 8.31071 -17.0087 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 6.72962 -17.3195 40
-      vertex 8.01865 -18.53 40
-      vertex 7.09897 -16.9006 40
+      vertex 8.2828 -17.0471 40
+      vertex 9.7082 -18.0534 40
+      vertex 8.29736 -17.0284 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 8.01865 -18.53 40
-      vertex 6.72962 -17.3195 40
-      vertex 7.53002 -19.0187 40
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 6.31954 -17.7296 40
-      vertex 7.53002 -19.0187 40
-      vertex 6.72962 -17.3195 40
+      vertex 9.7082 -18.0534 40
+      vertex 8.2828 -17.0471 40
+      vertex 9.24616 -18.6491 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 5.9006 -18.099 40
-      vertex 7.53002 -19.0187 40
-      vertex 6.31954 -17.7296 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 7.53002 -19.0187 40
-      vertex 5.9006 -18.099 40
-      vertex 7.01166 -19.4756 40
+      vertex 7.90246 -17.5375 40
+      vertex 9.24616 -18.6491 40
+      vertex 8.2828 -17.0471 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 5.88451 -18.1132 40
-      vertex 7.01166 -19.4756 40
-      vertex 5.9006 -18.099 40
+      vertex 7.49208 -18.003 40
+      vertex 9.24616 -18.6491 40
+      vertex 7.90246 -17.5375 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.24616 -18.6491 40
+      vertex 7.49208 -18.003 40
+      vertex 8.74762 -19.2146 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 5.86756 -18.1263 40
-      vertex 7.01166 -19.4756 40
-      vertex 5.88451 -18.1132 40
+      vertex 7.47637 -18.0208 40
+      vertex 8.74762 -19.2146 40
+      vertex 7.49208 -18.003 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 7.01166 -19.4756 40
-      vertex 5.86756 -18.1263 40
-      vertex 6.46564 -19.8992 40
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 5.42626 -18.4686 40
-      vertex 6.46564 -19.8992 40
-      vertex 5.86756 -18.1263 40
+      vertex 8.74762 -19.2146 40
+      vertex 7.47637 -18.0208 40
+      vertex 8.21456 -19.7476 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 5.40852 -18.4807 40
-      vertex 6.46564 -19.8992 40
-      vertex 5.42626 -18.4686 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.46564 -19.8992 40
-      vertex 5.40852 -18.4807 40
-      vertex 5.89409 -20.2876 40
+      vertex 7.02078 -18.4764 40
+      vertex 8.21456 -19.7476 40
+      vertex 7.47637 -18.0208 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 4.9466 -18.7946 40
-      vertex 5.89409 -20.2876 40
-      vertex 5.40852 -18.4807 40
+      vertex 7.00297 -18.4921 40
+      vertex 8.21456 -19.7476 40
+      vertex 7.02078 -18.4764 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.21456 -19.7476 40
+      vertex 7.00297 -18.4921 40
+      vertex 7.64909 -20.2462 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 4.46587 -19.0789 40
-      vertex 5.89409 -20.2876 40
-      vertex 4.9466 -18.7946 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.89409 -20.2876 40
-      vertex 4.46587 -19.0789 40
-      vertex 5.29929 -20.6394 40
+      vertex 6.53748 -18.9025 40
+      vertex 7.64909 -20.2462 40
+      vertex 7.00297 -18.4921 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 4.44741 -19.0898 40
-      vertex 5.29929 -20.6394 40
-      vertex 4.46587 -19.0789 40
+      vertex 6.04715 -19.2828 40
+      vertex 7.64909 -20.2462 40
+      vertex 6.53748 -18.9025 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.64909 -20.2462 40
+      vertex 6.04715 -19.2828 40
+      vertex 7.05342 -20.7082 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 4.4283 -19.0995 40
-      vertex 5.29929 -20.6394 40
-      vertex 4.44741 -19.0898 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.29929 -20.6394 40
-      vertex 4.4283 -19.0995 40
-      vertex 4.68357 -20.9531 40
+      vertex 6.02838 -19.2974 40
+      vertex 7.05342 -20.7082 40
+      vertex 6.04715 -19.2828 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 3.93067 -19.3531 40
-      vertex 4.68357 -20.9531 40
-      vertex 4.4283 -19.0995 40
+      vertex 6.00874 -19.3107 40
+      vertex 7.05342 -20.7082 40
+      vertex 6.02838 -19.2974 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.05342 -20.7082 40
+      vertex 6.00874 -19.3107 40
+      vertex 6.42992 -21.1319 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 3.4181 -19.5749 40
-      vertex 4.68357 -20.9531 40
-      vertex 3.93067 -19.3531 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.68357 -20.9531 40
-      vertex 3.4181 -19.5749 40
-      vertex 4.04937 -21.2275 40
+      vertex 5.49549 -19.6595 40
+      vertex 6.42992 -21.1319 40
+      vertex 6.00874 -19.3107 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 3.39842 -19.5834 40
-      vertex 4.04937 -21.2275 40
-      vertex 3.4181 -19.5749 40
+      vertex 4.96135 -19.9754 40
+      vertex 6.42992 -21.1319 40
+      vertex 5.49549 -19.6595 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.42992 -21.1319 40
+      vertex 4.96135 -19.9754 40
+      vertex 5.78104 -21.5157 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 2.87294 -19.7726 40
-      vertex 4.04937 -21.2275 40
-      vertex 3.39842 -19.5834 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.04937 -21.2275 40
-      vertex 2.87294 -19.7726 40
-      vertex 3.39919 -21.4616 40
+      vertex 4.94091 -19.9875 40
+      vertex 5.78104 -21.5157 40
+      vertex 4.96135 -19.9754 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 2.85275 -19.7799 40
-      vertex 3.39919 -21.4616 40
-      vertex 2.87294 -19.7726 40
+      vertex 4.38799 -20.2692 40
+      vertex 5.78104 -21.5157 40
+      vertex 4.94091 -19.9875 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.78104 -21.5157 40
+      vertex 4.38799 -20.2692 40
+      vertex 5.10935 -21.8579 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 2.31643 -19.9357 40
-      vertex 3.39919 -21.4616 40
-      vertex 2.85275 -19.7799 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3.39919 -21.4616 40
-      vertex 2.31643 -19.9357 40
-      vertex 2.73559 -21.6544 40
+      vertex 4.36683 -20.28 40
+      vertex 5.10935 -21.8579 40
+      vertex 4.38799 -20.2692 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 2.29583 -19.9417 40
-      vertex 2.73559 -21.6544 40
-      vertex 2.31643 -19.9357 40
+      vertex 3.79732 -20.5264 40
+      vertex 5.10935 -21.8579 40
+      vertex 4.36683 -20.28 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.10935 -21.8579 40
+      vertex 3.79732 -20.5264 40
+      vertex 4.41749 -22.1573 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 2.2749 -19.9464 40
-      vertex 2.73559 -21.6544 40
-      vertex 2.29583 -19.9417 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.2749 -19.9464 40
-      vertex 2.06119 -21.8052 40
-      vertex 2.73559 -21.6544 40
+      vertex 3.77552 -20.5359 40
+      vertex 4.41749 -22.1573 40
+      vertex 3.79732 -20.5264 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 1.72985 -20.0682 40
-      vertex 2.06119 -21.8052 40
-      vertex 2.2749 -19.9464 40
+      vertex 3.75318 -20.5439 40
+      vertex 4.41749 -22.1573 40
+      vertex 3.77552 -20.5359 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.75318 -20.5439 40
+      vertex 3.7082 -22.4127 40
+      vertex 4.41749 -22.1573 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 1.70866 -20.0715 40
-      vertex 2.06119 -21.8052 40
-      vertex 1.72985 -20.0682 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.70866 -20.0715 40
-      vertex 1.37866 -21.9133 40
-      vertex 2.06119 -21.8052 40
+      vertex 3.16931 -20.7541 40
+      vertex 3.7082 -22.4127 40
+      vertex 3.75318 -20.5439 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 1.15704 -20.1589 40
-      vertex 1.37866 -21.9133 40
-      vertex 1.70866 -20.0715 40
+      vertex 3.1465 -20.7608 40
+      vertex 3.7082 -22.4127 40
+      vertex 3.16931 -20.7541 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.1465 -20.7608 40
+      vertex 2.98428 -22.623 40
+      vertex 3.7082 -22.4127 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 0.601019 -20.2115 40
-      vertex 1.37866 -21.9133 40
-      vertex 1.15704 -20.1589 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.37866 -21.9133 40
-      vertex 0.601019 -20.2115 40
-      vertex 0.690695 -21.9783 40
+      vertex 2.55059 -20.9339 40
+      vertex 2.98428 -22.623 40
+      vertex 3.1465 -20.7608 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 0.579663 -20.2135 40
-      vertex 0.690695 -21.9783 40
-      vertex 0.601019 -20.2115 40
+      vertex 1.94498 -21.0693 40
+      vertex 2.98428 -22.623 40
+      vertex 2.55059 -20.9339 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98428 -22.623 40
+      vertex 1.94498 -21.0693 40
+      vertex 2.24858 -22.7874 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 0.0214407 -20.231 40
-      vertex 0.690695 -21.9783 40
-      vertex 0.579663 -20.2135 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0 -22 40
-      vertex 0.0214407 -20.231 40
-      vertex 0 -20.2317 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.0214407 -20.231 40
-      vertex 0 -22 40
-      vertex 0.690695 -21.9783 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.0214407 -20.231 40
-      vertex 0 -22 40
-      vertex 0 -20.2317 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.690695 -21.9783 40
-      vertex -0.0214407 -20.231 40
-      vertex -0.579663 -20.2135 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.690695 -21.9783 40
-      vertex -0.579663 -20.2135 40
-      vertex -0.601019 -20.2115 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.0214407 -20.231 40
-      vertex -0.690695 -21.9783 40
-      vertex 0 -22 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.37866 -21.9133 40
-      vertex -0.601019 -20.2115 40
-      vertex -1.15704 -20.1589 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.601019 -20.2115 40
-      vertex -1.37866 -21.9133 40
-      vertex -0.690695 -21.9783 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.70866 -20.0715 40
-      vertex -1.37866 -21.9133 40
-      vertex -1.15704 -20.1589 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.06119 -21.8052 40
-      vertex -1.70866 -20.0715 40
-      vertex -1.72985 -20.0682 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.70866 -20.0715 40
-      vertex -2.06119 -21.8052 40
-      vertex -1.37866 -21.9133 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.2749 -19.9464 40
-      vertex -2.06119 -21.8052 40
-      vertex -1.72985 -20.0682 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.73559 -21.6544 40
-      vertex -2.2749 -19.9464 40
-      vertex -2.29583 -19.9417 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.73559 -21.6544 40
-      vertex -2.29583 -19.9417 40
-      vertex -2.31643 -19.9357 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.2749 -19.9464 40
-      vertex -2.73559 -21.6544 40
-      vertex -2.06119 -21.8052 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -3.39919 -21.4616 40
-      vertex -2.31643 -19.9357 40
-      vertex -2.85275 -19.7799 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -3.39919 -21.4616 40
-      vertex -2.85275 -19.7799 40
-      vertex -2.87294 -19.7726 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.04937 -21.2275 40
-      vertex -2.87294 -19.7726 40
-      vertex -3.39842 -19.5834 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.31643 -19.9357 40
-      vertex -3.39919 -21.4616 40
-      vertex -2.73559 -21.6544 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.04937 -21.2275 40
-      vertex -3.39842 -19.5834 40
-      vertex -3.4181 -19.5749 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.68357 -20.9531 40
-      vertex -3.4181 -19.5749 40
-      vertex -3.93067 -19.3531 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.87294 -19.7726 40
-      vertex -4.04937 -21.2275 40
-      vertex -3.39919 -21.4616 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.68357 -20.9531 40
-      vertex -3.93067 -19.3531 40
-      vertex -4.4283 -19.0995 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.29929 -20.6394 40
-      vertex -4.4283 -19.0995 40
-      vertex -4.44741 -19.0898 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.29929 -20.6394 40
-      vertex -4.44741 -19.0898 40
-      vertex -4.46587 -19.0789 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -3.4181 -19.5749 40
-      vertex -4.68357 -20.9531 40
-      vertex -4.04937 -21.2275 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.89409 -20.2876 40
-      vertex -4.46587 -19.0789 40
-      vertex -4.9466 -18.7946 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.4283 -19.0995 40
-      vertex -5.29929 -20.6394 40
-      vertex -4.68357 -20.9531 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.89409 -20.2876 40
-      vertex -4.9466 -18.7946 40
-      vertex -5.40852 -18.4807 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -6.46564 -19.8992 40
-      vertex -5.40852 -18.4807 40
-      vertex -5.42626 -18.4686 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -6.46564 -19.8992 40
-      vertex -5.42626 -18.4686 40
-      vertex -5.86756 -18.1263 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.01166 -19.4756 40
-      vertex -5.86756 -18.1263 40
-      vertex -5.88451 -18.1132 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.46587 -19.0789 40
-      vertex -5.89409 -20.2876 40
-      vertex -5.29929 -20.6394 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.01166 -19.4756 40
-      vertex -5.88451 -18.1132 40
-      vertex -5.9006 -18.099 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.53002 -19.0187 40
-      vertex -5.9006 -18.099 40
-      vertex -6.31954 -17.7296 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.40852 -18.4807 40
-      vertex -6.46564 -19.8992 40
-      vertex -5.89409 -20.2876 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.53002 -19.0187 40
-      vertex -6.31954 -17.7296 40
-      vertex -6.72962 -17.3195 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.86756 -18.1263 40
-      vertex -7.01166 -19.4756 40
-      vertex -6.46564 -19.8992 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.01865 -18.53 40
-      vertex -6.72962 -17.3195 40
-      vertex -7.09897 -16.9006 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.47565 -18.0117 40
-      vertex -7.09897 -16.9006 40
-      vertex -7.11315 -16.8845 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.47565 -18.0117 40
-      vertex -7.11315 -16.8845 40
-      vertex -7.1263 -16.8676 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.89919 -17.4656 40
-      vertex -7.1263 -16.8676 40
-      vertex -7.46861 -16.4263 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.89919 -17.4656 40
-      vertex -7.46861 -16.4263 40
-      vertex -7.48067 -16.4085 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.9006 -18.099 40
-      vertex -7.53002 -19.0187 40
-      vertex -7.01166 -19.4756 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.28761 -16.8941 40
-      vertex -7.48067 -16.4085 40
-      vertex -7.79459 -15.9466 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -6.72962 -17.3195 40
-      vertex -8.01865 -18.53 40
-      vertex -7.53002 -19.0187 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.28761 -16.8941 40
-      vertex -7.79459 -15.9466 40
-      vertex -8.07889 -15.4659 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.07889 -15.4659 40
-      vertex -8.08981 -15.4474 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.08981 -15.4474 40
-      vertex -8.09955 -15.4283 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.09955 -15.4283 40
-      vertex -8.3531 -14.9307 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.09897 -16.9006 40
-      vertex -8.47565 -18.0117 40
-      vertex -8.01865 -18.53 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.3531 -14.9307 40
-      vertex -8.5749 -14.4181 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.5749 -14.4181 40
-      vertex -8.58342 -14.3984 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.58342 -14.3984 40
-      vertex -8.77261 -13.8729 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.77261 -13.8729 40
-      vertex -8.77987 -13.8528 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -7.1263 -16.8676 40
-      vertex -8.89919 -17.4656 40
-      vertex -8.47565 -18.0117 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.77987 -13.8528 40
-      vertex -8.93569 -13.3164 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.93569 -13.3164 40
-      vertex -8.94168 -13.2958 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.94168 -13.2958 40
-      vertex -8.94635 -13.2749 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -8.94635 -13.2749 40
-      vertex -9.06819 -12.7298 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -9.06819 -12.7298 40
-      vertex -9.07154 -12.7087 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -9.07154 -12.7087 40
-      vertex -9.15891 -12.157 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -9.15891 -12.157 40
-      vertex -9.21147 -11.601 40
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.63937 -16.2993 40
-      vertex -9.21147 -11.601 40
-      vertex -9.21349 -11.5797 40
+      vertex 1.9218 -21.0744 40
+      vertex 2.24858 -22.7874 40
+      vertex 1.94498 -21.0693 40
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -11 -11 40
-      vertex -9.23103 -11.0214 40
-      vertex -9.23171 -11 40
+      vertex 1.89834 -21.0781 40
+      vertex 2.24858 -22.7874 40
+      vertex 1.9218 -21.0744 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -7.48067 -16.4085 40
-      vertex -9.28761 -16.8941 40
-      vertex -8.89919 -17.4656 40
+      vertex 1.89834 -21.0781 40
+      vertex 1.504 -22.9054 40
+      vertex 2.24858 -22.7874 40
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.28543 -21.1752 40
+      vertex 1.504 -22.9054 40
+      vertex 1.89834 -21.0781 40
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.26179 -21.1775 40
+      vertex 1.504 -22.9054 40
+      vertex 1.28543 -21.1752 40
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -9.23103 -11.0214 40
-      vertex -9.63937 -16.2993 40
-      vertex -9.21349 -11.5797 40
+      vertex 1.26179 -21.1775 40
+      vertex 0.753486 -22.9763 40
+      vertex 1.504 -22.9054 40
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.643985 -21.2359 40
+      vertex 0.753486 -22.9763 40
+      vertex 1.26179 -21.1775 40
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.0237379 -21.2554 40
+      vertex 0.753486 -22.9763 40
+      vertex 0.643985 -21.2359 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -23 40
+      vertex 0.0237379 -21.2554 40
+      vertex 0 -21.2561 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.0237379 -21.2554 40
+      vertex 0 -23 40
+      vertex 0.753486 -22.9763 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0237379 -21.2554 40
+      vertex 0 -23 40
+      vertex 0 -21.2561 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.753486 -22.9763 40
+      vertex -0.0237379 -21.2554 40
+      vertex -0.643985 -21.2359 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0237379 -21.2554 40
+      vertex -0.753486 -22.9763 40
+      vertex 0 -23 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.26179 -21.1775 40
+      vertex -0.753486 -22.9763 40
+      vertex -0.643985 -21.2359 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.504 -22.9054 40
+      vertex -1.26179 -21.1775 40
+      vertex -1.28543 -21.1752 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.26179 -21.1775 40
+      vertex -1.504 -22.9054 40
+      vertex -0.753486 -22.9763 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.89834 -21.0781 40
+      vertex -1.504 -22.9054 40
+      vertex -1.28543 -21.1752 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.24858 -22.7874 40
+      vertex -1.89834 -21.0781 40
+      vertex -1.9218 -21.0744 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.24858 -22.7874 40
+      vertex -1.9218 -21.0744 40
+      vertex -1.94498 -21.0693 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.89834 -21.0781 40
+      vertex -2.24858 -22.7874 40
+      vertex -1.504 -22.9054 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.98428 -22.623 40
+      vertex -1.94498 -21.0693 40
+      vertex -2.55059 -20.9339 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.94498 -21.0693 40
+      vertex -2.98428 -22.623 40
+      vertex -2.24858 -22.7874 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.1465 -20.7608 40
+      vertex -2.98428 -22.623 40
+      vertex -2.55059 -20.9339 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.7082 -22.4127 40
+      vertex -3.1465 -20.7608 40
+      vertex -3.16931 -20.7541 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.1465 -20.7608 40
+      vertex -3.7082 -22.4127 40
+      vertex -2.98428 -22.623 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.75318 -20.5439 40
+      vertex -3.7082 -22.4127 40
+      vertex -3.16931 -20.7541 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.41749 -22.1573 40
+      vertex -3.75318 -20.5439 40
+      vertex -3.77552 -20.5359 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.41749 -22.1573 40
+      vertex -3.77552 -20.5359 40
+      vertex -3.79732 -20.5264 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.10935 -21.8579 40
+      vertex -3.79732 -20.5264 40
+      vertex -4.36683 -20.28 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.10935 -21.8579 40
+      vertex -4.36683 -20.28 40
+      vertex -4.38799 -20.2692 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.75318 -20.5439 40
+      vertex -4.41749 -22.1573 40
+      vertex -3.7082 -22.4127 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.78104 -21.5157 40
+      vertex -4.38799 -20.2692 40
+      vertex -4.94091 -19.9875 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.78104 -21.5157 40
+      vertex -4.94091 -19.9875 40
+      vertex -4.96135 -19.9754 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.79732 -20.5264 40
+      vertex -5.10935 -21.8579 40
+      vertex -4.41749 -22.1573 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.42992 -21.1319 40
+      vertex -4.96135 -19.9754 40
+      vertex -5.49549 -19.6595 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.38799 -20.2692 40
+      vertex -5.78104 -21.5157 40
+      vertex -5.10935 -21.8579 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.42992 -21.1319 40
+      vertex -5.49549 -19.6595 40
+      vertex -6.00874 -19.3107 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.05342 -20.7082 40
+      vertex -6.00874 -19.3107 40
+      vertex -6.02838 -19.2974 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.05342 -20.7082 40
+      vertex -6.02838 -19.2974 40
+      vertex -6.04715 -19.2828 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.96135 -19.9754 40
+      vertex -6.42992 -21.1319 40
+      vertex -5.78104 -21.5157 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.64909 -20.2462 40
+      vertex -6.04715 -19.2828 40
+      vertex -6.53748 -18.9025 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.64909 -20.2462 40
+      vertex -6.53748 -18.9025 40
+      vertex -7.00297 -18.4921 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.21456 -19.7476 40
+      vertex -7.00297 -18.4921 40
+      vertex -7.02078 -18.4764 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.00874 -19.3107 40
+      vertex -7.05342 -20.7082 40
+      vertex -6.42992 -21.1319 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.21456 -19.7476 40
+      vertex -7.02078 -18.4764 40
+      vertex -7.47637 -18.0208 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.74762 -19.2146 40
+      vertex -7.47637 -18.0208 40
+      vertex -7.49208 -18.003 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.04715 -19.2828 40
+      vertex -7.64909 -20.2462 40
+      vertex -7.05342 -20.7082 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.24616 -18.6491 40
+      vertex -7.49208 -18.003 40
+      vertex -7.90246 -17.5375 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.00297 -18.4921 40
+      vertex -8.21456 -19.7476 40
+      vertex -7.64909 -20.2462 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.24616 -18.6491 40
+      vertex -7.90246 -17.5375 40
+      vertex -8.2828 -17.0471 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.7082 -18.0534 40
+      vertex -8.2828 -17.0471 40
+      vertex -8.29736 -17.0284 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.7082 -18.0534 40
+      vertex -8.29736 -17.0284 40
+      vertex -8.31071 -17.0087 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.1319 -17.4299 40
+      vertex -8.31071 -17.0087 40
+      vertex -8.65951 -16.4955 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.47637 -18.0208 40
+      vertex -8.74762 -19.2146 40
+      vertex -8.21456 -19.7476 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.1319 -17.4299 40
+      vertex -8.65951 -16.4955 40
+      vertex -8.9754 -15.9614 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -8.9754 -15.9614 40
+      vertex -8.98749 -15.9409 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.49208 -18.003 40
+      vertex -9.24616 -18.6491 40
+      vertex -8.74762 -19.2146 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -8.98749 -15.9409 40
+      vertex -9.26921 -15.388 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -9.26921 -15.388 40
+      vertex -9.27999 -15.3668 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -9.27999 -15.3668 40
+      vertex -9.52645 -14.7973 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -9.52645 -14.7973 40
+      vertex -9.53588 -14.7755 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -9.53588 -14.7755 40
+      vertex -9.54392 -14.7532 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.2828 -17.0471 40
+      vertex -9.7082 -18.0534 40
+      vertex -9.24616 -18.6491 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -9.54392 -14.7532 40
+      vertex -9.75413 -14.1693 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -9.75413 -14.1693 40
+      vertex -9.76075 -14.1465 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -9.76075 -14.1465 40
+      vertex -9.93388 -13.5506 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -9.93388 -13.5506 40
+      vertex -10.0693 -12.945 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -10.0693 -12.945 40
+      vertex -10.0744 -12.9218 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -10.0744 -12.9218 40
+      vertex -10.0781 -12.8983 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.31071 -17.0087 40
+      vertex -10.1319 -17.4299 40
+      vertex -9.7082 -18.0534 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -10.0781 -12.8983 40
+      vertex -10.1752 -12.2854 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -10.1752 -12.2854 40
+      vertex -10.1775 -12.2618 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -10.1775 -12.2618 40
+      vertex -10.2359 -11.644 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -10.2359 -11.644 40
+      vertex -10.2554 -11.0237 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5157 -16.781 40
+      vertex -10.2554 -11.0237 40
+      vertex -10.2561 -11 40
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.9754 -15.9614 40
+      vertex -10.5157 -16.781 40
+      vertex -10.1319 -17.4299 40
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -27.6103 -3.5 0
-      vertex 9.07372 -3.5 40
-      vertex -9.07372 -3.5 40
+      vertex -30.5809 -4 0
+      vertex 10.0931 -4 40
+      vertex -10.0931 -4 40
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 9.07372 -3.5 40
-      vertex -27.6103 -3.5 0
-      vertex 27.6103 -3.5 0
+      vertex 10.0931 -4 40
+      vertex -30.5809 -4 0
+      vertex 30.5809 -4 0
     endloop
   endfacet
-  facet normal -0.902914 -0.0283672 0.428884
+  facet normal 0.247025 -0.850339 0.464654
     outer loop
-      vertex -29.9408 -12.8837 0
-      vertex -10.9783 -11.6907 40
-      vertex -11 -11 40
+      vertex 2.98428 -22.623 40
+      vertex 8.20677 -42.9632 0
+      vertex 3.7082 -22.4127 40
     endloop
   endfacet
-  facet normal -0.829082 -0.35872 0.428885
+  facet normal -0.585634 -0.664177 0.464652
     outer loop
-      vertex -27.8933 -22.0437 0
-      vertex -9.9531 -15.6836 40
-      vertex -10.2275 -15.0494 40
+      vertex -21.035 -36.4269 0
+      vertex -7.64909 -20.2462 40
+      vertex -8.21456 -19.7476 40
     endloop
   endfacet
-  facet normal -0.597391 -0.677631 0.428884
+  facet normal 0.299991 -0.833128 0.464654
     outer loop
-      vertex -19.1227 -34.1154 0
-      vertex -7.53002 -19.0187 40
-      vertex -20.5364 -32.8691 0
+      vertex 3.7082 -22.4127 40
+      vertex 12.1481 -41.6826 0
+      vertex 4.41749 -22.1573 40
     endloop
   endfacet
-  facet normal 0.0850319 -0.899349 0.428883
+  facet normal -0.833132 -0.299979 0.464654
     outer loop
-      vertex 1.88371 -40.9408 0
-      vertex 3.76 -40.7634 0
-      vertex 1.37866 -21.9133 40
+      vertex -30.6826 -23.1481 0
+      vertex -11.4127 -14.7082 40
+      vertex -31.3849 -21.1976 0
     endloop
   endfacet
-  facet normal 0.638818 -0.638726 0.428883
+  facet normal 0.402007 -0.788978 0.464654
     outer loop
-      vertex 20.5364 -32.8691 0
-      vertex 8.01865 -18.53 40
-      vertex 7.53002 -19.0187 40
+      vertex 14.0507 -40.8593 0
+      vertex 15.8979 -39.9181 0
+      vertex 5.10935 -21.8579 40
     endloop
   endfacet
-  facet normal 0.638771 -0.638771 0.428885
+  facet normal 0.881562 -0.0833339 0.464655
     outer loop
-      vertex 8.01865 -18.53 40
-      vertex 20.5364 -32.8691 0
-      vertex 21.8691 -31.5364 0
+      vertex 32.7398 -15.136 0
+      vertex 32.9349 -13.0721 0
+      vertex 11.9763 -11.7535 40
     endloop
   endfacet
-  facet normal 0.903278 -0 0.429057
+  facet normal 0.247009 -0.850343 0.464654
     outer loop
-      vertex 11 -11 40
-      vertex 30 0 0
-      vertex 11 0 40
+      vertex 8.20677 -42.9632 0
+      vertex 10.1976 -42.3849 0
+      vertex 3.7082 -22.4127 40
     endloop
   endfacet
-  facet normal 0.903278 0 0.429057
+  facet normal -0.699695 -0.542701 0.464653
     outer loop
-      vertex 30 0 0
-      vertex 11 -11 40
-      vertex 30 -11 0
+      vertex -25.4269 -32.035 0
+      vertex -9.24616 -18.6491 40
+      vertex -9.7082 -18.0534 40
     endloop
   endfacet
-  facet normal -0.777562 -0.459844 0.428884
+  facet normal -0.138519 -0.87459 0.464655
     outer loop
-      vertex -26.2892 -25.4526 0
-      vertex -9.28761 -16.8941 40
-      vertex -9.63937 -16.2993 40
+      vertex -4.136 -43.7398 0
+      vertex -2.24858 -22.7874 40
+      vertex -6.18358 -43.4155 0
     endloop
   endfacet
-  facet normal -0.141314 -0.892239 0.428883
+  facet normal 0.299979 -0.833132 0.464654
     outer loop
-      vertex -5.62144 -40.4686 0
-      vertex -1.37866 -21.9133 40
-      vertex -2.06119 -21.8052 40
+      vertex 10.1976 -42.3849 0
+      vertex 12.1481 -41.6826 0
+      vertex 3.7082 -22.4127 40
     endloop
   endfacet
-  facet normal 0.892238 -0.14132 0.428883
+  facet normal 0.885398 -0 0.464834
     outer loop
-      vertex 10.8052 -13.0612 40
-      vertex 29.4686 -16.6214 0
-      vertex 10.9133 -12.3787 40
+      vertex 12 -11 40
+      vertex 33 0 0
+      vertex 12 0 40
     endloop
   endfacet
-  facet normal 0.459859 -0.777553 0.428884
+  facet normal 0.885398 0 0.464834
     outer loop
-      vertex 14.4526 -37.2892 0
-      vertex 16.0748 -36.3298 0
-      vertex 5.89409 -20.2876 40
+      vertex 33 0 0
+      vertex 12 -11 40
+      vertex 33 -11 0
     endloop
   endfacet
-  facet normal 0.67763 -0.59739 0.428885
+  facet normal -0.19311 -0.86418 0.464653
     outer loop
-      vertex 21.8691 -31.5364 0
-      vertex 23.1154 -30.1227 0
-      vertex 8.01865 -18.53 40
+      vertex -8.20677 -42.9632 0
+      vertex -2.24858 -22.7874 40
+      vertex -2.98428 -22.623 40
     endloop
   endfacet
-  facet normal 0.881607 -0.197047 0.428883
+  facet normal -0.762179 -0.450755 0.464655
     outer loop
-      vertex 29.0575 -18.4607 0
-      vertex 29.4686 -16.6214 0
-      vertex 10.8052 -13.0612 40
+      vertex -27.8628 -28.6823 0
+      vertex -10.1319 -17.4299 40
+      vertex -28.9181 -26.8979 0
     endloop
   endfacet
-  facet normal 0.804898 -0.410119 0.428884
+  facet normal 0.885054 -0.0278378 0.464655
     outer loop
-      vertex 26.2892 -25.4526 0
-      vertex 27.1448 -23.7734 0
-      vertex 9.9531 -15.6836 40
+      vertex 11.9763 -11.7535 40
+      vertex 32.9349 -13.0721 0
+      vertex 12 -11 40
     endloop
   endfacet
-  facet normal 0.829082 -0.35872 0.428885
+  facet normal 0.81267 -0.35166 0.464654
     outer loop
-      vertex 9.9531 -15.6836 40
-      vertex 27.8933 -22.0437 0
-      vertex 10.2275 -15.0494 40
+      vertex 10.8579 -16.1094 40
+      vertex 30.6826 -23.1481 0
+      vertex 11.1573 -15.4175 40
     endloop
   endfacet
-  facet normal -0.89224 -0.141309 0.428883
+  facet normal 0.833132 -0.299979 0.464654
     outer loop
-      vertex -29.4686 -16.6214 0
-      vertex -10.9133 -12.3787 40
-      vertex -29.7634 -14.76 0
+      vertex 30.6826 -23.1481 0
+      vertex 31.3849 -21.1976 0
+      vertex 11.4127 -14.7082 40
     endloop
   endfacet
-  facet normal -0.899349 -0.0850315 0.428883
+  facet normal 0.762179 -0.450755 0.464655
     outer loop
-      vertex -29.7634 -14.76 0
-      vertex -10.9133 -12.3787 40
-      vertex -29.9408 -12.8837 0
+      vertex 27.8628 -28.6823 0
+      vertex 28.9181 -26.8979 0
+      vertex 10.1319 -17.4299 40
     endloop
   endfacet
-  facet normal -0.903278 0 0.429057
+  facet normal -0.626102 -0.626173 0.464654
     outer loop
-      vertex -30 -11 0
-      vertex -11 0 40
-      vertex -30 0 0
+      vertex -24.056 -33.5901 0
+      vertex -8.21456 -19.7476 40
+      vertex -8.74762 -19.2146 40
     endloop
   endfacet
-  facet normal -0.903278 0 0.429057
+  facet normal -0.626137 -0.626137 0.464655
     outer loop
-      vertex -11 0 40
-      vertex -30 -11 0
-      vertex -11 -11 40
+      vertex -8.21456 -19.7476 40
+      vertex -24.056 -33.5901 0
+      vertex -22.5901 -35.056 0
     endloop
   endfacet
-  facet normal -0.902914 -0.0283763 0.428884
+  facet normal -0.450799 -0.762153 0.464653
     outer loop
-      vertex -29.9408 -12.8837 0
-      vertex -11 -11 40
-      vertex -30 -11 0
+      vertex -15.8979 -39.9181 0
+      vertex -5.78104 -21.5157 40
+      vertex -6.42992 -21.1319 40
     endloop
   endfacet
-  facet normal -0.804898 -0.410119 0.428884
+  facet normal -0.585561 -0.664239 0.464655
     outer loop
-      vertex -26.2892 -25.4526 0
-      vertex -9.9531 -15.6836 40
-      vertex -27.1448 -23.7734 0
+      vertex -21.035 -36.4269 0
+      vertex -8.21456 -19.7476 40
+      vertex -22.5901 -35.056 0
     endloop
   endfacet
-  facet normal -0.829064 -0.358764 0.428884
+  facet normal 0.66424 -0.585561 0.464654
     outer loop
-      vertex -27.1448 -23.7734 0
-      vertex -9.9531 -15.6836 40
-      vertex -27.8933 -22.0437 0
+      vertex 24.056 -33.5901 0
+      vertex 25.4269 -32.035 0
+      vertex 8.74762 -19.2146 40
     endloop
   endfacet
-  facet normal -0.881588 -0.197129 0.428885
+  facet normal -0.0278063 -0.885056 0.464654
     outer loop
-      vertex -29.0575 -18.4607 0
-      vertex -10.6544 -13.7356 40
-      vertex -10.8052 -13.0612 40
+      vertex -2.07209 -43.9349 0
+      vertex 0 -44 0
+      vertex 0 -23 40
     endloop
   endfacet
-  facet normal -0.849952 -0.306006 0.428884
+  facet normal -0.351661 -0.812669 0.464654
     outer loop
-      vertex -27.8933 -22.0437 0
-      vertex -10.2275 -15.0494 40
-      vertex -28.5317 -20.2705 0
+      vertex -12.1481 -41.6826 0
+      vertex -5.10935 -21.8579 40
+      vertex -14.0507 -40.8593 0
     endloop
   endfacet
-  facet normal -0.358764 -0.829064 0.428884
+  facet normal -0.299991 -0.833128 0.464654
     outer loop
-      vertex -11.0437 -38.8933 0
-      vertex -4.68357 -20.9531 40
-      vertex -12.7734 -38.1448 0
+      vertex -12.1481 -41.6826 0
+      vertex -3.7082 -22.4127 40
+      vertex -4.41749 -22.1573 40
     endloop
   endfacet
-  facet normal -0.252037 -0.867488 0.428885
+  facet normal -0.0278383 -0.885054 0.464655
     outer loop
-      vertex -9.27051 -39.5317 0
-      vertex -2.73559 -21.6544 40
-      vertex -3.39919 -21.4616 40
+      vertex -2.07209 -43.9349 0
+      vertex 0 -23 40
+      vertex -0.753486 -22.9763 40
     endloop
   endfacet
-  facet normal -0.638771 -0.638771 0.428885
+  facet normal 0.351677 -0.812662 0.464654
     outer loop
-      vertex -20.5364 -32.8691 0
-      vertex -8.01865 -18.53 40
-      vertex -21.8691 -31.5364 0
+      vertex 4.41749 -22.1573 40
+      vertex 12.1481 -41.6826 0
+      vertex 5.10935 -21.8579 40
     endloop
   endfacet
-  facet normal -0.638818 -0.638726 0.428883
+  facet normal -0.664227 -0.585577 0.464654
     outer loop
-      vertex -8.01865 -18.53 40
-      vertex -20.5364 -32.8691 0
-      vertex -7.53002 -19.0187 40
+      vertex -25.4269 -32.035 0
+      vertex -8.74762 -19.2146 40
+      vertex -9.24616 -18.6491 40
     endloop
   endfacet
-  facet normal 0.0283762 -0.902914 0.428884
+  facet normal 0.401965 -0.789 0.464653
     outer loop
-      vertex 0 -41 0
-      vertex 1.88371 -40.9408 0
-      vertex 0 -22 40
+      vertex 5.10935 -21.8579 40
+      vertex 15.8979 -39.9181 0
+      vertex 5.78104 -21.5157 40
     endloop
   endfacet
-  facet normal -0.0283762 -0.902914 0.428884
+  facet normal 0.0832805 -0.881568 0.464653
     outer loop
-      vertex -1.88371 -40.9408 0
-      vertex 0 -41 0
-      vertex 0 -22 40
+      vertex 0.753486 -22.9763 40
+      vertex 4.136 -43.7398 0
+      vertex 1.504 -22.9054 40
     endloop
   endfacet
-  facet normal -0.141306 -0.89224 0.428883
+  facet normal 0.732381 -0.497708 0.464655
     outer loop
-      vertex -3.76 -40.7634 0
-      vertex -1.37866 -21.9133 40
-      vertex -5.62144 -40.4686 0
+      vertex 26.6976 -30.3969 0
+      vertex 27.8628 -28.6823 0
+      vertex 9.7082 -18.0534 40
     endloop
   endfacet
-  facet normal 0.899355 -0.0849681 0.428884
+  facet normal 0.138519 -0.87459 0.464655
     outer loop
-      vertex 10.9133 -12.3787 40
-      vertex 29.9408 -12.8837 0
-      vertex 10.9783 -11.6907 40
+      vertex 4.136 -43.7398 0
+      vertex 6.18358 -43.4155 0
+      vertex 2.24858 -22.7874 40
     endloop
   endfacet
-  facet normal 0.902914 -0.0283672 0.428884
+  facet normal 0.585634 -0.664177 0.464652
     outer loop
-      vertex 10.9783 -11.6907 40
-      vertex 29.9408 -12.8837 0
-      vertex 11 -11 40
+      vertex 7.64909 -20.2462 40
+      vertex 21.035 -36.4269 0
+      vertex 8.21456 -19.7476 40
     endloop
   endfacet
-  facet normal 0.141314 -0.892239 0.428883
+  facet normal 0.0278063 -0.885056 0.464654
     outer loop
-      vertex 1.37866 -21.9133 40
-      vertex 5.62144 -40.4686 0
-      vertex 2.06119 -21.8052 40
+      vertex 0 -44 0
+      vertex 2.07209 -43.9349 0
+      vertex 0 -23 40
     endloop
   endfacet
-  facet normal 0.507744 -0.747164 0.428884
+  facet normal 0.450799 -0.762153 0.464653
     outer loop
-      vertex 16.0748 -36.3298 0
-      vertex 17.6336 -35.2705 0
-      vertex 5.89409 -20.2876 40
+      vertex 5.78104 -21.5157 40
+      vertex 15.8979 -39.9181 0
+      vertex 6.42992 -21.1319 40
     endloop
   endfacet
-  facet normal 0.677583 -0.597445 0.428883
+  facet normal 0.87459 -0.138518 0.464655
     outer loop
-      vertex 8.01865 -18.53 40
-      vertex 23.1154 -30.1227 0
-      vertex 8.47565 -18.0117 40
+      vertex 32.4155 -17.1836 0
+      vertex 32.7398 -15.136 0
+      vertex 11.7874 -13.2486 40
     endloop
   endfacet
-  facet normal 0.902914 -0.0283763 0.428884
+  facet normal -0.874579 -0.138598 0.464653
     outer loop
-      vertex 29.9408 -12.8837 0
-      vertex 30 -11 0
-      vertex 11 -11 40
+      vertex -32.7398 -15.136 0
+      vertex -11.7874 -13.2486 40
+      vertex -11.9054 -12.504 40
     endloop
   endfacet
+  facet normal 0.762159 -0.450789 0.464654
+    outer loop
+      vertex 10.1319 -17.4299 40
+      vertex 28.9181 -26.8979 0
+      vertex 10.5157 -16.781 40
+    endloop
+  endfacet
+  facet normal 0.788979 -0.402007 0.464654
+    outer loop
+      vertex 28.9181 -26.8979 0
+      vertex 29.8593 -25.0507 0
+      vertex 10.8579 -16.1094 40
+    endloop
+  endfacet
+  facet normal 0.351661 -0.812669 0.464654
+    outer loop
+      vertex 12.1481 -41.6826 0
+      vertex 14.0507 -40.8593 0
+      vertex 5.10935 -21.8579 40
+    endloop
+  endfacet
+  facet normal 0.19319 -0.864161 0.464655
+    outer loop
+      vertex 6.18358 -43.4155 0
+      vertex 8.20677 -42.9632 0
+      vertex 2.24858 -22.7874 40
+    endloop
+  endfacet
+  facet normal 0.699664 -0.54274 0.464654
+    outer loop
+      vertex 25.4269 -32.035 0
+      vertex 26.6976 -30.3969 0
+      vertex 9.7082 -18.0534 40
+    endloop
+  endfacet
+  facet normal -0.850337 -0.247031 0.464654
+    outer loop
+      vertex -31.9632 -19.2068 0
+      vertex -11.4127 -14.7082 40
+      vertex -11.623 -13.9843 40
+    endloop
+  endfacet
+  facet normal 0.864161 -0.193189 0.464655
+    outer loop
+      vertex 31.9632 -19.2068 0
+      vertex 32.4155 -17.1836 0
+      vertex 11.7874 -13.2486 40
+    endloop
+  endfacet
+  facet normal -0.788979 -0.402007 0.464654
+    outer loop
+      vertex -28.9181 -26.8979 0
+      vertex -10.8579 -16.1094 40
+      vertex -29.8593 -25.0507 0
+    endloop
+  endfacet
+  facet normal -0.812669 -0.351661 0.464654
+    outer loop
+      vertex -29.8593 -25.0507 0
+      vertex -10.8579 -16.1094 40
+      vertex -30.6826 -23.1481 0
+    endloop
+  endfacet
+  facet normal -0.66424 -0.585561 0.464654
+    outer loop
+      vertex -24.056 -33.5901 0
+      vertex -8.74762 -19.2146 40
+      vertex -25.4269 -32.035 0
+    endloop
+  endfacet
+  facet normal -0.885398 0 0.464834
+    outer loop
+      vertex -33 -11 0
+      vertex -12 0 40
+      vertex -33 0 0
+    endloop
+  endfacet
+  facet normal -0.885398 0 0.464834
+    outer loop
+      vertex -12 0 40
+      vertex -33 -11 0
+      vertex -12 -11 40
+    endloop
+  endfacet
+  facet normal -0.732381 -0.497708 0.464655
+    outer loop
+      vertex -26.6976 -30.3969 0
+      vertex -9.7082 -18.0534 40
+      vertex -27.8628 -28.6823 0
+    endloop
+  endfacet
+  facet normal -0.0833335 -0.881562 0.464655
+    outer loop
+      vertex -2.07209 -43.9349 0
+      vertex -0.753486 -22.9763 40
+      vertex -4.136 -43.7398 0
+    endloop
+  endfacet
+  facet normal -0.73239 -0.497696 0.464655
+    outer loop
+      vertex -27.8628 -28.6823 0
+      vertex -9.7082 -18.0534 40
+      vertex -10.1319 -17.4299 40
+    endloop
+  endfacet
+  facet normal -0.0832805 -0.881568 0.464653
+    outer loop
+      vertex -4.136 -43.7398 0
+      vertex -0.753486 -22.9763 40
+      vertex -1.504 -22.9054 40
+    endloop
+  endfacet
+  facet normal 0.850342 -0.247013 0.464654
+    outer loop
+      vertex 31.3849 -21.1976 0
+      vertex 31.9632 -19.2068 0
+      vertex 11.4127 -14.7082 40
+    endloop
+  endfacet
+  facet normal 0.664227 -0.585577 0.464654
+    outer loop
+      vertex 8.74762 -19.2146 40
+      vertex 25.4269 -32.035 0
+      vertex 9.24616 -18.6491 40
+    endloop
+  endfacet
+  facet normal -0.81267 -0.35166 0.464654
+    outer loop
+      vertex -30.6826 -23.1481 0
+      vertex -10.8579 -16.1094 40
+      vertex -11.1573 -15.4175 40
+    endloop
+  endfacet
+  facet normal -0.850342 -0.247013 0.464654
+    outer loop
+      vertex -31.3849 -21.1976 0
+      vertex -11.4127 -14.7082 40
+      vertex -31.9632 -19.2068 0
+    endloop
+  endfacet
+  facet normal -0.885056 -0.0278061 0.464654
+    outer loop
+      vertex -32.9349 -13.0721 0
+      vertex -12 -11 40
+      vertex -33 -11 0
+    endloop
+  endfacet
+  facet normal 0.788978 -0.402008 0.464654
+    outer loop
+      vertex 10.5157 -16.781 40
+      vertex 28.9181 -26.8979 0
+      vertex 10.8579 -16.1094 40
+    endloop
+  endfacet
+  facet normal 0.86418 -0.19311 0.464653
+    outer loop
+      vertex 11.623 -13.9843 40
+      vertex 31.9632 -19.2068 0
+      vertex 11.7874 -13.2486 40
+    endloop
+  endfacet
+  facet normal -0.699664 -0.54274 0.464654
+    outer loop
+      vertex -25.4269 -32.035 0
+      vertex -9.7082 -18.0534 40
+      vertex -26.6976 -30.3969 0
+    endloop
+  endfacet
+  facet normal 0.450755 -0.762179 0.464654
+    outer loop
+      vertex 15.8979 -39.9181 0
+      vertex 17.6823 -38.8628 0
+      vertex 6.42992 -21.1319 40
+    endloop
+  endfacet
+  facet normal -0.881562 -0.0833339 0.464655
+    outer loop
+      vertex -32.7398 -15.136 0
+      vertex -11.9763 -11.7535 40
+      vertex -32.9349 -13.0721 0
+    endloop
+  endfacet
+  facet normal 0.850337 -0.247031 0.464654
+    outer loop
+      vertex 11.4127 -14.7082 40
+      vertex 31.9632 -19.2068 0
+      vertex 11.623 -13.9843 40
+    endloop
+  endfacet
+  facet normal 0.73239 -0.497696 0.464655
+    outer loop
+      vertex 9.7082 -18.0534 40
+      vertex 27.8628 -28.6823 0
+      vertex 10.1319 -17.4299 40
+    endloop
+  endfacet
+  facet normal 0.497696 -0.73239 0.464655
+    outer loop
+      vertex 6.42992 -21.1319 40
+      vertex 17.6823 -38.8628 0
+      vertex 7.05342 -20.7082 40
+    endloop
+  endfacet
+  facet normal -0.247025 -0.850339 0.464654
+    outer loop
+      vertex -8.20677 -42.9632 0
+      vertex -2.98428 -22.623 40
+      vertex -3.7082 -22.4127 40
+    endloop
+  endfacet
+  facet normal 0.885056 -0.0278061 0.464654
+    outer loop
+      vertex 32.9349 -13.0721 0
+      vertex 33 -11 0
+      vertex 12 -11 40
+    endloop
+  endfacet
+  facet normal -0.885054 -0.0278378 0.464655
+    outer loop
+      vertex -32.9349 -13.0721 0
+      vertex -11.9763 -11.7535 40
+      vertex -12 -11 40
+    endloop
+  endfacet
+  facet normal -0.881568 -0.083282 0.464653
+    outer loop
+      vertex -32.7398 -15.136 0
+      vertex -11.9054 -12.504 40
+      vertex -11.9763 -11.7535 40
+    endloop
+  endfacet
+  facet normal -0.788978 -0.402008 0.464654
+    outer loop
+      vertex -28.9181 -26.8979 0
+      vertex -10.5157 -16.781 40
+      vertex -10.8579 -16.1094 40
+    endloop
+  endfacet
+  facet normal -0.762159 -0.450789 0.464654
+    outer loop
+      vertex -28.9181 -26.8979 0
+      vertex -10.1319 -17.4299 40
+      vertex -10.5157 -16.781 40
+    endloop
+  endfacet
+  facet normal -0.497696 -0.73239 0.464655
+    outer loop
+      vertex -17.6823 -38.8628 0
+      vertex -6.42992 -21.1319 40
+      vertex -7.05342 -20.7082 40
+    endloop
+  endfacet
+  facet normal 0.699695 -0.542701 0.464653
+    outer loop
+      vertex 9.24616 -18.6491 40
+      vertex 25.4269 -32.035 0
+      vertex 9.7082 -18.0534 40
+    endloop
+  endfacet
+  facet normal 0.542689 -0.699705 0.464652
+    outer loop
+      vertex 7.05342 -20.7082 40
+      vertex 21.035 -36.4269 0
+      vertex 7.64909 -20.2462 40
+    endloop
+  endfacet
+  facet normal -0.19319 -0.864161 0.464655
+    outer loop
+      vertex -6.18358 -43.4155 0
+      vertex -2.24858 -22.7874 40
+      vertex -8.20677 -42.9632 0
+    endloop
+  endfacet
+  facet normal 0.874579 -0.138598 0.464653
+    outer loop
+      vertex 11.7874 -13.2486 40
+      vertex 32.7398 -15.136 0
+      vertex 11.9054 -12.504 40
+    endloop
+  endfacet
+  facet normal 0.881568 -0.083282 0.464653
+    outer loop
+      vertex 11.9054 -12.504 40
+      vertex 32.7398 -15.136 0
+      vertex 11.9763 -11.7535 40
+    endloop
+  endfacet
+  facet normal 0.812669 -0.351661 0.464654
+    outer loop
+      vertex 29.8593 -25.0507 0
+      vertex 30.6826 -23.1481 0
+      vertex 10.8579 -16.1094 40
+    endloop
+  endfacet
+  facet normal -0.138602 -0.874578 0.464653
+    outer loop
+      vertex -4.136 -43.7398 0
+      vertex -1.504 -22.9054 40
+      vertex -2.24858 -22.7874 40
+    endloop
+  endfacet
+  facet normal -0.833129 -0.299987 0.464654
+    outer loop
+      vertex -30.6826 -23.1481 0
+      vertex -11.1573 -15.4175 40
+      vertex -11.4127 -14.7082 40
+    endloop
+  endfacet
+  facet normal 0.497708 -0.732381 0.464654
+    outer loop
+      vertex 17.6823 -38.8628 0
+      vertex 19.3969 -37.6976 0
+      vertex 7.05342 -20.7082 40
+    endloop
+  endfacet
+  facet normal -0.450755 -0.762179 0.464654
+    outer loop
+      vertex -15.8979 -39.9181 0
+      vertex -6.42992 -21.1319 40
+      vertex -17.6823 -38.8628 0
+    endloop
+  endfacet
+  facet normal -0.299979 -0.833132 0.464654
+    outer loop
+      vertex -10.1976 -42.3849 0
+      vertex -3.7082 -22.4127 40
+      vertex -12.1481 -41.6826 0
+    endloop
+  endfacet
+  facet normal -0.247009 -0.850343 0.464654
+    outer loop
+      vertex -8.20677 -42.9632 0
+      vertex -3.7082 -22.4127 40
+      vertex -10.1976 -42.3849 0
+    endloop
+  endfacet
+  facet normal -0.86418 -0.19311 0.464653
+    outer loop
+      vertex -31.9632 -19.2068 0
+      vertex -11.623 -13.9843 40
+      vertex -11.7874 -13.2486 40
+    endloop
+  endfacet
+  facet normal 0.833129 -0.299987 0.464654
+    outer loop
+      vertex 11.1573 -15.4175 40
+      vertex 30.6826 -23.1481 0
+      vertex 11.4127 -14.7082 40
+    endloop
+  endfacet
+  facet normal 0.0833335 -0.881562 0.464655
+    outer loop
+      vertex 2.07209 -43.9349 0
+      vertex 4.136 -43.7398 0
+      vertex 0.753486 -22.9763 40
+    endloop
+  endfacet
+  facet normal 0.0278383 -0.885054 0.464655
+    outer loop
+      vertex 0 -23 40
+      vertex 2.07209 -43.9349 0
+      vertex 0.753486 -22.9763 40
+    endloop
+  endfacet
+  facet normal -0.864161 -0.193189 0.464655
+    outer loop
+      vertex -31.9632 -19.2068 0
+      vertex -11.7874 -13.2486 40
+      vertex -32.4155 -17.1836 0
+    endloop
+  endfacet
+  facet normal -0.87459 -0.138518 0.464655
+    outer loop
+      vertex -32.4155 -17.1836 0
+      vertex -11.7874 -13.2486 40
+      vertex -32.7398 -15.136 0
+    endloop
+  endfacet
+  facet normal -0.542689 -0.699705 0.464652
+    outer loop
+      vertex -21.035 -36.4269 0
+      vertex -7.05342 -20.7082 40
+      vertex -7.64909 -20.2462 40
+    endloop
+  endfacet
+  facet normal 0.138602 -0.874578 0.464653
+    outer loop
+      vertex 1.504 -22.9054 40
+      vertex 4.136 -43.7398 0
+      vertex 2.24858 -22.7874 40
+    endloop
+  endfacet
+  facet normal -0.351677 -0.812662 0.464654
+    outer loop
+      vertex -12.1481 -41.6826 0
+      vertex -4.41749 -22.1573 40
+      vertex -5.10935 -21.8579 40
+    endloop
+  endfacet
+  facet normal 0.54274 -0.699664 0.464654
+    outer loop
+      vertex 19.3969 -37.6976 0
+      vertex 21.035 -36.4269 0
+      vertex 7.05342 -20.7082 40
+    endloop
+  endfacet
+  facet normal -0.401965 -0.789 0.464653
+    outer loop
+      vertex -15.8979 -39.9181 0
+      vertex -5.10935 -21.8579 40
+      vertex -5.78104 -21.5157 40
+    endloop
+  endfacet
+  facet normal 0.585561 -0.664239 0.464655
+    outer loop
+      vertex 21.035 -36.4269 0
+      vertex 22.5901 -35.056 0
+      vertex 8.21456 -19.7476 40
+    endloop
+  endfacet
+  facet normal -0.402007 -0.788978 0.464654
+    outer loop
+      vertex -14.0507 -40.8593 0
+      vertex -5.10935 -21.8579 40
+      vertex -15.8979 -39.9181 0
+    endloop
+  endfacet
+  facet normal 0.626102 -0.626173 0.464654
+    outer loop
+      vertex 8.21456 -19.7476 40
+      vertex 24.056 -33.5901 0
+      vertex 8.74762 -19.2146 40
+    endloop
+  endfacet
+  facet normal 0.626137 -0.626137 0.464655
+    outer loop
+      vertex 24.056 -33.5901 0
+      vertex 8.21456 -19.7476 40
+      vertex 22.5901 -35.056 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.9349 -13.0721 0
+      vertex 30.6835 -12.9228 0
+      vertex 30.7439 -11 0
+    endloop
+  endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 29.9408 -12.8837 0
-      vertex 27.7137 -12.7367 0
-      vertex 27.7683 -11 0
+      vertex 31.9632 -19.2068 0
+      vertex 30.6832 -12.9304 0
+      vertex 30.6835 -12.9228 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 27.7135 -12.7436 0
-      vertex 27.7137 -12.7367 0
+      vertex 29.2366 -20.5076 0
+      vertex 31.3849 -21.1976 0
+      vertex 30.6826 -23.1481 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 27.55 -14.4734 0
-      vertex 27.7135 -12.7436 0
+      vertex 31.9632 -19.2068 0
+      vertex 30.6825 -12.9381 0
+      vertex 30.6832 -12.9304 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 27.5493 -14.4803 0
-      vertex 27.55 -14.4734 0
+      vertex 31.9632 -19.2068 0
+      vertex 30.5015 -14.8532 0
+      vertex 30.6825 -12.9381 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 27.5483 -14.4871 0
-      vertex 27.5493 -14.4803 0
+      vertex 31.9632 -19.2068 0
+      vertex 30.5003 -14.8608 0
+      vertex 30.5015 -14.8532 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 27.2764 -16.2033 0
-      vertex 27.5483 -14.4871 0
+      vertex 31.9632 -19.2068 0
+      vertex 30.1993 -16.7608 0
+      vertex 30.5003 -14.8608 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 27.2749 -16.21 0
-      vertex 27.2764 -16.2033 0
+      vertex 28.585 -22.3176 0
+      vertex 30.6826 -23.1481 0
+      vertex 29.8593 -25.0507 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 25.8183 -21.2222 0
-      vertex 27.8933 -22.0437 0
-      vertex 27.1448 -23.7734 0
+      vertex 31.9632 -19.2068 0
+      vertex 29.7797 -18.6382 0
+      vertex 30.1993 -16.7608 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 26.8959 -17.9057 0
-      vertex 27.2749 -16.21 0
+      vertex 31.9632 -19.2068 0
+      vertex 29.778 -18.6457 0
+      vertex 29.7797 -18.6382 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 26.4111 -19.5743 0
-      vertex 26.8959 -17.9057 0
+      vertex 31.9632 -19.2068 0
+      vertex 29.7759 -18.6531 0
+      vertex 29.778 -18.6457 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 26.4092 -19.5809 0
-      vertex 26.4111 -19.5743 0
+      vertex 31.3849 -21.1976 0
+      vertex 29.2392 -20.5004 0
+      vertex 29.7759 -18.6531 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 25.1224 -22.8293 0
-      vertex 27.1448 -23.7734 0
-      vertex 26.2892 -25.4526 0
+      vertex 31.3849 -21.1976 0
+      vertex 29.2366 -20.5076 0
+      vertex 29.2392 -20.5004 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 27.8933 -22.0437 0
-      vertex 25.8206 -21.2157 0
-      vertex 26.4092 -19.5809 0
+      vertex 27.8179 -24.0901 0
+      vertex 29.8593 -25.0507 0
+      vertex 28.9181 -26.8979 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 27.8933 -22.0437 0
-      vertex 25.8183 -21.2222 0
-      vertex 25.8206 -21.2157 0
+      vertex 30.6826 -23.1481 0
+      vertex 28.585 -22.3176 0
+      vertex 29.2366 -20.5076 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 24.3335 -24.3775 0
-      vertex 26.2892 -25.4526 0
-      vertex 25.3298 -27.0748 0
+      vertex 26.9411 -25.811 0
+      vertex 28.9181 -26.8979 0
+      vertex 27.8628 -28.6823 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 27.1448 -23.7734 0
-      vertex 25.1282 -22.8168 0
-      vertex 25.8183 -21.2222 0
+      vertex 29.8593 -25.0507 0
+      vertex 27.821 -24.0831 0
+      vertex 28.585 -22.3176 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 27.1448 -23.7734 0
-      vertex 25.1255 -22.8232 0
-      vertex 25.1282 -22.8168 0
+      vertex 29.8593 -25.0507 0
+      vertex 27.8179 -24.0901 0
+      vertex 27.821 -24.0831 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 27.1448 -23.7734 0
-      vertex 25.1224 -22.8293 0
-      vertex 25.1255 -22.8232 0
+      vertex 28.9181 -26.8979 0
+      vertex 26.9446 -25.8042 0
+      vertex 27.8179 -24.0901 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 26.2892 -25.4526 0
-      vertex 24.3335 -24.3775 0
-      vertex 25.1224 -22.8293 0
+      vertex 28.9181 -26.8979 0
+      vertex 26.9411 -25.811 0
+      vertex 26.9446 -25.8042 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 23.4417 -25.8847 0
-      vertex 25.3298 -27.0748 0
-      vertex 24.2705 -28.6336 0
+      vertex 25.9536 -27.4797 0
+      vertex 27.8628 -28.6823 0
+      vertex 26.6976 -30.3969 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 25.3298 -27.0748 0
-      vertex 23.4491 -25.8731 0
-      vertex 24.3335 -24.3775 0
+      vertex 27.8628 -28.6823 0
+      vertex 25.9618 -27.4668 0
+      vertex 26.9411 -25.811 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 25.3298 -27.0748 0
-      vertex 23.4455 -25.879 0
-      vertex 23.4491 -25.8731 0
+      vertex 27.8628 -28.6823 0
+      vertex 25.9579 -27.4734 0
+      vertex 25.9618 -27.4668 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 25.3298 -27.0748 0
-      vertex 23.4417 -25.8847 0
-      vertex 23.4455 -25.879 0
+      vertex 27.8628 -28.6823 0
+      vertex 25.9536 -27.4797 0
+      vertex 25.9579 -27.4734 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 22.4608 -27.3272 0
-      vertex 24.2705 -28.6336 0
-      vertex 23.1154 -30.1227 0
+      vertex 24.8723 -29.0708 0
+      vertex 26.6976 -30.3969 0
+      vertex 25.4269 -32.035 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 24.2705 -28.6336 0
-      vertex 22.465 -27.3218 0
-      vertex 23.4417 -25.8847 0
+      vertex 26.6976 -30.3969 0
+      vertex 24.8723 -29.0708 0
+      vertex 25.9536 -27.4797 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 24.2705 -28.6336 0
-      vertex 22.4608 -27.3272 0
-      vertex 22.465 -27.3218 0
+      vertex 23.6835 -30.6026 0
+      vertex 25.4269 -32.035 0
+      vertex 24.056 -33.5901 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 21.3958 -28.7002 0
-      vertex 23.1154 -30.1227 0
-      vertex 21.8691 -31.5364 0
+      vertex 25.4269 -32.035 0
+      vertex 23.6933 -30.5908 0
+      vertex 24.8723 -29.0708 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 23.1154 -30.1227 0
-      vertex 21.3958 -28.7002 0
-      vertex 22.4608 -27.3272 0
+      vertex 25.4269 -32.035 0
+      vertex 23.6886 -30.5969 0
+      vertex 23.6933 -30.5908 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 20.2422 -30.0087 0
-      vertex 21.8691 -31.5364 0
-      vertex 20.5364 -32.8691 0
+      vertex 25.4269 -32.035 0
+      vertex 23.6835 -30.6026 0
+      vertex 23.6886 -30.5969 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 21.8691 -31.5364 0
-      vertex 20.2468 -30.0035 0
-      vertex 21.3958 -28.7002 0
+      vertex 22.4113 -32.0457 0
+      vertex 24.056 -33.5901 0
+      vertex 22.5901 -35.056 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 21.8691 -31.5364 0
-      vertex 20.2422 -30.0087 0
-      vertex 20.2468 -30.0035 0
+      vertex 24.056 -33.5901 0
+      vertex 22.4113 -32.0457 0
+      vertex 23.6835 -30.6026 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 19.0035 -31.2468 0
-      vertex 20.5364 -32.8691 0
-      vertex 19.1227 -34.1154 0
+      vertex 22.5901 -35.056 0
+      vertex 21.0456 -33.4113 0
+      vertex 22.4113 -32.0457 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 20.5364 -32.8691 0
-      vertex 19.0087 -31.2422 0
-      vertex 20.2422 -30.0087 0
+      vertex 21.035 -36.4269 0
+      vertex 21.0456 -33.4113 0
+      vertex 22.5901 -35.056 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 20.5364 -32.8691 0
-      vertex 19.0035 -31.2468 0
-      vertex 19.0087 -31.2422 0
+      vertex 21.035 -36.4269 0
+      vertex 19.6026 -34.6835 0
+      vertex 21.0456 -33.4113 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 19.1227 -34.1154 0
-      vertex 17.7002 -32.3958 0
-      vertex 19.0035 -31.2468 0
+      vertex 21.035 -36.4269 0
+      vertex 19.5969 -34.6886 0
+      vertex 19.6026 -34.6835 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 17.6336 -35.2705 0
-      vertex 17.7002 -32.3958 0
-      vertex 19.1227 -34.1154 0
+      vertex 21.035 -36.4269 0
+      vertex 19.5908 -34.6933 0
+      vertex 19.5969 -34.6886 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 17.6336 -35.2705 0
-      vertex 16.3272 -33.4608 0
-      vertex 17.7002 -32.3958 0
+      vertex 19.3969 -37.6976 0
+      vertex 19.5908 -34.6933 0
+      vertex 21.035 -36.4269 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 17.6336 -35.2705 0
-      vertex 16.3218 -33.465 0
-      vertex 16.3272 -33.4608 0
+      vertex 19.3969 -37.6976 0
+      vertex 18.0708 -35.8723 0
+      vertex 19.5908 -34.6933 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 16.0748 -36.3298 0
-      vertex 16.3218 -33.465 0
-      vertex 17.6336 -35.2705 0
+      vertex 17.6823 -38.8628 0
+      vertex 18.0708 -35.8723 0
+      vertex 19.3969 -37.6976 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 16.0748 -36.3298 0
-      vertex 14.8847 -34.4417 0
-      vertex 16.3218 -33.465 0
+      vertex 17.6823 -38.8628 0
+      vertex 16.4797 -36.9536 0
+      vertex 18.0708 -35.8723 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 16.0748 -36.3298 0
-      vertex 14.879 -34.4455 0
-      vertex 14.8847 -34.4417 0
+      vertex 17.6823 -38.8628 0
+      vertex 16.4734 -36.9579 0
+      vertex 16.4797 -36.9536 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 16.0748 -36.3298 0
-      vertex 14.8731 -34.4491 0
-      vertex 14.879 -34.4455 0
+      vertex 17.6823 -38.8628 0
+      vertex 16.4668 -36.9618 0
+      vertex 16.4734 -36.9579 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 14.4526 -37.2892 0
-      vertex 14.8731 -34.4491 0
-      vertex 16.0748 -36.3298 0
+      vertex 15.8979 -39.9181 0
+      vertex 16.4668 -36.9618 0
+      vertex 17.6823 -38.8628 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 14.4526 -37.2892 0
-      vertex 13.3775 -35.3335 0
-      vertex 14.8731 -34.4491 0
+      vertex 15.8979 -39.9181 0
+      vertex 14.811 -37.9411 0
+      vertex 16.4668 -36.9618 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 12.7734 -38.1448 0
-      vertex 13.3775 -35.3335 0
-      vertex 14.4526 -37.2892 0
+      vertex 15.8979 -39.9181 0
+      vertex 14.8042 -37.9446 0
+      vertex 14.811 -37.9411 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 12.7734 -38.1448 0
-      vertex 11.8293 -36.1224 0
-      vertex 13.3775 -35.3335 0
+      vertex 14.0507 -40.8593 0
+      vertex 14.8042 -37.9446 0
+      vertex 15.8979 -39.9181 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 12.7734 -38.1448 0
-      vertex 11.8232 -36.1255 0
-      vertex 11.8293 -36.1224 0
+      vertex 14.0507 -40.8593 0
+      vertex 13.0901 -38.8179 0
+      vertex 14.8042 -37.9446 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 12.7734 -38.1448 0
-      vertex 11.8168 -36.1282 0
-      vertex 11.8232 -36.1255 0
+      vertex 14.0507 -40.8593 0
+      vertex 13.0831 -38.821 0
+      vertex 13.0901 -38.8179 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 11.0437 -38.8933 0
-      vertex 11.8168 -36.1282 0
-      vertex 12.7734 -38.1448 0
+      vertex 12.1481 -41.6826 0
+      vertex 13.0831 -38.821 0
+      vertex 14.0507 -40.8593 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 11.0437 -38.8933 0
-      vertex 10.2222 -36.8183 0
-      vertex 11.8168 -36.1282 0
+      vertex 12.1481 -41.6826 0
+      vertex 11.3176 -39.585 0
+      vertex 13.0831 -38.821 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 11.0437 -38.8933 0
-      vertex 10.2157 -36.8206 0
-      vertex 10.2222 -36.8183 0
+      vertex 10.1976 -42.3849 0
+      vertex 11.3176 -39.585 0
+      vertex 12.1481 -41.6826 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.27051 -39.5317 0
-      vertex 10.2157 -36.8206 0
-      vertex 11.0437 -38.8933 0
+      vertex 10.1976 -42.3849 0
+      vertex 9.5076 -40.2366 0
+      vertex 11.3176 -39.585 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.27051 -39.5317 0
-      vertex 8.58087 -37.4092 0
-      vertex 10.2157 -36.8206 0
+      vertex 10.1976 -42.3849 0
+      vertex 9.50039 -40.2392 0
+      vertex 9.5076 -40.2366 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.27051 -39.5317 0
-      vertex 8.57425 -37.4111 0
-      vertex 8.58087 -37.4092 0
+      vertex 8.20677 -42.9632 0
+      vertex 9.50039 -40.2392 0
+      vertex 10.1976 -42.3849 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 7.4607 -40.0575 0
-      vertex 8.57425 -37.4111 0
-      vertex 9.27051 -39.5317 0
+      vertex 8.20677 -42.9632 0
+      vertex 7.65305 -40.7759 0
+      vertex 9.50039 -40.2392 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 7.4607 -40.0575 0
-      vertex 6.90569 -37.8959 0
-      vertex 8.57425 -37.4111 0
+      vertex 8.20677 -42.9632 0
+      vertex 7.6457 -40.778 0
+      vertex 7.65305 -40.7759 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 5.62144 -40.4686 0
-      vertex 6.90569 -37.8959 0
-      vertex 7.4607 -40.0575 0
+      vertex 8.20677 -42.9632 0
+      vertex 7.63822 -40.7797 0
+      vertex 7.6457 -40.778 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 5.62144 -40.4686 0
-      vertex 5.20999 -38.2749 0
-      vertex 6.90569 -37.8959 0
+      vertex 6.18358 -43.4155 0
+      vertex 7.63822 -40.7797 0
+      vertex 8.20677 -42.9632 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 5.62144 -40.4686 0
-      vertex 5.20326 -38.2764 0
-      vertex 5.20999 -38.2749 0
+      vertex 6.18358 -43.4155 0
+      vertex 5.76083 -41.1993 0
+      vertex 7.63822 -40.7797 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 3.76 -40.7634 0
-      vertex 5.20326 -38.2764 0
-      vertex 5.62144 -40.4686 0
+      vertex 4.136 -43.7398 0
+      vertex 5.76083 -41.1993 0
+      vertex 6.18358 -43.4155 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 3.76 -40.7634 0
-      vertex 3.4871 -38.5483 0
-      vertex 5.20326 -38.2764 0
+      vertex 4.136 -43.7398 0
+      vertex 3.8608 -41.5003 0
+      vertex 5.76083 -41.1993 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 3.76 -40.7634 0
-      vertex 3.48029 -38.5493 0
-      vertex 3.4871 -38.5483 0
+      vertex 4.136 -43.7398 0
+      vertex 3.85323 -41.5015 0
+      vertex 3.8608 -41.5003 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 3.76 -40.7634 0
-      vertex 3.47342 -38.55 0
-      vertex 3.48029 -38.5493 0
+      vertex 2.07209 -43.9349 0
+      vertex 3.85323 -41.5015 0
+      vertex 4.136 -43.7398 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 1.88371 -40.9408 0
-      vertex 3.47342 -38.55 0
-      vertex 3.76 -40.7634 0
+      vertex 2.07209 -43.9349 0
+      vertex 1.93805 -41.6825 0
+      vertex 3.85323 -41.5015 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 1.88371 -40.9408 0
-      vertex 1.74358 -38.7135 0
-      vertex 3.47342 -38.55 0
+      vertex 2.07209 -43.9349 0
+      vertex 1.93043 -41.6832 0
+      vertex 1.93805 -41.6825 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 1.88371 -40.9408 0
-      vertex 1.73669 -38.7137 0
-      vertex 1.74358 -38.7135 0
+      vertex 2.07209 -43.9349 0
+      vertex 1.92277 -41.6835 0
+      vertex 1.93043 -41.6832 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 -41 0
-      vertex 1.73669 -38.7137 0
-      vertex 1.88371 -40.9408 0
+      vertex 0 -44 0
+      vertex 1.92277 -41.6835 0
+      vertex 2.07209 -43.9349 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 -41 0
-      vertex 0 -38.7683 0
-      vertex 1.73669 -38.7137 0
+      vertex 0 -44 0
+      vertex 0 -41.7439 0
+      vertex 1.92277 -41.6835 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0 -41 0
-      vertex -1.73669 -38.7137 0
-      vertex 0 -38.7683 0
+      vertex 0 -44 0
+      vertex -1.92277 -41.6835 0
+      vertex 0 -41.7439 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.88371 -40.9408 0
-      vertex -1.73669 -38.7137 0
-      vertex 0 -41 0
+      vertex -2.07209 -43.9349 0
+      vertex -1.92277 -41.6835 0
+      vertex 0 -44 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -1.73669 -38.7137 0
-      vertex -1.88371 -40.9408 0
-      vertex -1.74358 -38.7135 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.88371 -40.9408 0
-      vertex -3.47342 -38.55 0
-      vertex -1.74358 -38.7135 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3.76 -40.7634 0
-      vertex -3.47342 -38.55 0
-      vertex -1.88371 -40.9408 0
+      vertex -1.92277 -41.6835 0
+      vertex -2.07209 -43.9349 0
+      vertex -1.93043 -41.6832 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -3.47342 -38.55 0
-      vertex -3.76 -40.7634 0
-      vertex -3.48029 -38.5493 0
+      vertex -1.93043 -41.6832 0
+      vertex -2.07209 -43.9349 0
+      vertex -1.93805 -41.6825 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.07209 -43.9349 0
+      vertex -3.85323 -41.5015 0
+      vertex -1.93805 -41.6825 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.136 -43.7398 0
+      vertex -3.85323 -41.5015 0
+      vertex -2.07209 -43.9349 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -3.48029 -38.5493 0
-      vertex -3.76 -40.7634 0
-      vertex -3.4871 -38.5483 0
+      vertex -3.85323 -41.5015 0
+      vertex -4.136 -43.7398 0
+      vertex -3.8608 -41.5003 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3.76 -40.7634 0
-      vertex -5.20326 -38.2764 0
-      vertex -3.4871 -38.5483 0
+      vertex -4.136 -43.7398 0
+      vertex -5.76083 -41.1993 0
+      vertex -3.8608 -41.5003 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -5.62144 -40.4686 0
-      vertex -5.20326 -38.2764 0
-      vertex -3.76 -40.7634 0
+      vertex -6.18358 -43.4155 0
+      vertex -5.76083 -41.1993 0
+      vertex -4.136 -43.7398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.18358 -43.4155 0
+      vertex -7.63822 -40.7797 0
+      vertex -5.76083 -41.1993 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.20677 -42.9632 0
+      vertex -7.63822 -40.7797 0
+      vertex -6.18358 -43.4155 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -5.20326 -38.2764 0
-      vertex -5.62144 -40.4686 0
-      vertex -5.20999 -38.2749 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.62144 -40.4686 0
-      vertex -6.90569 -37.8959 0
-      vertex -5.20999 -38.2749 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -7.4607 -40.0575 0
-      vertex -6.90569 -37.8959 0
-      vertex -5.62144 -40.4686 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -7.4607 -40.0575 0
-      vertex -8.57425 -37.4111 0
-      vertex -6.90569 -37.8959 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -9.27051 -39.5317 0
-      vertex -8.57425 -37.4111 0
-      vertex -7.4607 -40.0575 0
+      vertex -7.63822 -40.7797 0
+      vertex -8.20677 -42.9632 0
+      vertex -7.6457 -40.778 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -8.57425 -37.4111 0
-      vertex -9.27051 -39.5317 0
-      vertex -8.58087 -37.4092 0
+      vertex -7.6457 -40.778 0
+      vertex -8.20677 -42.9632 0
+      vertex -7.65305 -40.7759 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -9.27051 -39.5317 0
-      vertex -10.2157 -36.8206 0
-      vertex -8.58087 -37.4092 0
+      vertex -8.20677 -42.9632 0
+      vertex -9.50039 -40.2392 0
+      vertex -7.65305 -40.7759 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -11.0437 -38.8933 0
-      vertex -10.2157 -36.8206 0
-      vertex -9.27051 -39.5317 0
+      vertex -10.1976 -42.3849 0
+      vertex -9.50039 -40.2392 0
+      vertex -8.20677 -42.9632 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -10.2157 -36.8206 0
-      vertex -11.0437 -38.8933 0
-      vertex -10.2222 -36.8183 0
+      vertex -9.50039 -40.2392 0
+      vertex -10.1976 -42.3849 0
+      vertex -9.5076 -40.2366 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -11.0437 -38.8933 0
-      vertex -11.8168 -36.1282 0
-      vertex -10.2222 -36.8183 0
+      vertex -10.1976 -42.3849 0
+      vertex -11.3176 -39.585 0
+      vertex -9.5076 -40.2366 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -12.7734 -38.1448 0
-      vertex -11.8168 -36.1282 0
-      vertex -11.0437 -38.8933 0
+      vertex -12.1481 -41.6826 0
+      vertex -11.3176 -39.585 0
+      vertex -10.1976 -42.3849 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.1481 -41.6826 0
+      vertex -13.0831 -38.821 0
+      vertex -11.3176 -39.585 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0507 -40.8593 0
+      vertex -13.0831 -38.821 0
+      vertex -12.1481 -41.6826 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -11.8168 -36.1282 0
-      vertex -12.7734 -38.1448 0
-      vertex -11.8232 -36.1255 0
+      vertex -13.0831 -38.821 0
+      vertex -14.0507 -40.8593 0
+      vertex -13.0901 -38.8179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0507 -40.8593 0
+      vertex -14.8042 -37.9446 0
+      vertex -13.0901 -38.8179 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8979 -39.9181 0
+      vertex -14.8042 -37.9446 0
+      vertex -14.0507 -40.8593 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -11.8232 -36.1255 0
-      vertex -12.7734 -38.1448 0
-      vertex -11.8293 -36.1224 0
+      vertex -14.8042 -37.9446 0
+      vertex -15.8979 -39.9181 0
+      vertex -14.811 -37.9411 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -12.7734 -38.1448 0
-      vertex -13.3775 -35.3335 0
-      vertex -11.8293 -36.1224 0
+      vertex -15.8979 -39.9181 0
+      vertex -16.4668 -36.9618 0
+      vertex -14.811 -37.9411 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -14.4526 -37.2892 0
-      vertex -13.3775 -35.3335 0
-      vertex -12.7734 -38.1448 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.4526 -37.2892 0
-      vertex -14.8731 -34.4491 0
-      vertex -13.3775 -35.3335 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.0748 -36.3298 0
-      vertex -14.8731 -34.4491 0
-      vertex -14.4526 -37.2892 0
+      vertex -17.6823 -38.8628 0
+      vertex -16.4668 -36.9618 0
+      vertex -15.8979 -39.9181 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -14.8731 -34.4491 0
-      vertex -16.0748 -36.3298 0
-      vertex -14.879 -34.4455 0
+      vertex -16.4668 -36.9618 0
+      vertex -17.6823 -38.8628 0
+      vertex -16.4734 -36.9579 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -14.879 -34.4455 0
-      vertex -16.0748 -36.3298 0
-      vertex -14.8847 -34.4417 0
+      vertex -16.4734 -36.9579 0
+      vertex -17.6823 -38.8628 0
+      vertex -16.4797 -36.9536 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -16.0748 -36.3298 0
-      vertex -16.3218 -33.465 0
-      vertex -14.8847 -34.4417 0
+      vertex -17.6823 -38.8628 0
+      vertex -18.0708 -35.8723 0
+      vertex -16.4797 -36.9536 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -17.6336 -35.2705 0
-      vertex -16.3218 -33.465 0
-      vertex -16.0748 -36.3298 0
+      vertex -19.3969 -37.6976 0
+      vertex -18.0708 -35.8723 0
+      vertex -17.6823 -38.8628 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3969 -37.6976 0
+      vertex -19.5908 -34.6933 0
+      vertex -18.0708 -35.8723 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.035 -36.4269 0
+      vertex -19.5908 -34.6933 0
+      vertex -19.3969 -37.6976 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -16.3218 -33.465 0
-      vertex -17.6336 -35.2705 0
-      vertex -16.3272 -33.4608 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17.6336 -35.2705 0
-      vertex -17.7002 -32.3958 0
-      vertex -16.3272 -33.4608 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -19.1227 -34.1154 0
-      vertex -17.7002 -32.3958 0
-      vertex -17.6336 -35.2705 0
+      vertex -19.5908 -34.6933 0
+      vertex -21.035 -36.4269 0
+      vertex -19.5969 -34.6886 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -17.7002 -32.3958 0
-      vertex -19.1227 -34.1154 0
-      vertex -19.0035 -31.2468 0
+      vertex -19.5969 -34.6886 0
+      vertex -21.035 -36.4269 0
+      vertex -19.6026 -34.6835 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -20.5364 -32.8691 0
-      vertex -19.0035 -31.2468 0
-      vertex -19.1227 -34.1154 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -19.0035 -31.2468 0
-      vertex -20.5364 -32.8691 0
-      vertex -19.0087 -31.2422 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -19.0087 -31.2422 0
-      vertex -20.5364 -32.8691 0
-      vertex -20.2422 -30.0087 0
+      vertex -21.035 -36.4269 0
+      vertex -21.0456 -33.4113 0
+      vertex -19.6026 -34.6835 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -21.8691 -31.5364 0
-      vertex -20.2422 -30.0087 0
-      vertex -20.5364 -32.8691 0
+      vertex -22.5901 -35.056 0
+      vertex -21.0456 -33.4113 0
+      vertex -21.035 -36.4269 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -20.2422 -30.0087 0
-      vertex -21.8691 -31.5364 0
-      vertex -20.2468 -30.0035 0
+      vertex -21.0456 -33.4113 0
+      vertex -22.5901 -35.056 0
+      vertex -22.4113 -32.0457 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.056 -33.5901 0
+      vertex -22.4113 -32.0457 0
+      vertex -22.5901 -35.056 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -20.2468 -30.0035 0
-      vertex -21.8691 -31.5364 0
-      vertex -21.3958 -28.7002 0
+      vertex -22.4113 -32.0457 0
+      vertex -24.056 -33.5901 0
+      vertex -23.6835 -30.6026 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -23.1154 -30.1227 0
-      vertex -21.3958 -28.7002 0
-      vertex -21.8691 -31.5364 0
+      vertex -25.4269 -32.035 0
+      vertex -23.6835 -30.6026 0
+      vertex -24.056 -33.5901 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -21.3958 -28.7002 0
-      vertex -23.1154 -30.1227 0
-      vertex -22.4608 -27.3272 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -24.2705 -28.6336 0
-      vertex -22.4608 -27.3272 0
-      vertex -23.1154 -30.1227 0
+      vertex -23.6835 -30.6026 0
+      vertex -25.4269 -32.035 0
+      vertex -23.6886 -30.5969 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -22.4608 -27.3272 0
-      vertex -24.2705 -28.6336 0
-      vertex -22.465 -27.3218 0
+      vertex -23.6886 -30.5969 0
+      vertex -25.4269 -32.035 0
+      vertex -23.6933 -30.5908 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -22.465 -27.3218 0
-      vertex -24.2705 -28.6336 0
-      vertex -23.4417 -25.8847 0
+      vertex -23.6933 -30.5908 0
+      vertex -25.4269 -32.035 0
+      vertex -24.8723 -29.0708 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -25.3298 -27.0748 0
-      vertex -23.4417 -25.8847 0
-      vertex -24.2705 -28.6336 0
+      vertex -26.6976 -30.3969 0
+      vertex -24.8723 -29.0708 0
+      vertex -25.4269 -32.035 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -23.4417 -25.8847 0
-      vertex -25.3298 -27.0748 0
-      vertex -23.4455 -25.879 0
+      vertex -24.8723 -29.0708 0
+      vertex -26.6976 -30.3969 0
+      vertex -25.9536 -27.4797 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.8628 -28.6823 0
+      vertex -25.9536 -27.4797 0
+      vertex -26.6976 -30.3969 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -23.4455 -25.879 0
-      vertex -25.3298 -27.0748 0
-      vertex -23.4491 -25.8731 0
+      vertex -25.9536 -27.4797 0
+      vertex -27.8628 -28.6823 0
+      vertex -25.9579 -27.4734 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -23.4491 -25.8731 0
-      vertex -25.3298 -27.0748 0
-      vertex -24.3335 -24.3775 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -26.2892 -25.4526 0
-      vertex -24.3335 -24.3775 0
-      vertex -25.3298 -27.0748 0
+      vertex -25.9579 -27.4734 0
+      vertex -27.8628 -28.6823 0
+      vertex -25.9618 -27.4668 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -24.3335 -24.3775 0
-      vertex -26.2892 -25.4526 0
-      vertex -25.1224 -22.8293 0
+      vertex -25.9618 -27.4668 0
+      vertex -27.8628 -28.6823 0
+      vertex -26.9411 -25.811 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -27.1448 -23.7734 0
-      vertex -25.1224 -22.8293 0
-      vertex -26.2892 -25.4526 0
+      vertex -28.9181 -26.8979 0
+      vertex -26.9411 -25.811 0
+      vertex -27.8628 -28.6823 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -25.1224 -22.8293 0
-      vertex -27.1448 -23.7734 0
-      vertex -25.1255 -22.8232 0
+      vertex -26.9411 -25.811 0
+      vertex -28.9181 -26.8979 0
+      vertex -26.9446 -25.8042 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -25.1255 -22.8232 0
-      vertex -27.1448 -23.7734 0
-      vertex -25.1282 -22.8168 0
+      vertex -26.9446 -25.8042 0
+      vertex -28.9181 -26.8979 0
+      vertex -27.8179 -24.0901 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.8593 -25.0507 0
+      vertex -27.8179 -24.0901 0
+      vertex -28.9181 -26.8979 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -25.1282 -22.8168 0
-      vertex -27.1448 -23.7734 0
-      vertex -25.8183 -21.2222 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -27.8933 -22.0437 0
-      vertex -25.8183 -21.2222 0
-      vertex -27.1448 -23.7734 0
+      vertex -27.8179 -24.0901 0
+      vertex -29.8593 -25.0507 0
+      vertex -27.821 -24.0831 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -25.8183 -21.2222 0
-      vertex -27.8933 -22.0437 0
-      vertex -25.8206 -21.2157 0
+      vertex -27.821 -24.0831 0
+      vertex -29.8593 -25.0507 0
+      vertex -28.585 -22.3176 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.6826 -23.1481 0
+      vertex -28.585 -22.3176 0
+      vertex -29.8593 -25.0507 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -25.8206 -21.2157 0
-      vertex -27.8933 -22.0437 0
-      vertex -26.4092 -19.5809 0
+      vertex -28.585 -22.3176 0
+      vertex -30.6826 -23.1481 0
+      vertex -29.2366 -20.5076 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -28.5317 -20.2705 0
-      vertex -26.4092 -19.5809 0
-      vertex -27.8933 -22.0437 0
+      vertex -31.3849 -21.1976 0
+      vertex -29.2366 -20.5076 0
+      vertex -30.6826 -23.1481 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -26.4092 -19.5809 0
-      vertex -28.5317 -20.2705 0
-      vertex -26.4111 -19.5743 0
+      vertex -29.2366 -20.5076 0
+      vertex -31.3849 -21.1976 0
+      vertex -29.2392 -20.5004 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -26.4111 -19.5743 0
-      vertex -28.5317 -20.2705 0
-      vertex -26.8959 -17.9057 0
+      vertex -29.2392 -20.5004 0
+      vertex -31.3849 -21.1976 0
+      vertex -29.7759 -18.6531 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -29.0575 -18.4607 0
-      vertex -26.8959 -17.9057 0
-      vertex -28.5317 -20.2705 0
+      vertex -31.9632 -19.2068 0
+      vertex -29.7759 -18.6531 0
+      vertex -31.3849 -21.1976 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -26.8959 -17.9057 0
-      vertex -29.0575 -18.4607 0
-      vertex -27.2749 -16.21 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -29.4686 -16.6214 0
-      vertex -27.2749 -16.21 0
-      vertex -29.0575 -18.4607 0
+      vertex -29.7759 -18.6531 0
+      vertex -31.9632 -19.2068 0
+      vertex -29.778 -18.6457 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -27.2749 -16.21 0
-      vertex -29.4686 -16.6214 0
-      vertex -27.2764 -16.2033 0
+      vertex -29.778 -18.6457 0
+      vertex -31.9632 -19.2068 0
+      vertex -29.7797 -18.6382 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -27.5483 -14.4871 0
-      vertex -29.7634 -14.76 0
-      vertex -27.5493 -14.4803 0
+      vertex -29.7797 -18.6382 0
+      vertex -31.9632 -19.2068 0
+      vertex -30.1993 -16.7608 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -29.7634 -14.76 0
-      vertex -27.5483 -14.4871 0
-      vertex -29.4686 -16.6214 0
+      vertex -32.4155 -17.1836 0
+      vertex -30.1993 -16.7608 0
+      vertex -31.9632 -19.2068 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -27.2764 -16.2033 0
-      vertex -29.4686 -16.6214 0
-      vertex -27.5483 -14.4871 0
+      vertex -30.1993 -16.7608 0
+      vertex -32.4155 -17.1836 0
+      vertex -30.5003 -14.8608 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 27.7683 -11 0
-      vertex 30 -11 0
-      vertex 29.9408 -12.8837 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.7137 -12.7367 0
-      vertex 29.9408 -12.8837 0
-      vertex 29.7634 -14.76 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.7137 -12.7367 0
-      vertex 29.7634 -14.76 0
-      vertex 29.4686 -16.6214 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.7137 -12.7367 0
-      vertex 29.4686 -16.6214 0
-      vertex 29.0575 -18.4607 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.7137 -12.7367 0
-      vertex 29.0575 -18.4607 0
-      vertex 28.5317 -20.2705 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 26.4092 -19.5809 0
-      vertex 28.5317 -20.2705 0
-      vertex 27.8933 -22.0437 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30 -11 0
-      vertex 27.7683 -11 0
-      vertex 27.6103 -3.5 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30 -11 0
-      vertex 27.6103 -3.5 0
-      vertex 30 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -27.6103 -3.5 0
-      vertex 30 0 0
-      vertex 27.6103 -3.5 0
+      vertex -32.7398 -15.136 0
+      vertex -30.5003 -14.8608 0
+      vertex -32.4155 -17.1836 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -27.5493 -14.4803 0
-      vertex -29.7634 -14.76 0
-      vertex -27.55 -14.4734 0
+      vertex -30.5003 -14.8608 0
+      vertex -32.7398 -15.136 0
+      vertex -30.5015 -14.8532 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -27.55 -14.4734 0
-      vertex -29.7634 -14.76 0
-      vertex -27.7135 -12.7436 0
+      vertex -30.5015 -14.8532 0
+      vertex -32.7398 -15.136 0
+      vertex -30.6825 -12.9381 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -29.9408 -12.8837 0
-      vertex -27.7135 -12.7436 0
-      vertex -29.7634 -14.76 0
+      vertex 30.7439 -11 0
+      vertex 33 -11 0
+      vertex 32.9349 -13.0721 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.6835 -12.9228 0
+      vertex 32.9349 -13.0721 0
+      vertex 32.7398 -15.136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.6835 -12.9228 0
+      vertex 32.7398 -15.136 0
+      vertex 32.4155 -17.1836 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 30.6835 -12.9228 0
+      vertex 32.4155 -17.1836 0
+      vertex 31.9632 -19.2068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 29.7759 -18.6531 0
+      vertex 31.9632 -19.2068 0
+      vertex 31.3849 -21.1976 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33 -11 0
+      vertex 30.7439 -11 0
+      vertex 30.5809 -4 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33 -11 0
+      vertex 30.5809 -4 0
+      vertex 33 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.5809 -4 0
+      vertex 33 0 0
+      vertex 30.5809 -4 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.9349 -13.0721 0
+      vertex -30.6825 -12.9381 0
+      vertex -32.7398 -15.136 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -27.7135 -12.7436 0
-      vertex -29.9408 -12.8837 0
-      vertex -27.7137 -12.7367 0
+      vertex -30.6825 -12.9381 0
+      vertex -32.9349 -13.0721 0
+      vertex -30.6832 -12.9304 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -27.7137 -12.7367 0
-      vertex -29.9408 -12.8837 0
-      vertex -27.7683 -11 0
+      vertex -30.6832 -12.9304 0
+      vertex -32.9349 -13.0721 0
+      vertex -30.6835 -12.9228 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -30.6835 -12.9228 0
+      vertex -32.9349 -13.0721 0
+      vertex -30.7439 -11 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -30 -11 0
-      vertex -27.7683 -11 0
-      vertex -29.9408 -12.8837 0
+      vertex -33 -11 0
+      vertex -30.7439 -11 0
+      vertex -32.9349 -13.0721 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -27.7683 -11 0
-      vertex -30 -11 0
-      vertex -27.6103 -3.5 0
+      vertex -30.7439 -11 0
+      vertex -33 -11 0
+      vertex -30.5809 -4 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -27.6103 -3.5 0
-      vertex -30 0 0
-      vertex 30 0 0
+      vertex -30.5809 -4 0
+      vertex -33 0 0
+      vertex 33 0 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -30 0 0
-      vertex -27.6103 -3.5 0
-      vertex -30 -11 0
+      vertex -33 0 0
+      vertex -30.5809 -4 0
+      vertex -33 -11 0
     endloop
   endfacet
-  facet normal -0.899355 -0.0849681 0.428884
+  facet normal 0.19311 -0.86418 0.464653
     outer loop
-      vertex -29.9408 -12.8837 0
-      vertex -10.9133 -12.3787 40
-      vertex -10.9783 -11.6907 40
+      vertex 2.24858 -22.7874 40
+      vertex 8.20677 -42.9632 0
+      vertex 2.98428 -22.623 40
     endloop
   endfacet
-  facet normal -0.86749 -0.252031 0.428884
+  facet normal -0.54274 -0.699664 0.464654
     outer loop
-      vertex -28.5317 -20.2705 0
-      vertex -10.6544 -13.7356 40
-      vertex -29.0575 -18.4607 0
+      vertex -19.3969 -37.6976 0
+      vertex -7.05342 -20.7082 40
+      vertex -21.035 -36.4269 0
     endloop
   endfacet
-  facet normal -0.459859 -0.777553 0.428884
+  facet normal -0.497708 -0.732381 0.464654
     outer loop
-      vertex -14.4526 -37.2892 0
-      vertex -5.89409 -20.2876 40
-      vertex -16.0748 -36.3298 0
-    endloop
-  endfacet
-  facet normal -0.306007 -0.849951 0.428885
-    outer loop
-      vertex -9.27051 -39.5317 0
-      vertex -4.04937 -21.2275 40
-      vertex -11.0437 -38.8933 0
-    endloop
-  endfacet
-  facet normal -0.410091 -0.804913 0.428883
-    outer loop
-      vertex -14.4526 -37.2892 0
-      vertex -4.68357 -20.9531 40
-      vertex -5.29929 -20.6394 40
-    endloop
-  endfacet
-  facet normal -0.747133 -0.507789 0.428885
-    outer loop
-      vertex -24.2705 -28.6336 0
-      vertex -8.89919 -17.4656 40
-      vertex -9.28761 -16.8941 40
-    endloop
-  endfacet
-  facet normal 0.141306 -0.89224 0.428883
-    outer loop
-      vertex 3.76 -40.7634 0
-      vertex 5.62144 -40.4686 0
-      vertex 1.37866 -21.9133 40
-    endloop
-  endfacet
-  facet normal -0.0850319 -0.899349 0.428883
-    outer loop
-      vertex -1.88371 -40.9408 0
-      vertex -1.37866 -21.9133 40
-      vertex -3.76 -40.7634 0
-    endloop
-  endfacet
-  facet normal -0.0283674 -0.902914 0.428884
-    outer loop
-      vertex -1.88371 -40.9408 0
-      vertex 0 -22 40
-      vertex -0.690695 -21.9783 40
-    endloop
-  endfacet
-  facet normal 0.410119 -0.804898 0.428884
-    outer loop
-      vertex 12.7734 -38.1448 0
-      vertex 14.4526 -37.2892 0
-      vertex 4.68357 -20.9531 40
-    endloop
-  endfacet
-  facet normal 0.252037 -0.867488 0.428885
-    outer loop
-      vertex 2.73559 -21.6544 40
-      vertex 9.27051 -39.5317 0
-      vertex 3.39919 -21.4616 40
-    endloop
-  endfacet
-  facet normal 0.306007 -0.849951 0.428885
-    outer loop
-      vertex 9.27051 -39.5317 0
-      vertex 11.0437 -38.8933 0
-      vertex 4.04937 -21.2275 40
-    endloop
-  endfacet
-  facet normal 0.553686 -0.713786 0.428885
-    outer loop
-      vertex 17.6336 -35.2705 0
-      vertex 19.1227 -34.1154 0
-      vertex 7.01166 -19.4756 40
-    endloop
-  endfacet
-  facet normal 0.881588 -0.197129 0.428885
-    outer loop
-      vertex 10.6544 -13.7356 40
-      vertex 29.0575 -18.4607 0
-      vertex 10.8052 -13.0612 40
-    endloop
-  endfacet
-  facet normal 0.86749 -0.252031 0.428884
-    outer loop
-      vertex 28.5317 -20.2705 0
-      vertex 29.0575 -18.4607 0
-      vertex 10.6544 -13.7356 40
-    endloop
-  endfacet
-  facet normal 0.899349 -0.0850315 0.428883
-    outer loop
-      vertex 29.7634 -14.76 0
-      vertex 29.9408 -12.8837 0
-      vertex 10.9133 -12.3787 40
-    endloop
-  endfacet
-  facet normal 0.89224 -0.141309 0.428883
-    outer loop
-      vertex 29.4686 -16.6214 0
-      vertex 29.7634 -14.76 0
-      vertex 10.9133 -12.3787 40
-    endloop
-  endfacet
-  facet normal 0.597331 -0.677682 0.428886
-    outer loop
-      vertex 7.01166 -19.4756 40
-      vertex 19.1227 -34.1154 0
-      vertex 7.53002 -19.0187 40
-    endloop
-  endfacet
-  facet normal 0.597391 -0.677631 0.428884
-    outer loop
-      vertex 19.1227 -34.1154 0
-      vertex 20.5364 -32.8691 0
-      vertex 7.53002 -19.0187 40
-    endloop
-  endfacet
-  facet normal 0.713786 -0.553686 0.428884
-    outer loop
-      vertex 23.1154 -30.1227 0
-      vertex 24.2705 -28.6336 0
-      vertex 8.47565 -18.0117 40
-    endloop
-  endfacet
-  facet normal 0.777553 -0.459859 0.428883
-    outer loop
-      vertex 25.3298 -27.0748 0
-      vertex 26.2892 -25.4526 0
-      vertex 9.28761 -16.8941 40
-    endloop
-  endfacet
-  facet normal 0.747165 -0.507744 0.428884
-    outer loop
-      vertex 24.2705 -28.6336 0
-      vertex 25.3298 -27.0748 0
-      vertex 9.28761 -16.8941 40
-    endloop
-  endfacet
-  facet normal 0.747133 -0.507789 0.428885
-    outer loop
-      vertex 8.89919 -17.4656 40
-      vertex 24.2705 -28.6336 0
-      vertex 9.28761 -16.8941 40
-    endloop
-  endfacet
-  facet normal 0.849952 -0.306006 0.428884
-    outer loop
-      vertex 27.8933 -22.0437 0
-      vertex 28.5317 -20.2705 0
-      vertex 10.2275 -15.0494 40
-    endloop
-  endfacet
-  facet normal 0.867488 -0.252037 0.428884
-    outer loop
-      vertex 10.4616 -14.3992 40
-      vertex 28.5317 -20.2705 0
-      vertex 10.6544 -13.7356 40
-    endloop
-  endfacet
-  facet normal 0.777562 -0.459844 0.428884
-    outer loop
-      vertex 9.28761 -16.8941 40
-      vertex 26.2892 -25.4526 0
-      vertex 9.63937 -16.2993 40
-    endloop
-  endfacet
-  facet normal 0.804891 -0.410132 0.428884
-    outer loop
-      vertex 9.63937 -16.2993 40
-      vertex 26.2892 -25.4526 0
-      vertex 9.9531 -15.6836 40
-    endloop
-  endfacet
-  facet normal -0.892238 -0.14132 0.428883
-    outer loop
-      vertex -29.4686 -16.6214 0
-      vertex -10.8052 -13.0612 40
-      vertex -10.9133 -12.3787 40
-    endloop
-  endfacet
-  facet normal -0.881607 -0.197047 0.428883
-    outer loop
-      vertex -29.0575 -18.4607 0
-      vertex -10.8052 -13.0612 40
-      vertex -29.4686 -16.6214 0
-    endloop
-  endfacet
-  facet normal -0.867488 -0.252037 0.428884
-    outer loop
-      vertex -28.5317 -20.2705 0
-      vertex -10.4616 -14.3992 40
-      vertex -10.6544 -13.7356 40
-    endloop
-  endfacet
-  facet normal -0.849948 -0.306018 0.428884
-    outer loop
-      vertex -28.5317 -20.2705 0
-      vertex -10.2275 -15.0494 40
-      vertex -10.4616 -14.3992 40
-    endloop
-  endfacet
-  facet normal -0.410119 -0.804898 0.428884
-    outer loop
-      vertex -12.7734 -38.1448 0
-      vertex -4.68357 -20.9531 40
-      vertex -14.4526 -37.2892 0
-    endloop
-  endfacet
-  facet normal -0.197051 -0.881607 0.428883
-    outer loop
-      vertex -5.62144 -40.4686 0
-      vertex -2.06119 -21.8052 40
-      vertex -7.4607 -40.0575 0
-    endloop
-  endfacet
-  facet normal -0.306026 -0.849945 0.428884
-    outer loop
-      vertex -9.27051 -39.5317 0
-      vertex -3.39919 -21.4616 40
-      vertex -4.04937 -21.2275 40
-    endloop
-  endfacet
-  facet normal -0.507744 -0.747164 0.428884
-    outer loop
-      vertex -16.0748 -36.3298 0
-      vertex -5.89409 -20.2876 40
-      vertex -17.6336 -35.2705 0
-    endloop
-  endfacet
-  facet normal -0.459883 -0.777539 0.428883
-    outer loop
-      vertex -14.4526 -37.2892 0
-      vertex -5.29929 -20.6394 40
-      vertex -5.89409 -20.2876 40
-    endloop
-  endfacet
-  facet normal -0.777553 -0.459859 0.428883
-    outer loop
-      vertex -25.3298 -27.0748 0
-      vertex -9.28761 -16.8941 40
-      vertex -26.2892 -25.4526 0
-    endloop
-  endfacet
-  facet normal -0.747165 -0.507744 0.428884
-    outer loop
-      vertex -24.2705 -28.6336 0
-      vertex -9.28761 -16.8941 40
-      vertex -25.3298 -27.0748 0
-    endloop
-  endfacet
-  facet normal -0.713831 -0.553627 0.428886
-    outer loop
-      vertex -24.2705 -28.6336 0
-      vertex -8.47565 -18.0117 40
-      vertex -8.89919 -17.4656 40
-    endloop
-  endfacet
-  facet normal 0.0849724 -0.899354 0.428884
-    outer loop
-      vertex 0.690695 -21.9783 40
-      vertex 1.88371 -40.9408 0
-      vertex 1.37866 -21.9133 40
-    endloop
-  endfacet
-  facet normal -0.0849724 -0.899354 0.428884
-    outer loop
-      vertex -1.88371 -40.9408 0
-      vertex -0.690695 -21.9783 40
-      vertex -1.37866 -21.9133 40
-    endloop
-  endfacet
-  facet normal 0.459883 -0.777539 0.428883
-    outer loop
-      vertex 5.29929 -20.6394 40
-      vertex 14.4526 -37.2892 0
-      vertex 5.89409 -20.2876 40
-    endloop
-  endfacet
-  facet normal 0.358764 -0.829064 0.428884
-    outer loop
-      vertex 11.0437 -38.8933 0
-      vertex 12.7734 -38.1448 0
-      vertex 4.68357 -20.9531 40
-    endloop
-  endfacet
-  facet normal 0.25203 -0.86749 0.428884
-    outer loop
-      vertex 7.4607 -40.0575 0
-      vertex 9.27051 -39.5317 0
-      vertex 2.73559 -21.6544 40
-    endloop
-  endfacet
-  facet normal 0.35872 -0.829082 0.428885
-    outer loop
-      vertex 4.04937 -21.2275 40
-      vertex 11.0437 -38.8933 0
-      vertex 4.68357 -20.9531 40
-    endloop
-  endfacet
-  facet normal 0.713831 -0.553627 0.428886
-    outer loop
-      vertex 8.47565 -18.0117 40
-      vertex 24.2705 -28.6336 0
-      vertex 8.89919 -17.4656 40
-    endloop
-  endfacet
-  facet normal 0.829064 -0.358764 0.428884
-    outer loop
-      vertex 27.1448 -23.7734 0
-      vertex 27.8933 -22.0437 0
-      vertex 9.9531 -15.6836 40
-    endloop
-  endfacet
-  facet normal 0.849948 -0.306018 0.428884
-    outer loop
-      vertex 10.2275 -15.0494 40
-      vertex 28.5317 -20.2705 0
-      vertex 10.4616 -14.3992 40
-    endloop
-  endfacet
-  facet normal -0.35872 -0.829082 0.428885
-    outer loop
-      vertex -11.0437 -38.8933 0
-      vertex -4.04937 -21.2275 40
-      vertex -4.68357 -20.9531 40
-    endloop
-  endfacet
-  facet normal -0.25203 -0.86749 0.428884
-    outer loop
-      vertex -7.4607 -40.0575 0
-      vertex -2.73559 -21.6544 40
-      vertex -9.27051 -39.5317 0
-    endloop
-  endfacet
-  facet normal -0.197129 -0.881588 0.428885
-    outer loop
-      vertex -7.4607 -40.0575 0
-      vertex -2.06119 -21.8052 40
-      vertex -2.73559 -21.6544 40
-    endloop
-  endfacet
-  facet normal -0.553686 -0.713786 0.428885
-    outer loop
-      vertex -17.6336 -35.2705 0
-      vertex -7.01166 -19.4756 40
-      vertex -19.1227 -34.1154 0
-    endloop
-  endfacet
-  facet normal -0.597331 -0.677682 0.428886
-    outer loop
-      vertex -19.1227 -34.1154 0
-      vertex -7.01166 -19.4756 40
-      vertex -7.53002 -19.0187 40
-    endloop
-  endfacet
-  facet normal -0.553727 -0.713754 0.428883
-    outer loop
-      vertex -17.6336 -35.2705 0
-      vertex -6.46564 -19.8992 40
-      vertex -7.01166 -19.4756 40
-    endloop
-  endfacet
-  facet normal -0.507741 -0.747166 0.428884
-    outer loop
-      vertex -17.6336 -35.2705 0
-      vertex -5.89409 -20.2876 40
-      vertex -6.46564 -19.8992 40
-    endloop
-  endfacet
-  facet normal -0.804891 -0.410132 0.428884
-    outer loop
-      vertex -26.2892 -25.4526 0
-      vertex -9.63937 -16.2993 40
-      vertex -9.9531 -15.6836 40
-    endloop
-  endfacet
-  facet normal -0.67763 -0.59739 0.428885
-    outer loop
-      vertex -21.8691 -31.5364 0
-      vertex -8.01865 -18.53 40
-      vertex -23.1154 -30.1227 0
-    endloop
-  endfacet
-  facet normal -0.713786 -0.553686 0.428884
-    outer loop
-      vertex -23.1154 -30.1227 0
-      vertex -8.47565 -18.0117 40
-      vertex -24.2705 -28.6336 0
-    endloop
-  endfacet
-  facet normal 0.197051 -0.881607 0.428883
-    outer loop
-      vertex 5.62144 -40.4686 0
-      vertex 7.4607 -40.0575 0
-      vertex 2.06119 -21.8052 40
-    endloop
-  endfacet
-  facet normal 0.197129 -0.881588 0.428885
-    outer loop
-      vertex 2.06119 -21.8052 40
-      vertex 7.4607 -40.0575 0
-      vertex 2.73559 -21.6544 40
-    endloop
-  endfacet
-  facet normal 0.0283674 -0.902914 0.428884
-    outer loop
-      vertex 0 -22 40
-      vertex 1.88371 -40.9408 0
-      vertex 0.690695 -21.9783 40
-    endloop
-  endfacet
-  facet normal 0.507741 -0.747166 0.428884
-    outer loop
-      vertex 5.89409 -20.2876 40
-      vertex 17.6336 -35.2705 0
-      vertex 6.46564 -19.8992 40
-    endloop
-  endfacet
-  facet normal 0.553727 -0.713754 0.428883
-    outer loop
-      vertex 6.46564 -19.8992 40
-      vertex 17.6336 -35.2705 0
-      vertex 7.01166 -19.4756 40
-    endloop
-  endfacet
-  facet normal 0.410091 -0.804913 0.428883
-    outer loop
-      vertex 4.68357 -20.9531 40
-      vertex 14.4526 -37.2892 0
-      vertex 5.29929 -20.6394 40
-    endloop
-  endfacet
-  facet normal 0.306026 -0.849945 0.428884
-    outer loop
-      vertex 3.39919 -21.4616 40
-      vertex 9.27051 -39.5317 0
-      vertex 4.04937 -21.2275 40
-    endloop
-  endfacet
-  facet normal -0.677583 -0.597445 0.428883
-    outer loop
-      vertex -23.1154 -30.1227 0
-      vertex -8.01865 -18.53 40
-      vertex -8.47565 -18.0117 40
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -1.69959 0 24.7692
-      vertex -1.69959 0 15.2308
-      vertex -2.02468 0 24.8862
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.94705 0 25.3562
-      vertex -14.6547 0 15.4891
-      vertex -15 0 15.5
+      vertex -17.6823 -38.8628 0
+      vertex -7.05342 -20.7082 40
+      vertex -19.3969 -37.6976 0
     endloop
   endfacet
   facet normal 0 1 0
@@ -4320,9 +4306,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -14.3107 0 15.4566
-      vertex -14.6547 0 15.4891
+      vertex -3.23282 0 25.5504
+      vertex -15.6547 0 15.4891
+      vertex -16 0 15.5
     endloop
   endfacet
   facet normal 0 1 0
@@ -4334,9 +4320,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -13.9694 0 15.4026
-      vertex -14.3107 0 15.4566
+      vertex -3.23282 0 25.5504
+      vertex -15.3107 0 15.4566
+      vertex -15.6547 0 15.4891
     endloop
   endfacet
   facet normal 0 1 0
@@ -4348,9 +4334,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -13.6322 0 15.3272
-      vertex -13.9694 0 15.4026
+      vertex -3.23282 0 25.5504
+      vertex -14.9694 0 15.4026
+      vertex -15.3107 0 15.4566
     endloop
   endfacet
   facet normal 0 1 0
@@ -4362,9 +4348,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -13.3004 0 15.2308
-      vertex -13.6322 0 15.3272
+      vertex -3.23282 0 25.5504
+      vertex -14.6322 0 15.3272
+      vertex -14.9694 0 15.4026
     endloop
   endfacet
   facet normal 0 1 0
@@ -4376,9 +4362,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -12.9753 0 15.1138
-      vertex -13.3004 0 15.2308
+      vertex -3.23282 0 25.5504
+      vertex -14.3004 0 15.2308
+      vertex -14.6322 0 15.3272
     endloop
   endfacet
   facet normal 0 1 0
@@ -4390,9 +4376,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -12.6582 0 14.9765
-      vertex -12.9753 0 15.1138
+      vertex -3.23282 0 25.5504
+      vertex -13.9753 0 15.1138
+      vertex -14.3004 0 15.2308
     endloop
   endfacet
   facet normal 0 1 0
@@ -4404,574 +4390,588 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
+      vertex -3.23282 0 25.5504
+      vertex -13.6582 0 14.9765
+      vertex -13.9753 0 15.1138
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
       vertex -2.94705 0 25.3562
-      vertex -12.3504 0 14.8197
-      vertex -12.6582 0 14.9765
+      vertex -2.94705 0 14.6438
+      vertex -3.23282 0 25.5504
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.23282 0 25.5504
+      vertex -13.3504 0 14.8197
+      vertex -13.6582 0 14.9765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.23282 0 14.4496
-      vertex -2.94705 0 25.3562
+      vertex -3.23282 0 25.5504
       vertex -2.94705 0 14.6438
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -12.053 0 14.6438
-      vertex -12.3504 0 14.8197
+      vertex -3.23282 0 25.5504
+      vertex -13.053 0 14.6438
+      vertex -13.3504 0 14.8197
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -11.7672 0 14.4496
-      vertex -2.94705 0 25.3562
+      vertex -3.50583 0 14.2378
+      vertex -3.23282 0 25.5504
       vertex -3.23282 0 14.4496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -11.7672 0 14.4496
-      vertex -12.053 0 14.6438
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -3.50583 0 14.2378
-      vertex -11.7672 0 14.4496
-      vertex -3.23282 0 14.4496
+      vertex -3.23282 0 25.5504
+      vertex -12.7672 0 14.4496
+      vertex -13.053 0 14.6438
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -3.50583 0 14.2378
-      vertex -11.4942 0 14.2378
-      vertex -11.7672 0 14.4496
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -3.76501 0 14.0093
-      vertex -11.4942 0 14.2378
+      vertex -12.4942 0 14.2378
+      vertex -3.23282 0 25.5504
       vertex -3.50583 0 14.2378
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
+      vertex -3.23282 0 25.5504
+      vertex -12.4942 0 14.2378
+      vertex -12.7672 0 14.4496
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
       vertex -3.76501 0 14.0093
-      vertex -11.235 0 14.0093
-      vertex -11.4942 0 14.2378
+      vertex -12.4942 0 14.2378
+      vertex -3.50583 0 14.2378
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.76501 0 14.0093
+      vertex -12.235 0 14.0093
+      vertex -12.4942 0 14.2378
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.00933 0 13.765
-      vertex -11.235 0 14.0093
+      vertex -12.235 0 14.0093
       vertex -3.76501 0 14.0093
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.00933 0 13.765
-      vertex -10.9907 0 13.765
-      vertex -11.235 0 14.0093
+      vertex -11.9907 0 13.765
+      vertex -12.235 0 14.0093
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.23782 0 13.5058
-      vertex -10.9907 0 13.765
+      vertex -11.9907 0 13.765
       vertex -4.00933 0 13.765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.23782 0 13.5058
-      vertex -10.7622 0 13.5058
-      vertex -10.9907 0 13.765
+      vertex -11.7622 0 13.5058
+      vertex -11.9907 0 13.765
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.44959 0 13.2328
-      vertex -10.7622 0 13.5058
+      vertex -11.7622 0 13.5058
       vertex -4.23782 0 13.5058
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.44959 0 13.2328
-      vertex -10.5504 0 13.2328
-      vertex -10.7622 0 13.5058
+      vertex -11.5504 0 13.2328
+      vertex -11.7622 0 13.5058
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.6438 0 12.947
-      vertex -10.5504 0 13.2328
+      vertex -11.5504 0 13.2328
       vertex -4.44959 0 13.2328
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.6438 0 12.947
-      vertex -10.3562 0 12.947
-      vertex -10.5504 0 13.2328
+      vertex -11.3562 0 12.947
+      vertex -11.5504 0 13.2328
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.81969 0 12.6496
-      vertex -10.3562 0 12.947
+      vertex -11.3562 0 12.947
       vertex -4.6438 0 12.947
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.81969 0 12.6496
-      vertex -10.1803 0 12.6496
-      vertex -10.3562 0 12.947
+      vertex -11.1803 0 12.6496
+      vertex -11.3562 0 12.947
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.97655 0 12.3418
-      vertex -10.1803 0 12.6496
+      vertex -11.1803 0 12.6496
       vertex -4.81969 0 12.6496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.97655 0 12.3418
-      vertex -10.0235 0 12.3418
-      vertex -10.1803 0 12.6496
+      vertex -11.0235 0 12.3418
+      vertex -11.1803 0 12.6496
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.11377 0 12.0247
-      vertex -10.0235 0 12.3418
+      vertex -11.0235 0 12.3418
       vertex -4.97655 0 12.3418
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.11377 0 12.0247
-      vertex -9.88623 0 12.0247
-      vertex -10.0235 0 12.3418
+      vertex -10.8862 0 12.0247
+      vertex -11.0235 0 12.3418
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.23081 0 11.6996
-      vertex -9.88623 0 12.0247
+      vertex -10.8862 0 12.0247
       vertex -5.11377 0 12.0247
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.23081 0 11.6996
-      vertex -9.76919 0 11.6996
-      vertex -9.88623 0 12.0247
+      vertex -10.7692 0 11.6996
+      vertex -10.8862 0 12.0247
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.32721 0 11.3678
-      vertex -9.76919 0 11.6996
+      vertex -10.7692 0 11.6996
       vertex -5.23081 0 11.6996
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.32721 0 11.3678
-      vertex -9.67279 0 11.3678
-      vertex -9.76919 0 11.6996
+      vertex -10.6728 0 11.3678
+      vertex -10.7692 0 11.6996
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.40258 0 11.0306
-      vertex -9.67279 0 11.3678
+      vertex -10.6728 0 11.3678
       vertex -5.32721 0 11.3678
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.40258 0 11.0306
-      vertex -9.59742 0 11.0306
-      vertex -9.67279 0 11.3678
+      vertex -10.5974 0 11.0306
+      vertex -10.6728 0 11.3678
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.45663 0 10.6893
-      vertex -9.59742 0 11.0306
+      vertex -10.5974 0 11.0306
       vertex -5.40258 0 11.0306
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.45663 0 10.6893
-      vertex -9.54337 0 10.6893
-      vertex -9.59742 0 11.0306
+      vertex -10.5434 0 10.6893
+      vertex -10.5974 0 11.0306
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.48915 0 10.3453
-      vertex -9.54337 0 10.6893
+      vertex -10.5434 0 10.6893
       vertex -5.45663 0 10.6893
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.48915 0 10.3453
-      vertex -9.51085 0 10.3453
-      vertex -9.54337 0 10.6893
+      vertex -10.5109 0 10.3453
+      vertex -10.5434 0 10.6893
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.5 0 10
-      vertex -9.51085 0 10.3453
+      vertex -10.5109 0 10.3453
       vertex -5.48915 0 10.3453
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.5 0 10
-      vertex -9.5 0 10
-      vertex -9.51085 0 10.3453
+      vertex -10.5 0 10
+      vertex -10.5109 0 10.3453
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.48915 0 9.65465
-      vertex -9.5 0 10
+      vertex -10.5 0 10
       vertex -5.5 0 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.48915 0 9.65465
-      vertex -9.51085 0 9.65465
-      vertex -9.5 0 10
+      vertex -10.5109 0 9.65465
+      vertex -10.5 0 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.45663 0 9.31067
-      vertex -9.51085 0 9.65465
+      vertex -10.5109 0 9.65465
       vertex -5.48915 0 9.65465
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.45663 0 9.31067
-      vertex -9.54337 0 9.31067
-      vertex -9.51085 0 9.65465
+      vertex -10.5434 0 9.31067
+      vertex -10.5109 0 9.65465
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.40258 0 8.9694
-      vertex -9.54337 0 9.31067
+      vertex -10.5434 0 9.31067
       vertex -5.45663 0 9.31067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.40258 0 8.9694
-      vertex -9.59742 0 8.9694
-      vertex -9.54337 0 9.31067
+      vertex -10.5974 0 8.9694
+      vertex -10.5434 0 9.31067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.32721 0 8.63221
-      vertex -9.59742 0 8.9694
+      vertex -10.5974 0 8.9694
       vertex -5.40258 0 8.9694
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.32721 0 8.63221
-      vertex -9.67279 0 8.63221
-      vertex -9.59742 0 8.9694
+      vertex -10.6728 0 8.63221
+      vertex -10.5974 0 8.9694
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.23081 0 8.30041
-      vertex -9.67279 0 8.63221
+      vertex -10.6728 0 8.63221
       vertex -5.32721 0 8.63221
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.23081 0 8.30041
-      vertex -9.76919 0 8.30041
-      vertex -9.67279 0 8.63221
+      vertex -10.7692 0 8.30041
+      vertex -10.6728 0 8.63221
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.11377 0 7.97532
-      vertex -9.76919 0 8.30041
+      vertex -10.7692 0 8.30041
       vertex -5.23081 0 8.30041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.11377 0 7.97532
-      vertex -9.88623 0 7.97532
-      vertex -9.76919 0 8.30041
+      vertex -10.8862 0 7.97532
+      vertex -10.7692 0 8.30041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.97655 0 7.65821
-      vertex -9.88623 0 7.97532
+      vertex -10.8862 0 7.97532
       vertex -5.11377 0 7.97532
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.97655 0 7.65821
-      vertex -10.0235 0 7.65821
-      vertex -9.88623 0 7.97532
+      vertex -11.0235 0 7.65821
+      vertex -10.8862 0 7.97532
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.81969 0 7.35036
-      vertex -10.0235 0 7.65821
+      vertex -11.0235 0 7.65821
       vertex -4.97655 0 7.65821
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.81969 0 7.35036
-      vertex -10.1803 0 7.35036
-      vertex -10.0235 0 7.65821
+      vertex -11.1803 0 7.35036
+      vertex -11.0235 0 7.65821
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.6438 0 7.05295
-      vertex -10.1803 0 7.35036
+      vertex -11.1803 0 7.35036
       vertex -4.81969 0 7.35036
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.6438 0 7.05295
-      vertex -10.3562 0 7.05295
-      vertex -10.1803 0 7.35036
+      vertex -11.3562 0 7.05295
+      vertex -11.1803 0 7.35036
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.44959 0 6.76718
-      vertex -10.3562 0 7.05295
+      vertex -11.3562 0 7.05295
       vertex -4.6438 0 7.05295
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.44959 0 6.76718
-      vertex -10.5504 0 6.76718
-      vertex -10.3562 0 7.05295
+      vertex -11.5504 0 6.76718
+      vertex -11.3562 0 7.05295
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.23782 0 6.49417
-      vertex -10.5504 0 6.76718
+      vertex -11.5504 0 6.76718
       vertex -4.44959 0 6.76718
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.23782 0 6.49417
-      vertex -10.7622 0 6.49417
-      vertex -10.5504 0 6.76718
+      vertex -11.7622 0 6.49417
+      vertex -11.5504 0 6.76718
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.00933 0 6.23499
-      vertex -10.7622 0 6.49417
+      vertex -11.7622 0 6.49417
       vertex -4.23782 0 6.49417
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.00933 0 6.23499
-      vertex -10.9907 0 6.23499
-      vertex -10.7622 0 6.49417
+      vertex -11.9907 0 6.23499
+      vertex -11.7622 0 6.49417
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.76501 0 5.99067
-      vertex -10.9907 0 6.23499
+      vertex -11.9907 0 6.23499
       vertex -4.00933 0 6.23499
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.76501 0 5.99067
-      vertex -11.235 0 5.99067
-      vertex -10.9907 0 6.23499
+      vertex -12.235 0 5.99067
+      vertex -11.9907 0 6.23499
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.50583 0 5.76218
-      vertex -11.235 0 5.99067
+      vertex -12.235 0 5.99067
       vertex -3.76501 0 5.99067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.50583 0 5.76218
-      vertex -11.4942 0 5.76218
-      vertex -11.235 0 5.99067
+      vertex -12.4942 0 5.76218
+      vertex -12.235 0 5.99067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.23282 0 5.55041
-      vertex -11.4942 0 5.76218
+      vertex -12.4942 0 5.76218
       vertex -3.50583 0 5.76218
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.23282 0 5.55041
-      vertex -11.7672 0 5.55041
-      vertex -11.4942 0 5.76218
+      vertex -12.7672 0 5.55041
+      vertex -12.4942 0 5.76218
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -2.94705 0 5.3562
-      vertex -11.7672 0 5.55041
+      vertex -12.7672 0 5.55041
       vertex -3.23282 0 5.55041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -2.94705 0 5.3562
-      vertex -12.053 0 5.3562
-      vertex -11.7672 0 5.55041
+      vertex -13.053 0 5.3562
+      vertex -12.7672 0 5.55041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -2.64964 0 5.18031
-      vertex -12.053 0 5.3562
+      vertex -13.053 0 5.3562
       vertex -2.94705 0 5.3562
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -2.64964 0 5.18031
-      vertex -12.3504 0 5.18031
-      vertex -12.053 0 5.3562
+      vertex -13.3504 0 5.18031
+      vertex -13.053 0 5.3562
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -2.34179 0 5.02345
-      vertex -12.3504 0 5.18031
+      vertex -13.3504 0 5.18031
       vertex -2.64964 0 5.18031
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -2.34179 0 5.02345
-      vertex -12.6582 0 5.02345
-      vertex -12.3504 0 5.18031
+      vertex -13.6582 0 5.02345
+      vertex -13.3504 0 5.18031
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -2.02468 0 4.88623
-      vertex -12.6582 0 5.02345
+      vertex -13.6582 0 5.02345
       vertex -2.34179 0 5.02345
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -2.02468 0 4.88623
-      vertex -12.9753 0 4.88623
-      vertex -12.6582 0 5.02345
+      vertex -13.9753 0 4.88623
+      vertex -13.6582 0 5.02345
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -1.69959 0 4.76919
-      vertex -12.9753 0 4.88623
+      vertex -13.9753 0 4.88623
       vertex -2.02468 0 4.88623
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -1.69959 0 4.76919
-      vertex -13.3004 0 4.76919
-      vertex -12.9753 0 4.88623
+      vertex -14.3004 0 4.76919
+      vertex -13.9753 0 4.88623
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -1.36779 0 4.67279
-      vertex -13.3004 0 4.76919
+      vertex -14.3004 0 4.76919
       vertex -1.69959 0 4.76919
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -1.36779 0 4.67279
-      vertex -13.6322 0 4.67279
-      vertex -13.3004 0 4.76919
+      vertex -14.6322 0 4.67279
+      vertex -14.3004 0 4.76919
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -1.0306 0 4.59742
-      vertex -13.6322 0 4.67279
+      vertex -14.6322 0 4.67279
       vertex -1.36779 0 4.67279
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -1.0306 0 4.59742
-      vertex -13.9694 0 4.59742
-      vertex -13.6322 0 4.67279
+      vertex -14.9694 0 4.59742
+      vertex -14.6322 0 4.67279
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -0.689332 0 4.54337
-      vertex -13.9694 0 4.59742
+      vertex -14.9694 0 4.59742
       vertex -1.0306 0 4.59742
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -0.689332 0 4.54337
-      vertex -14.3107 0 4.54337
-      vertex -13.9694 0 4.59742
+      vertex -15.3107 0 4.54337
+      vertex -14.9694 0 4.59742
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -30 0 0
+      vertex -33 0 0
       vertex -0.689332 0 4.54337
       vertex -0.345347 0 4.51085
     endloop
@@ -4979,953 +4979,960 @@ solid OpenSCAD_Model
   facet normal 0 1 0
     outer loop
       vertex -0.689332 0 4.54337
-      vertex -30 0 0
-      vertex -14.3107 0 4.54337
+      vertex -33 0 0
+      vertex -15.3107 0 4.54337
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -30 0 0
+      vertex -33 0 0
       vertex -0.345347 0 4.51085
       vertex 0 0 4.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -14.3107 0 4.54337
-      vertex -30 0 0
-      vertex -14.6547 0 4.51085
+      vertex -15.3107 0 4.54337
+      vertex -33 0 0
+      vertex -15.6547 0 4.51085
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 12.6582 0 14.9765
-      vertex 4.23782 0 26.4942
-      vertex 12.9753 0 15.1138
+      vertex 13.6582 0 14.9765
+      vertex 4.44959 0 26.7672
+      vertex 13.9753 0 15.1138
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 0.345347 0 15.4891
       vertex 0 0 15.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
+      vertex 4.44959 0 26.7672
+      vertex 13.6582 0 14.9765
       vertex 4.23782 0 26.4942
-      vertex 12.6582 0 14.9765
-      vertex 4.00933 0 26.235
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 0.689332 0 15.4566
       vertex 0.345347 0 15.4891
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 12.3504 0 14.8197
-      vertex 4.00933 0 26.235
-      vertex 12.6582 0 14.9765
+      vertex 13.3504 0 14.8197
+      vertex 4.23782 0 26.4942
+      vertex 13.6582 0 14.9765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 1.0306 0 15.4026
       vertex 0.689332 0 15.4566
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
+      vertex 4.23782 0 26.4942
+      vertex 13.3504 0 14.8197
       vertex 4.00933 0 26.235
-      vertex 12.3504 0 14.8197
-      vertex 3.76501 0 25.9907
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 1.36779 0 15.3272
       vertex 1.0306 0 15.4026
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 12.053 0 14.6438
-      vertex 3.76501 0 25.9907
-      vertex 12.3504 0 14.8197
+      vertex 13.053 0 14.6438
+      vertex 4.00933 0 26.235
+      vertex 13.3504 0 14.8197
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 1.69959 0 15.2308
       vertex 1.36779 0 15.3272
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
+      vertex 4.00933 0 26.235
+      vertex 13.053 0 14.6438
       vertex 3.76501 0 25.9907
-      vertex 12.053 0 14.6438
-      vertex 3.50583 0 25.7622
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 2.02468 0 15.1138
       vertex 1.69959 0 15.2308
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 11.7672 0 14.4496
-      vertex 3.50583 0 25.7622
-      vertex 12.053 0 14.6438
+      vertex 12.7672 0 14.4496
+      vertex 3.76501 0 25.9907
+      vertex 13.053 0 14.6438
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 2.34179 0 14.9765
       vertex 2.02468 0 15.1138
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
+      vertex 3.76501 0 25.9907
+      vertex 12.7672 0 14.4496
       vertex 3.50583 0 25.7622
-      vertex 11.7672 0 14.4496
-      vertex 3.23282 0 25.5504
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 2.64964 0 14.8197
       vertex 2.34179 0 14.9765
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 1 -0
     outer loop
-      vertex 3.23282 0 14.4496
-      vertex 3.23282 0 25.5504
-      vertex 11.7672 0 14.4496
+      vertex 12.4942 0 14.2378
+      vertex 3.50583 0 25.7622
+      vertex 12.7672 0 14.4496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 2.94705 0 14.6438
       vertex 2.64964 0 14.8197
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 3.23282 0 25.5504
-      vertex 3.23282 0 14.4496
-      vertex 2.94705 0 25.3562
+      vertex 3.50583 0 14.2378
+      vertex 3.50583 0 25.7622
+      vertex 12.4942 0 14.2378
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 25.3562
+      vertex 3.23282 0 25.5504
       vertex 3.23282 0 14.4496
       vertex 2.94705 0 14.6438
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0 1 0
     outer loop
-      vertex 11.4942 0 14.2378
-      vertex 3.23282 0 14.4496
-      vertex 11.7672 0 14.4496
+      vertex 3.50583 0 25.7622
+      vertex 3.50583 0 14.2378
+      vertex 3.23282 0 25.5504
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.4942 0 14.2378
+      vertex 3.23282 0 25.5504
       vertex 3.50583 0 14.2378
       vertex 3.23282 0 14.4496
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 11.235 0 14.0093
+      vertex 12.235 0 14.0093
       vertex 3.50583 0 14.2378
-      vertex 11.4942 0 14.2378
+      vertex 12.4942 0 14.2378
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.235 0 14.0093
+      vertex 12.235 0 14.0093
       vertex 3.76501 0 14.0093
       vertex 3.50583 0 14.2378
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 10.9907 0 13.765
+      vertex 11.9907 0 13.765
       vertex 3.76501 0 14.0093
-      vertex 11.235 0 14.0093
+      vertex 12.235 0 14.0093
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.9907 0 13.765
+      vertex 11.9907 0 13.765
       vertex 4.00933 0 13.765
       vertex 3.76501 0 14.0093
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 10.7622 0 13.5058
+      vertex 11.7622 0 13.5058
       vertex 4.00933 0 13.765
-      vertex 10.9907 0 13.765
+      vertex 11.9907 0 13.765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.7622 0 13.5058
+      vertex 11.7622 0 13.5058
       vertex 4.23782 0 13.5058
       vertex 4.00933 0 13.765
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 10.5504 0 13.2328
+      vertex 11.5504 0 13.2328
       vertex 4.23782 0 13.5058
-      vertex 10.7622 0 13.5058
+      vertex 11.7622 0 13.5058
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.5504 0 13.2328
+      vertex 11.5504 0 13.2328
       vertex 4.44959 0 13.2328
       vertex 4.23782 0 13.5058
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 10.3562 0 12.947
+      vertex 11.3562 0 12.947
       vertex 4.44959 0 13.2328
-      vertex 10.5504 0 13.2328
+      vertex 11.5504 0 13.2328
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.3562 0 12.947
+      vertex 11.3562 0 12.947
       vertex 4.6438 0 12.947
       vertex 4.44959 0 13.2328
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 10.1803 0 12.6496
+      vertex 11.1803 0 12.6496
       vertex 4.6438 0 12.947
-      vertex 10.3562 0 12.947
+      vertex 11.3562 0 12.947
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.1803 0 12.6496
+      vertex 11.1803 0 12.6496
       vertex 4.81969 0 12.6496
       vertex 4.6438 0 12.947
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 10.0235 0 12.3418
+      vertex 11.0235 0 12.3418
       vertex 4.81969 0 12.6496
-      vertex 10.1803 0 12.6496
+      vertex 11.1803 0 12.6496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.0235 0 12.3418
+      vertex 11.0235 0 12.3418
       vertex 4.97655 0 12.3418
       vertex 4.81969 0 12.6496
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 9.88623 0 12.0247
+      vertex 10.8862 0 12.0247
       vertex 4.97655 0 12.3418
-      vertex 10.0235 0 12.3418
+      vertex 11.0235 0 12.3418
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.88623 0 12.0247
+      vertex 10.8862 0 12.0247
       vertex 5.11377 0 12.0247
       vertex 4.97655 0 12.3418
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 9.76919 0 11.6996
+      vertex 10.7692 0 11.6996
       vertex 5.11377 0 12.0247
-      vertex 9.88623 0 12.0247
+      vertex 10.8862 0 12.0247
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.76919 0 11.6996
+      vertex 10.7692 0 11.6996
       vertex 5.23081 0 11.6996
       vertex 5.11377 0 12.0247
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 9.67279 0 11.3678
+      vertex 10.6728 0 11.3678
       vertex 5.23081 0 11.6996
-      vertex 9.76919 0 11.6996
+      vertex 10.7692 0 11.6996
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.67279 0 11.3678
+      vertex 10.6728 0 11.3678
       vertex 5.32721 0 11.3678
       vertex 5.23081 0 11.6996
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 9.59742 0 11.0306
+      vertex 10.5974 0 11.0306
       vertex 5.32721 0 11.3678
-      vertex 9.67279 0 11.3678
+      vertex 10.6728 0 11.3678
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.59742 0 11.0306
+      vertex 10.5974 0 11.0306
       vertex 5.40258 0 11.0306
       vertex 5.32721 0 11.3678
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 9.54337 0 10.6893
+      vertex 10.5434 0 10.6893
       vertex 5.40258 0 11.0306
-      vertex 9.59742 0 11.0306
+      vertex 10.5974 0 11.0306
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.54337 0 10.6893
+      vertex 10.5434 0 10.6893
       vertex 5.45663 0 10.6893
       vertex 5.40258 0 11.0306
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 9.51085 0 10.3453
+      vertex 10.5109 0 10.3453
       vertex 5.45663 0 10.6893
-      vertex 9.54337 0 10.6893
+      vertex 10.5434 0 10.6893
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.51085 0 10.3453
+      vertex 10.5109 0 10.3453
       vertex 5.48915 0 10.3453
       vertex 5.45663 0 10.6893
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 9.5 0 10
+      vertex 10.5 0 10
       vertex 5.48915 0 10.3453
-      vertex 9.51085 0 10.3453
+      vertex 10.5109 0 10.3453
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.5 0 10
+      vertex 10.5 0 10
       vertex 5.5 0 10
       vertex 5.48915 0 10.3453
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.51085 0 9.65465
+      vertex 10.5109 0 9.65465
       vertex 5.5 0 10
-      vertex 9.5 0 10
+      vertex 10.5 0 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.51085 0 9.65465
+      vertex 10.5109 0 9.65465
       vertex 5.48915 0 9.65465
       vertex 5.5 0 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.54337 0 9.31067
+      vertex 10.5434 0 9.31067
       vertex 5.48915 0 9.65465
-      vertex 9.51085 0 9.65465
+      vertex 10.5109 0 9.65465
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.54337 0 9.31067
+      vertex 10.5434 0 9.31067
       vertex 5.45663 0 9.31067
       vertex 5.48915 0 9.65465
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.59742 0 8.9694
+      vertex 10.5974 0 8.9694
       vertex 5.45663 0 9.31067
-      vertex 9.54337 0 9.31067
+      vertex 10.5434 0 9.31067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.59742 0 8.9694
+      vertex 10.5974 0 8.9694
       vertex 5.40258 0 8.9694
       vertex 5.45663 0 9.31067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.67279 0 8.63221
+      vertex 10.6728 0 8.63221
       vertex 5.40258 0 8.9694
-      vertex 9.59742 0 8.9694
+      vertex 10.5974 0 8.9694
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.67279 0 8.63221
+      vertex 10.6728 0 8.63221
       vertex 5.32721 0 8.63221
       vertex 5.40258 0 8.9694
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.76919 0 8.30041
+      vertex 10.7692 0 8.30041
       vertex 5.32721 0 8.63221
-      vertex 9.67279 0 8.63221
+      vertex 10.6728 0 8.63221
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.76919 0 8.30041
+      vertex 10.7692 0 8.30041
       vertex 5.23081 0 8.30041
       vertex 5.32721 0 8.63221
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.88623 0 7.97532
+      vertex 10.8862 0 7.97532
       vertex 5.23081 0 8.30041
-      vertex 9.76919 0 8.30041
+      vertex 10.7692 0 8.30041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.88623 0 7.97532
+      vertex 10.8862 0 7.97532
       vertex 5.11377 0 7.97532
       vertex 5.23081 0 8.30041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.0235 0 7.65821
+      vertex 11.0235 0 7.65821
       vertex 5.11377 0 7.97532
-      vertex 9.88623 0 7.97532
+      vertex 10.8862 0 7.97532
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.0235 0 7.65821
+      vertex 11.0235 0 7.65821
       vertex 4.97655 0 7.65821
       vertex 5.11377 0 7.97532
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.1803 0 7.35036
+      vertex 11.1803 0 7.35036
       vertex 4.97655 0 7.65821
-      vertex 10.0235 0 7.65821
+      vertex 11.0235 0 7.65821
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.1803 0 7.35036
+      vertex 11.1803 0 7.35036
       vertex 4.81969 0 7.35036
       vertex 4.97655 0 7.65821
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.3562 0 7.05295
+      vertex 11.3562 0 7.05295
       vertex 4.81969 0 7.35036
-      vertex 10.1803 0 7.35036
+      vertex 11.1803 0 7.35036
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.3562 0 7.05295
+      vertex 11.3562 0 7.05295
       vertex 4.6438 0 7.05295
       vertex 4.81969 0 7.35036
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.5504 0 6.76718
+      vertex 11.5504 0 6.76718
       vertex 4.6438 0 7.05295
-      vertex 10.3562 0 7.05295
+      vertex 11.3562 0 7.05295
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.5504 0 6.76718
+      vertex 11.5504 0 6.76718
       vertex 4.44959 0 6.76718
       vertex 4.6438 0 7.05295
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.7622 0 6.49417
+      vertex 11.7622 0 6.49417
       vertex 4.44959 0 6.76718
-      vertex 10.5504 0 6.76718
+      vertex 11.5504 0 6.76718
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.7622 0 6.49417
+      vertex 11.7622 0 6.49417
       vertex 4.23782 0 6.49417
       vertex 4.44959 0 6.76718
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.9907 0 6.23499
+      vertex 11.9907 0 6.23499
       vertex 4.23782 0 6.49417
-      vertex 10.7622 0 6.49417
+      vertex 11.7622 0 6.49417
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.9907 0 6.23499
+      vertex 11.9907 0 6.23499
       vertex 4.00933 0 6.23499
       vertex 4.23782 0 6.49417
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.235 0 5.99067
+      vertex 12.235 0 5.99067
       vertex 4.00933 0 6.23499
-      vertex 10.9907 0 6.23499
+      vertex 11.9907 0 6.23499
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.235 0 5.99067
+      vertex 12.235 0 5.99067
       vertex 3.76501 0 5.99067
       vertex 4.00933 0 6.23499
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.4942 0 5.76218
+      vertex 12.4942 0 5.76218
       vertex 3.76501 0 5.99067
-      vertex 11.235 0 5.99067
+      vertex 12.235 0 5.99067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.4942 0 5.76218
+      vertex 12.4942 0 5.76218
       vertex 3.50583 0 5.76218
       vertex 3.76501 0 5.99067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.7672 0 5.55041
+      vertex 12.7672 0 5.55041
       vertex 3.50583 0 5.76218
-      vertex 11.4942 0 5.76218
+      vertex 12.4942 0 5.76218
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.7672 0 5.55041
+      vertex 12.7672 0 5.55041
       vertex 3.23282 0 5.55041
       vertex 3.50583 0 5.76218
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 12.053 0 5.3562
+      vertex 13.053 0 5.3562
       vertex 3.23282 0 5.55041
-      vertex 11.7672 0 5.55041
+      vertex 12.7672 0 5.55041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 12.053 0 5.3562
+      vertex 13.053 0 5.3562
       vertex 2.94705 0 5.3562
       vertex 3.23282 0 5.55041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 12.3504 0 5.18031
+      vertex 13.3504 0 5.18031
       vertex 2.94705 0 5.3562
-      vertex 12.053 0 5.3562
+      vertex 13.053 0 5.3562
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 12.3504 0 5.18031
+      vertex 13.3504 0 5.18031
       vertex 2.64964 0 5.18031
       vertex 2.94705 0 5.3562
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 12.6582 0 5.02345
+      vertex 13.6582 0 5.02345
       vertex 2.64964 0 5.18031
-      vertex 12.3504 0 5.18031
+      vertex 13.3504 0 5.18031
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 12.6582 0 5.02345
+      vertex 13.6582 0 5.02345
       vertex 2.34179 0 5.02345
       vertex 2.64964 0 5.18031
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 12.9753 0 4.88623
+      vertex 13.9753 0 4.88623
       vertex 2.34179 0 5.02345
-      vertex 12.6582 0 5.02345
+      vertex 13.6582 0 5.02345
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 12.9753 0 4.88623
+      vertex 13.9753 0 4.88623
       vertex 2.02468 0 4.88623
       vertex 2.34179 0 5.02345
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 13.3004 0 4.76919
+      vertex 14.3004 0 4.76919
       vertex 2.02468 0 4.88623
-      vertex 12.9753 0 4.88623
+      vertex 13.9753 0 4.88623
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 13.3004 0 4.76919
+      vertex 14.3004 0 4.76919
       vertex 1.69959 0 4.76919
       vertex 2.02468 0 4.88623
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 13.6322 0 4.67279
+      vertex 14.6322 0 4.67279
       vertex 1.69959 0 4.76919
-      vertex 13.3004 0 4.76919
+      vertex 14.3004 0 4.76919
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 13.6322 0 4.67279
+      vertex 14.6322 0 4.67279
       vertex 1.36779 0 4.67279
       vertex 1.69959 0 4.76919
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 13.9694 0 4.59742
+      vertex 14.9694 0 4.59742
       vertex 1.36779 0 4.67279
-      vertex 13.6322 0 4.67279
+      vertex 14.6322 0 4.67279
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 13.9694 0 4.59742
+      vertex 14.9694 0 4.59742
       vertex 1.0306 0 4.59742
       vertex 1.36779 0 4.67279
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 14.3107 0 4.54337
+      vertex 15.3107 0 4.54337
       vertex 1.0306 0 4.59742
-      vertex 13.9694 0 4.59742
+      vertex 14.9694 0 4.59742
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 14.3107 0 4.54337
+      vertex 15.3107 0 4.54337
       vertex 0.689332 0 4.54337
       vertex 1.0306 0 4.59742
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 30 0 0
-      vertex 14.3107 0 4.54337
-      vertex 14.6547 0 4.51085
+      vertex 33 0 0
+      vertex 15.3107 0 4.54337
+      vertex 15.6547 0 4.51085
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 14.3107 0 4.54337
-      vertex 30 0 0
+      vertex 15.3107 0 4.54337
+      vertex 33 0 0
       vertex 0.689332 0 4.54337
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 30 0 0
-      vertex 14.6547 0 4.51085
-      vertex 15 0 4.5
+      vertex 33 0 0
+      vertex 15.6547 0 4.51085
+      vertex 16 0 4.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 0.689332 0 4.54337
-      vertex 30 0 0
+      vertex 33 0 0
       vertex 0.345347 0 4.51085
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 0 0 35.5
-      vertex -11 0 40
+      vertex -12 0 40
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 0.345347 0 35.4891
       vertex 0 0 35.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 0.689332 0 35.4566
       vertex 0.345347 0 35.4891
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 1.0306 0 35.4026
       vertex 0.689332 0 35.4566
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 1.36779 0 35.3272
       vertex 1.0306 0 35.4026
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 1.69959 0 35.2308
       vertex 1.36779 0 35.3272
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 2.02468 0 35.1138
       vertex 1.69959 0 35.2308
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 2.34179 0 34.9765
       vertex 2.02468 0 35.1138
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 2.64964 0 34.8197
       vertex 2.34179 0 34.9765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 2.94705 0 34.6438
       vertex 2.64964 0 34.8197
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 3.23282 0 34.4496
       vertex 2.94705 0 34.6438
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 3.50583 0 34.2378
       vertex 3.23282 0 34.4496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 3.76501 0 34.0093
       vertex 3.50583 0 34.2378
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 4.00933 0 33.765
       vertex 3.76501 0 34.0093
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 4.23782 0 33.5058
       vertex 4.00933 0 33.765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 4.44959 0 33.2328
       vertex 4.23782 0 33.5058
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 4.6438 0 32.947
       vertex 4.44959 0 33.2328
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 4.81969 0 32.6496
       vertex 4.6438 0 32.947
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 4.97655 0 32.3418
       vertex 4.81969 0 32.6496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 5.11377 0 32.0247
       vertex 4.97655 0 32.3418
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 5.23081 0 31.6996
       vertex 5.11377 0 32.0247
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 5.32721 0 31.3678
       vertex 5.23081 0 31.6996
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 5.40258 0 31.0306
       vertex 5.32721 0 31.3678
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 5.45663 0 30.6893
       vertex 5.40258 0 31.0306
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 5.48915 0 30.3453
       vertex 5.45663 0 30.6893
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 5.5 0 30
       vertex 5.48915 0 30.3453
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
+      vertex 12 0 40
       vertex 5.48915 0 29.6547
       vertex 5.5 0 30
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 16.3678 0 15.3272
+      vertex 16.6893 0 15.4566
       vertex 5.48915 0 29.6547
-      vertex 11 0 40
+      vertex 12 0 40
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 5.48915 0 29.6547
-      vertex 16.0306 0 15.4026
+      vertex 16.6893 0 15.4566
       vertex 5.45663 0 29.3107
     endloop
   endfacet
   facet normal -0 1 -0
     outer loop
-      vertex 15.6893 0 15.4566
+      vertex 16.3453 0 15.4891
       vertex 5.45663 0 29.3107
-      vertex 16.0306 0 15.4026
+      vertex 16.6893 0 15.4566
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 5.45663 0 29.3107
-      vertex 15.6893 0 15.4566
+      vertex 16.3453 0 15.4891
       vertex 5.40258 0 28.9694
     endloop
   endfacet
   facet normal -0 1 -0
     outer loop
-      vertex 15.3453 0 15.4891
+      vertex 16 0 15.5
       vertex 5.40258 0 28.9694
-      vertex 15.6893 0 15.4566
+      vertex 16.3453 0 15.4891
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 5.40258 0 28.9694
-      vertex 15.3453 0 15.4891
+      vertex 16 0 15.5
       vertex 5.32721 0 28.6322
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 15.6547 0 15.4891
+      vertex 5.32721 0 28.6322
+      vertex 16 0 15.5
     endloop
   endfacet
   facet normal 0 1 0
@@ -5986,674 +5993,674 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 4.44959 0 26.7672
-      vertex 12.9753 0 15.1138
-      vertex 4.23782 0 26.4942
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 12.9753 0 15.1138
-      vertex 4.44959 0 26.7672
-      vertex 13.3004 0 15.2308
+      vertex 3.23282 0 25.5504
+      vertex 0 0 15.5
+      vertex 2.94705 0 25.3562
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 4.6438 0 27.053
-      vertex 13.3004 0 15.2308
+      vertex 13.9753 0 15.1138
       vertex 4.44959 0 26.7672
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 13.3004 0 15.2308
+      vertex 13.9753 0 15.1138
       vertex 4.6438 0 27.053
-      vertex 13.6322 0 15.3272
+      vertex 14.3004 0 15.2308
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 4.81969 0 27.3504
-      vertex 13.6322 0 15.3272
+      vertex 14.3004 0 15.2308
       vertex 4.6438 0 27.053
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 13.6322 0 15.3272
+      vertex 14.3004 0 15.2308
       vertex 4.81969 0 27.3504
-      vertex 13.9694 0 15.4026
+      vertex 14.6322 0 15.3272
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 4.97655 0 27.6582
-      vertex 13.9694 0 15.4026
+      vertex 14.6322 0 15.3272
       vertex 4.81969 0 27.3504
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 13.9694 0 15.4026
+      vertex 14.6322 0 15.3272
       vertex 4.97655 0 27.6582
-      vertex 14.3107 0 15.4566
+      vertex 14.9694 0 15.4026
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 5.11377 0 27.9753
-      vertex 14.3107 0 15.4566
+      vertex 14.9694 0 15.4026
       vertex 4.97655 0 27.6582
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 14.3107 0 15.4566
+      vertex 14.9694 0 15.4026
       vertex 5.11377 0 27.9753
-      vertex 14.6547 0 15.4891
+      vertex 15.3107 0 15.4566
     endloop
   endfacet
-  facet normal -0 1 -0
+  facet normal 0 1 -0
     outer loop
-      vertex 15 0 15.5
-      vertex 5.32721 0 28.6322
-      vertex 15.3453 0 15.4891
+      vertex 15.3107 0 15.4566
+      vertex 5.23081 0 28.3004
+      vertex 15.6547 0 15.4891
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 5.23081 0 28.3004
-      vertex 14.6547 0 15.4891
+      vertex 15.3107 0 15.4566
       vertex 5.11377 0 27.9753
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 14.6547 0 15.4891
-      vertex 5.23081 0 28.3004
-      vertex 15 0 15.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 5.32721 0 28.6322
-      vertex 15 0 15.5
+      vertex 15.6547 0 15.4891
       vertex 5.23081 0 28.3004
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 5.48915 0 29.6547
-      vertex 16.3678 0 15.3272
-      vertex 16.0306 0 15.4026
+      vertex 12 0 40
+      vertex 17.0306 0 15.4026
+      vertex 16.6893 0 15.4566
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 16.6996 0 15.2308
-      vertex 16.3678 0 15.3272
+      vertex 12 0 40
+      vertex 17.3678 0 15.3272
+      vertex 17.0306 0 15.4026
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 17.0247 0 15.1138
-      vertex 16.6996 0 15.2308
+      vertex 12 0 40
+      vertex 17.6996 0 15.2308
+      vertex 17.3678 0 15.3272
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 17.3418 0 14.9765
-      vertex 17.0247 0 15.1138
+      vertex 12 0 40
+      vertex 18.0247 0 15.1138
+      vertex 17.6996 0 15.2308
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 17.6496 0 14.8197
-      vertex 17.3418 0 14.9765
+      vertex 12 0 40
+      vertex 18.3418 0 14.9765
+      vertex 18.0247 0 15.1138
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 17.947 0 14.6438
-      vertex 17.6496 0 14.8197
+      vertex 12 0 40
+      vertex 18.6496 0 14.8197
+      vertex 18.3418 0 14.9765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 18.2328 0 14.4496
-      vertex 17.947 0 14.6438
+      vertex 12 0 40
+      vertex 18.947 0 14.6438
+      vertex 18.6496 0 14.8197
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 18.5058 0 14.2378
-      vertex 18.2328 0 14.4496
+      vertex 12 0 40
+      vertex 19.2328 0 14.4496
+      vertex 18.947 0 14.6438
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 18.765 0 14.0093
-      vertex 18.5058 0 14.2378
+      vertex 12 0 40
+      vertex 19.5058 0 14.2378
+      vertex 19.2328 0 14.4496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 19.0093 0 13.765
-      vertex 18.765 0 14.0093
+      vertex 12 0 40
+      vertex 19.765 0 14.0093
+      vertex 19.5058 0 14.2378
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 19.2378 0 13.5058
-      vertex 19.0093 0 13.765
+      vertex 12 0 40
+      vertex 20.0093 0 13.765
+      vertex 19.765 0 14.0093
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 19.4496 0 13.2328
-      vertex 19.2378 0 13.5058
+      vertex 12 0 40
+      vertex 20.2378 0 13.5058
+      vertex 20.0093 0 13.765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 19.6438 0 12.947
-      vertex 19.4496 0 13.2328
+      vertex 12 0 40
+      vertex 20.4496 0 13.2328
+      vertex 20.2378 0 13.5058
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11 0 40
-      vertex 19.8197 0 12.6496
-      vertex 19.6438 0 12.947
+      vertex 12 0 40
+      vertex 20.6438 0 12.947
+      vertex 20.4496 0 13.2328
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 30 0 0
-      vertex 19.8197 0 12.6496
-      vertex 11 0 40
+      vertex 33 0 0
+      vertex 20.6438 0 12.947
+      vertex 12 0 40
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 19.8197 0 12.6496
-      vertex 30 0 0
-      vertex 19.9765 0 12.3418
+      vertex 20.6438 0 12.947
+      vertex 33 0 0
+      vertex 20.8197 0 12.6496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 19.9765 0 12.3418
-      vertex 30 0 0
-      vertex 20.1138 0 12.0247
+      vertex 20.8197 0 12.6496
+      vertex 33 0 0
+      vertex 20.9765 0 12.3418
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.9765 0 12.3418
+      vertex 33 0 0
+      vertex 21.1138 0 12.0247
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 0.345347 0 4.51085
-      vertex 30 0 0
+      vertex 33 0 0
       vertex 0 0 4.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -30 0 0
+      vertex -33 0 0
       vertex 0 0 4.5
-      vertex 30 0 0
+      vertex 33 0 0
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 15.3453 0 4.51085
-      vertex 30 0 0
-      vertex 15 0 4.5
+      vertex 16.3453 0 4.51085
+      vertex 33 0 0
+      vertex 16 0 4.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 15.6893 0 4.54337
-      vertex 30 0 0
-      vertex 15.3453 0 4.51085
+      vertex 16.6893 0 4.54337
+      vertex 33 0 0
+      vertex 16.3453 0 4.51085
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 16.0306 0 4.59742
-      vertex 30 0 0
-      vertex 15.6893 0 4.54337
+      vertex 17.0306 0 4.59742
+      vertex 33 0 0
+      vertex 16.6893 0 4.54337
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 16.3678 0 4.67279
-      vertex 30 0 0
-      vertex 16.0306 0 4.59742
+      vertex 17.3678 0 4.67279
+      vertex 33 0 0
+      vertex 17.0306 0 4.59742
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 16.6996 0 4.76919
-      vertex 30 0 0
-      vertex 16.3678 0 4.67279
+      vertex 17.6996 0 4.76919
+      vertex 33 0 0
+      vertex 17.3678 0 4.67279
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 17.0247 0 4.88623
-      vertex 30 0 0
-      vertex 16.6996 0 4.76919
+      vertex 18.0247 0 4.88623
+      vertex 33 0 0
+      vertex 17.6996 0 4.76919
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 17.3418 0 5.02345
-      vertex 30 0 0
-      vertex 17.0247 0 4.88623
+      vertex 18.3418 0 5.02345
+      vertex 33 0 0
+      vertex 18.0247 0 4.88623
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 17.6496 0 5.18031
-      vertex 30 0 0
-      vertex 17.3418 0 5.02345
+      vertex 18.6496 0 5.18031
+      vertex 33 0 0
+      vertex 18.3418 0 5.02345
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 17.947 0 5.3562
-      vertex 30 0 0
-      vertex 17.6496 0 5.18031
+      vertex 18.947 0 5.3562
+      vertex 33 0 0
+      vertex 18.6496 0 5.18031
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 18.2328 0 5.55041
-      vertex 30 0 0
-      vertex 17.947 0 5.3562
+      vertex 19.2328 0 5.55041
+      vertex 33 0 0
+      vertex 18.947 0 5.3562
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 18.5058 0 5.76218
-      vertex 30 0 0
-      vertex 18.2328 0 5.55041
+      vertex 19.5058 0 5.76218
+      vertex 33 0 0
+      vertex 19.2328 0 5.55041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 18.765 0 5.99067
-      vertex 30 0 0
-      vertex 18.5058 0 5.76218
+      vertex 19.765 0 5.99067
+      vertex 33 0 0
+      vertex 19.5058 0 5.76218
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 19.0093 0 6.23499
-      vertex 30 0 0
-      vertex 18.765 0 5.99067
+      vertex 20.0093 0 6.23499
+      vertex 33 0 0
+      vertex 19.765 0 5.99067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 19.2378 0 6.49417
-      vertex 30 0 0
-      vertex 19.0093 0 6.23499
+      vertex 20.2378 0 6.49417
+      vertex 33 0 0
+      vertex 20.0093 0 6.23499
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 19.4496 0 6.76718
-      vertex 30 0 0
-      vertex 19.2378 0 6.49417
+      vertex 20.4496 0 6.76718
+      vertex 33 0 0
+      vertex 20.2378 0 6.49417
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 19.6438 0 7.05295
-      vertex 30 0 0
-      vertex 19.4496 0 6.76718
+      vertex 20.6438 0 7.05295
+      vertex 33 0 0
+      vertex 20.4496 0 6.76718
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 19.8197 0 7.35036
-      vertex 30 0 0
-      vertex 19.6438 0 7.05295
+      vertex 20.8197 0 7.35036
+      vertex 33 0 0
+      vertex 20.6438 0 7.05295
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 19.9765 0 7.65821
-      vertex 30 0 0
-      vertex 19.8197 0 7.35036
+      vertex 20.9765 0 7.65821
+      vertex 33 0 0
+      vertex 20.8197 0 7.35036
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.1138 0 7.97532
-      vertex 30 0 0
-      vertex 19.9765 0 7.65821
+      vertex 21.1138 0 7.97532
+      vertex 33 0 0
+      vertex 20.9765 0 7.65821
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.2308 0 8.30041
-      vertex 30 0 0
-      vertex 20.1138 0 7.97532
+      vertex 21.2308 0 8.30041
+      vertex 33 0 0
+      vertex 21.1138 0 7.97532
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.3272 0 8.63221
-      vertex 30 0 0
-      vertex 20.2308 0 8.30041
+      vertex 21.3272 0 8.63221
+      vertex 33 0 0
+      vertex 21.2308 0 8.30041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.4026 0 8.9694
-      vertex 30 0 0
-      vertex 20.3272 0 8.63221
+      vertex 21.4026 0 8.9694
+      vertex 33 0 0
+      vertex 21.3272 0 8.63221
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.4566 0 9.31067
-      vertex 30 0 0
-      vertex 20.4026 0 8.9694
+      vertex 21.4566 0 9.31067
+      vertex 33 0 0
+      vertex 21.4026 0 8.9694
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.4891 0 9.65465
-      vertex 30 0 0
-      vertex 20.4566 0 9.31067
+      vertex 21.4891 0 9.65465
+      vertex 33 0 0
+      vertex 21.4566 0 9.31067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.5 0 10
-      vertex 30 0 0
-      vertex 20.4891 0 9.65465
+      vertex 21.5 0 10
+      vertex 33 0 0
+      vertex 21.4891 0 9.65465
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.4891 0 10.3453
-      vertex 30 0 0
-      vertex 20.5 0 10
+      vertex 21.4891 0 10.3453
+      vertex 33 0 0
+      vertex 21.5 0 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.4566 0 10.6893
-      vertex 30 0 0
-      vertex 20.4891 0 10.3453
+      vertex 21.4566 0 10.6893
+      vertex 33 0 0
+      vertex 21.4891 0 10.3453
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.4026 0 11.0306
-      vertex 30 0 0
-      vertex 20.4566 0 10.6893
+      vertex 21.4026 0 11.0306
+      vertex 33 0 0
+      vertex 21.4566 0 10.6893
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.3272 0 11.3678
-      vertex 30 0 0
-      vertex 20.4026 0 11.0306
+      vertex 21.3272 0 11.3678
+      vertex 33 0 0
+      vertex 21.4026 0 11.0306
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.2308 0 11.6996
-      vertex 30 0 0
-      vertex 20.3272 0 11.3678
+      vertex 21.2308 0 11.6996
+      vertex 33 0 0
+      vertex 21.3272 0 11.3678
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 20.1138 0 12.0247
-      vertex 30 0 0
-      vertex 20.2308 0 11.6996
+      vertex 21.1138 0 12.0247
+      vertex 33 0 0
+      vertex 21.2308 0 11.6996
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -0.345347 0 35.4891
-      vertex -11 0 40
+      vertex -12 0 40
       vertex 0 0 35.5
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -0.689332 0 35.4566
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -0.345347 0 35.4891
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -1.0306 0 35.4026
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -0.689332 0 35.4566
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -1.36779 0 35.3272
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -1.0306 0 35.4026
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -1.69959 0 35.2308
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -1.36779 0 35.3272
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -2.02468 0 35.1138
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -1.69959 0 35.2308
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -2.34179 0 34.9765
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -2.02468 0 35.1138
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -2.64964 0 34.8197
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -2.34179 0 34.9765
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -2.94705 0 34.6438
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -2.64964 0 34.8197
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -3.23282 0 34.4496
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -2.94705 0 34.6438
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -3.50583 0 34.2378
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -3.23282 0 34.4496
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -3.76501 0 34.0093
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -3.50583 0 34.2378
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.00933 0 33.765
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -3.76501 0 34.0093
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.23782 0 33.5058
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -4.00933 0 33.765
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.44959 0 33.2328
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -4.23782 0 33.5058
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.6438 0 32.947
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -4.44959 0 33.2328
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.81969 0 32.6496
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -4.6438 0 32.947
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -4.97655 0 32.3418
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -4.81969 0 32.6496
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.11377 0 32.0247
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -4.97655 0 32.3418
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.23081 0 31.6996
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -5.11377 0 32.0247
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.32721 0 31.3678
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -5.23081 0 31.6996
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.40258 0 31.0306
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -5.32721 0 31.3678
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.45663 0 30.6893
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -5.40258 0 31.0306
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.48915 0 30.3453
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -5.45663 0 30.6893
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex -5.5 0 30
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -5.48915 0 30.3453
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.48915 0 29.6547
-      vertex -11 0 40
+      vertex -12 0 40
       vertex -5.5 0 30
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -16.0306 0 15.4026
+      vertex -16.6893 0 15.4566
       vertex -5.48915 0 29.6547
       vertex -5.45663 0 29.3107
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -15.6893 0 15.4566
+      vertex -16.3453 0 15.4891
       vertex -5.45663 0 29.3107
       vertex -5.40258 0 28.9694
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -15.3453 0 15.4891
+      vertex -16 0 15.5
       vertex -5.40258 0 28.9694
       vertex -5.32721 0 28.6322
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -5.32721 0 28.6322
       vertex -5.23081 0 28.3004
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -5.23081 0 28.3004
       vertex -5.11377 0 27.9753
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -5.11377 0 27.9753
       vertex -4.97655 0 27.6582
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -16 0 15.5
+      vertex -4.97655 0 27.6582
+      vertex -4.81969 0 27.3504
     endloop
   endfacet
   facet normal 0 1 0
@@ -6735,506 +6742,429 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.94705 0 25.3562
-      vertex -15 0 15.5
-      vertex -3.23282 0 25.5504
+      vertex -1.69959 0 24.7692
+      vertex -1.69959 0 15.2308
+      vertex -2.02468 0 24.8862
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.23282 0 25.5504
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -3.50583 0 25.7622
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.50583 0 25.7622
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -3.76501 0 25.9907
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -3.76501 0 25.9907
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -4.00933 0 26.235
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.00933 0 26.235
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -4.23782 0 26.4942
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.23782 0 26.4942
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -4.44959 0 26.7672
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.44959 0 26.7672
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -4.6438 0 27.053
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -4.6438 0 27.053
-      vertex -15 0 15.5
+      vertex -16 0 15.5
       vertex -4.81969 0 27.3504
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -4.81969 0 27.3504
-      vertex -15 0 15.5
-      vertex -4.97655 0 27.6582
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.32721 0 28.6322
-      vertex -15 0 15.5
-      vertex -15.3453 0 15.4891
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.40258 0 28.9694
-      vertex -15.3453 0 15.4891
-      vertex -15.6893 0 15.4566
+      vertex -16 0 15.5
+      vertex -16.3453 0 15.4891
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.45663 0 29.3107
-      vertex -15.6893 0 15.4566
-      vertex -16.0306 0 15.4026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -16.3678 0 15.3272
-      vertex -5.48915 0 29.6547
-      vertex -16.0306 0 15.4026
+      vertex -16.3453 0 15.4891
+      vertex -16.6893 0 15.4566
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex -5.48915 0 29.6547
-      vertex -16.3678 0 15.3272
-      vertex -11 0 40
+      vertex -16.6893 0 15.4566
+      vertex -12 0 40
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -16.6996 0 15.2308
-      vertex -11 0 40
-      vertex -16.3678 0 15.3272
+      vertex -17.0306 0 15.4026
+      vertex -12 0 40
+      vertex -16.6893 0 15.4566
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -17.0247 0 15.1138
-      vertex -11 0 40
-      vertex -16.6996 0 15.2308
+      vertex -17.3678 0 15.3272
+      vertex -12 0 40
+      vertex -17.0306 0 15.4026
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -17.3418 0 14.9765
-      vertex -11 0 40
-      vertex -17.0247 0 15.1138
+      vertex -17.6996 0 15.2308
+      vertex -12 0 40
+      vertex -17.3678 0 15.3272
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -17.6496 0 14.8197
-      vertex -11 0 40
-      vertex -17.3418 0 14.9765
+      vertex -18.0247 0 15.1138
+      vertex -12 0 40
+      vertex -17.6996 0 15.2308
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -17.947 0 14.6438
-      vertex -11 0 40
-      vertex -17.6496 0 14.8197
+      vertex -18.3418 0 14.9765
+      vertex -12 0 40
+      vertex -18.0247 0 15.1138
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -18.2328 0 14.4496
-      vertex -11 0 40
-      vertex -17.947 0 14.6438
+      vertex -18.6496 0 14.8197
+      vertex -12 0 40
+      vertex -18.3418 0 14.9765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -18.5058 0 14.2378
-      vertex -11 0 40
-      vertex -18.2328 0 14.4496
+      vertex -18.947 0 14.6438
+      vertex -12 0 40
+      vertex -18.6496 0 14.8197
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -18.765 0 14.0093
-      vertex -11 0 40
-      vertex -18.5058 0 14.2378
+      vertex -19.2328 0 14.4496
+      vertex -12 0 40
+      vertex -18.947 0 14.6438
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.0093 0 13.765
-      vertex -11 0 40
-      vertex -18.765 0 14.0093
+      vertex -19.5058 0 14.2378
+      vertex -12 0 40
+      vertex -19.2328 0 14.4496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.2378 0 13.5058
-      vertex -11 0 40
-      vertex -19.0093 0 13.765
+      vertex -19.765 0 14.0093
+      vertex -12 0 40
+      vertex -19.5058 0 14.2378
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.4496 0 13.2328
-      vertex -11 0 40
-      vertex -19.2378 0 13.5058
+      vertex -20.0093 0 13.765
+      vertex -12 0 40
+      vertex -19.765 0 14.0093
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.6438 0 12.947
-      vertex -11 0 40
-      vertex -19.4496 0 13.2328
+      vertex -20.2378 0 13.5058
+      vertex -12 0 40
+      vertex -20.0093 0 13.765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.8197 0 12.6496
-      vertex -11 0 40
-      vertex -19.6438 0 12.947
+      vertex -20.4496 0 13.2328
+      vertex -12 0 40
+      vertex -20.2378 0 13.5058
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -30 0 0
-      vertex -19.8197 0 12.6496
-      vertex -19.9765 0 12.3418
+      vertex -20.6438 0 12.947
+      vertex -12 0 40
+      vertex -20.4496 0 13.2328
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -30 0 0
-      vertex -19.9765 0 12.3418
-      vertex -20.1138 0 12.0247
+      vertex -33 0 0
+      vertex -20.6438 0 12.947
+      vertex -20.8197 0 12.6496
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -30 0 0
-      vertex -20.1138 0 12.0247
-      vertex -20.2308 0 11.6996
+      vertex -33 0 0
+      vertex -20.8197 0 12.6496
+      vertex -20.9765 0 12.3418
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -14.6547 0 4.51085
-      vertex -30 0 0
-      vertex -15 0 4.5
+      vertex -33 0 0
+      vertex -20.9765 0 12.3418
+      vertex -21.1138 0 12.0247
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -15 0 4.5
-      vertex -30 0 0
-      vertex -15.3453 0 4.51085
+      vertex -33 0 0
+      vertex -21.1138 0 12.0247
+      vertex -21.2308 0 11.6996
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15.6547 0 4.51085
+      vertex -33 0 0
+      vertex -16 0 4.5
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -19.8197 0 12.6496
-      vertex -30 0 0
-      vertex -11 0 40
+      vertex -20.6438 0 12.947
+      vertex -33 0 0
+      vertex -12 0 40
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -20.3272 0 11.3678
-      vertex -30 0 0
-      vertex -20.2308 0 11.6996
+      vertex -21.3272 0 11.3678
+      vertex -33 0 0
+      vertex -21.2308 0 11.6996
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -20.4026 0 11.0306
-      vertex -30 0 0
-      vertex -20.3272 0 11.3678
+      vertex -21.4026 0 11.0306
+      vertex -33 0 0
+      vertex -21.3272 0 11.3678
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -20.4566 0 10.6893
-      vertex -30 0 0
-      vertex -20.4026 0 11.0306
+      vertex -21.4566 0 10.6893
+      vertex -33 0 0
+      vertex -21.4026 0 11.0306
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -20.4891 0 10.3453
-      vertex -30 0 0
-      vertex -20.4566 0 10.6893
+      vertex -21.4891 0 10.3453
+      vertex -33 0 0
+      vertex -21.4566 0 10.6893
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -20.5 0 10
-      vertex -30 0 0
-      vertex -20.4891 0 10.3453
+      vertex -21.5 0 10
+      vertex -33 0 0
+      vertex -21.4891 0 10.3453
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -20.4891 0 9.65465
-      vertex -30 0 0
-      vertex -20.5 0 10
+      vertex -21.4891 0 9.65465
+      vertex -33 0 0
+      vertex -21.5 0 10
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -20.4566 0 9.31067
-      vertex -30 0 0
-      vertex -20.4891 0 9.65465
+      vertex -21.4566 0 9.31067
+      vertex -33 0 0
+      vertex -21.4891 0 9.65465
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -20.4026 0 8.9694
-      vertex -30 0 0
-      vertex -20.4566 0 9.31067
+      vertex -21.4026 0 8.9694
+      vertex -33 0 0
+      vertex -21.4566 0 9.31067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -20.3272 0 8.63221
-      vertex -30 0 0
-      vertex -20.4026 0 8.9694
+      vertex -21.3272 0 8.63221
+      vertex -33 0 0
+      vertex -21.4026 0 8.9694
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -20.2308 0 8.30041
-      vertex -30 0 0
-      vertex -20.3272 0 8.63221
+      vertex -21.2308 0 8.30041
+      vertex -33 0 0
+      vertex -21.3272 0 8.63221
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -20.1138 0 7.97532
-      vertex -30 0 0
-      vertex -20.2308 0 8.30041
+      vertex -21.1138 0 7.97532
+      vertex -33 0 0
+      vertex -21.2308 0 8.30041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.9765 0 7.65821
-      vertex -30 0 0
-      vertex -20.1138 0 7.97532
+      vertex -20.9765 0 7.65821
+      vertex -33 0 0
+      vertex -21.1138 0 7.97532
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.8197 0 7.35036
-      vertex -30 0 0
-      vertex -19.9765 0 7.65821
+      vertex -20.8197 0 7.35036
+      vertex -33 0 0
+      vertex -20.9765 0 7.65821
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.6438 0 7.05295
-      vertex -30 0 0
-      vertex -19.8197 0 7.35036
+      vertex -20.6438 0 7.05295
+      vertex -33 0 0
+      vertex -20.8197 0 7.35036
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.4496 0 6.76718
-      vertex -30 0 0
-      vertex -19.6438 0 7.05295
+      vertex -20.4496 0 6.76718
+      vertex -33 0 0
+      vertex -20.6438 0 7.05295
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.2378 0 6.49417
-      vertex -30 0 0
-      vertex -19.4496 0 6.76718
+      vertex -20.2378 0 6.49417
+      vertex -33 0 0
+      vertex -20.4496 0 6.76718
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -19.0093 0 6.23499
-      vertex -30 0 0
-      vertex -19.2378 0 6.49417
+      vertex -20.0093 0 6.23499
+      vertex -33 0 0
+      vertex -20.2378 0 6.49417
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -18.765 0 5.99067
-      vertex -30 0 0
-      vertex -19.0093 0 6.23499
+      vertex -19.765 0 5.99067
+      vertex -33 0 0
+      vertex -20.0093 0 6.23499
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -18.5058 0 5.76218
-      vertex -30 0 0
-      vertex -18.765 0 5.99067
+      vertex -19.5058 0 5.76218
+      vertex -33 0 0
+      vertex -19.765 0 5.99067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -18.2328 0 5.55041
-      vertex -30 0 0
-      vertex -18.5058 0 5.76218
+      vertex -19.2328 0 5.55041
+      vertex -33 0 0
+      vertex -19.5058 0 5.76218
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -17.947 0 5.3562
-      vertex -30 0 0
-      vertex -18.2328 0 5.55041
+      vertex -18.947 0 5.3562
+      vertex -33 0 0
+      vertex -19.2328 0 5.55041
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -17.6496 0 5.18031
-      vertex -30 0 0
-      vertex -17.947 0 5.3562
+      vertex -18.6496 0 5.18031
+      vertex -33 0 0
+      vertex -18.947 0 5.3562
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -17.3418 0 5.02345
-      vertex -30 0 0
-      vertex -17.6496 0 5.18031
+      vertex -18.3418 0 5.02345
+      vertex -33 0 0
+      vertex -18.6496 0 5.18031
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -17.0247 0 4.88623
-      vertex -30 0 0
-      vertex -17.3418 0 5.02345
+      vertex -18.0247 0 4.88623
+      vertex -33 0 0
+      vertex -18.3418 0 5.02345
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -16.6996 0 4.76919
-      vertex -30 0 0
-      vertex -17.0247 0 4.88623
+      vertex -17.6996 0 4.76919
+      vertex -33 0 0
+      vertex -18.0247 0 4.88623
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -16.3678 0 4.67279
-      vertex -30 0 0
-      vertex -16.6996 0 4.76919
+      vertex -17.3678 0 4.67279
+      vertex -33 0 0
+      vertex -17.6996 0 4.76919
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -16.0306 0 4.59742
-      vertex -30 0 0
-      vertex -16.3678 0 4.67279
+      vertex -17.0306 0 4.59742
+      vertex -33 0 0
+      vertex -17.3678 0 4.67279
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -15.6893 0 4.54337
-      vertex -30 0 0
-      vertex -16.0306 0 4.59742
+      vertex -16.6893 0 4.54337
+      vertex -33 0 0
+      vertex -17.0306 0 4.59742
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -15.3453 0 4.51085
-      vertex -30 0 0
-      vertex -15.6893 0 4.54337
+      vertex -16.3453 0 4.51085
+      vertex -33 0 0
+      vertex -16.6893 0 4.54337
     endloop
   endfacet
-  facet normal 0.999507 -0 0.0314065
+  facet normal 0 1 0
     outer loop
-      vertex -5.5 -2.7 30
-      vertex -5.48915 0 29.6547
-      vertex -5.5 0 30
-    endloop
-  endfacet
-  facet normal 0.999507 0 0.0314065
-    outer loop
-      vertex -5.48915 0 29.6547
-      vertex -5.5 -2.7 30
-      vertex -5.48915 -2.7 29.6547
-    endloop
-  endfacet
-  facet normal 0.612964 0 0.790111
-    outer loop
-      vertex -3.50583 0 25.7622
-      vertex -3.23282 -2.7 25.5504
-      vertex -3.23282 0 25.5504
-    endloop
-  endfacet
-  facet normal 0.612964 0 0.790111
-    outer loop
-      vertex -3.23282 -2.7 25.5504
-      vertex -3.50583 0 25.7622
-      vertex -3.50583 -2.7 25.7622
-    endloop
-  endfacet
-  facet normal -0.397329 0 0.917676
-    outer loop
-      vertex 2.02468 0 24.8862
-      vertex 2.34179 -2.7 25.0235
-      vertex 2.34179 0 25.0235
-    endloop
-  endfacet
-  facet normal -0.397329 0 0.917676
-    outer loop
-      vertex 2.34179 -2.7 25.0235
-      vertex 2.02468 0 24.8862
-      vertex 2.02468 -2.7 24.8862
-    endloop
-  endfacet
-  facet normal 0.917756 -0 0.397144
-    outer loop
-      vertex -5.11377 -2.7 27.9753
-      vertex -4.97655 0 27.6582
-      vertex -5.11377 0 27.9753
-    endloop
-  endfacet
-  facet normal 0.917756 0 0.397144
-    outer loop
-      vertex -4.97655 0 27.6582
-      vertex -5.11377 -2.7 27.9753
-      vertex -4.97655 -2.7 27.6582
-    endloop
-  endfacet
-  facet normal 0.338636 0 0.940917
-    outer loop
-      vertex -2.02468 0 24.8862
-      vertex -1.69959 -2.7 24.7692
-      vertex -1.69959 0 24.7692
-    endloop
-  endfacet
-  facet normal 0.338636 0 0.940917
-    outer loop
-      vertex -1.69959 -2.7 24.7692
-      vertex -2.02468 0 24.8862
-      vertex -2.02468 -2.7 24.8862
+      vertex -16 0 4.5
+      vertex -33 0 0
+      vertex -16.3453 0 4.51085
     endloop
   endfacet
   facet normal 0.995561 -0 0.0941153
@@ -7251,158 +7181,18 @@ solid OpenSCAD_Model
       vertex -5.45663 -2.7 29.3107
     endloop
   endfacet
-  facet normal 0.975919 -0 0.218135
+  facet normal 0.999507 -0 0.0314065
     outer loop
-      vertex -5.40258 -2.7 28.9694
-      vertex -5.32721 0 28.6322
-      vertex -5.40258 0 28.9694
+      vertex -5.5 -2.7 30
+      vertex -5.48915 0 29.6547
+      vertex -5.5 0 30
     endloop
   endfacet
-  facet normal 0.975919 0 0.218135
+  facet normal 0.999507 0 0.0314065
     outer loop
-      vertex -5.32721 0 28.6322
-      vertex -5.40258 -2.7 28.9694
-      vertex -5.32721 -2.7 28.6322
-    endloop
-  endfacet
-  facet normal 0.890974 -0 0.454055
-    outer loop
-      vertex -4.97655 -2.7 27.6582
-      vertex -4.81969 0 27.3504
-      vertex -4.97655 0 27.6582
-    endloop
-  endfacet
-  facet normal 0.890974 0 0.454055
-    outer loop
-      vertex -4.81969 0 27.3504
-      vertex -4.97655 -2.7 27.6582
-      vertex -4.81969 -2.7 27.3504
-    endloop
-  endfacet
-  facet normal 0.509068 0 0.860727
-    outer loop
-      vertex -2.94705 0 25.3562
-      vertex -2.64964 -2.7 25.1803
-      vertex -2.64964 0 25.1803
-    endloop
-  endfacet
-  facet normal 0.509068 0 0.860727
-    outer loop
-      vertex -2.64964 -2.7 25.1803
-      vertex -2.94705 0 25.3562
-      vertex -2.94705 -2.7 25.3562
-    endloop
-  endfacet
-  facet normal -0.0315467 0 0.999502
-    outer loop
-      vertex 0 0 24.5
-      vertex 0.345347 -2.7 24.5109
-      vertex 0.345347 0 24.5109
-    endloop
-  endfacet
-  facet normal -0.0315467 0 0.999502
-    outer loop
-      vertex 0.345347 -2.7 24.5109
-      vertex 0 0 24.5
-      vertex 0 -2.7 24.5
-    endloop
-  endfacet
-  facet normal 0.279 0 0.960291
-    outer loop
-      vertex -1.69959 0 24.7692
-      vertex -1.36779 -2.7 24.6728
-      vertex -1.36779 0 24.6728
-    endloop
-  endfacet
-  facet normal 0.279 0 0.960291
-    outer loop
-      vertex -1.36779 -2.7 24.6728
-      vertex -1.69959 0 24.7692
-      vertex -1.69959 -2.7 24.7692
-    endloop
-  endfacet
-  facet normal -0.960291 0 0.279
-    outer loop
-      vertex 5.23081 -2.7 28.3004
-      vertex 5.32721 0 28.6322
-      vertex 5.23081 0 28.3004
-    endloop
-  endfacet
-  facet normal -0.960291 0 0.279
-    outer loop
-      vertex 5.32721 0 28.6322
-      vertex 5.23081 -2.7 28.3004
-      vertex 5.32721 -2.7 28.6322
-    endloop
-  endfacet
-  facet normal -0.860732 0 0.509059
-    outer loop
-      vertex 4.6438 -2.7 27.053
-      vertex 4.81969 0 27.3504
-      vertex 4.6438 0 27.053
-    endloop
-  endfacet
-  facet normal -0.860732 0 0.509059
-    outer loop
-      vertex 4.81969 0 27.3504
-      vertex 4.6438 -2.7 27.053
-      vertex 4.81969 -2.7 27.3504
-    endloop
-  endfacet
-  facet normal -0.790142 0 0.612924
-    outer loop
-      vertex 4.23782 -2.7 26.4942
-      vertex 4.44959 0 26.7672
-      vertex 4.23782 0 26.4942
-    endloop
-  endfacet
-  facet normal -0.790142 0 0.612924
-    outer loop
-      vertex 4.44959 0 26.7672
-      vertex 4.23782 -2.7 26.4942
-      vertex 4.44959 -2.7 26.7672
-    endloop
-  endfacet
-  facet normal -0.094062 0 0.995566
-    outer loop
-      vertex 0.345347 0 24.5109
-      vertex 0.689332 -2.7 24.5434
-      vertex 0.689332 0 24.5434
-    endloop
-  endfacet
-  facet normal -0.094062 0 0.995566
-    outer loop
-      vertex 0.689332 -2.7 24.5434
-      vertex 0.345347 0 24.5109
-      vertex 0.345347 -2.7 24.5109
-    endloop
-  endfacet
-  facet normal -0.509068 0 0.860727
-    outer loop
-      vertex 2.64964 0 25.1803
-      vertex 2.94705 -2.7 25.3562
-      vertex 2.94705 0 25.3562
-    endloop
-  endfacet
-  facet normal -0.509068 0 0.860727
-    outer loop
-      vertex 2.94705 -2.7 25.3562
-      vertex 2.64964 0 25.1803
-      vertex 2.64964 -2.7 25.1803
-    endloop
-  endfacet
-  facet normal 0.960291 0 -0.279
-    outer loop
-      vertex -5.23081 -2.7 31.6996
-      vertex -5.32721 0 31.3678
-      vertex -5.23081 0 31.6996
-    endloop
-  endfacet
-  facet normal 0.960291 0 -0.279
-    outer loop
-      vertex -5.32721 0 31.3678
-      vertex -5.23081 -2.7 31.6996
-      vertex -5.32721 -2.7 31.3678
+      vertex -5.48915 0 29.6547
+      vertex -5.5 -2.7 30
+      vertex -5.48915 -2.7 29.6547
     endloop
   endfacet
   facet normal 0.790142 0 -0.612924
@@ -7419,384 +7209,6 @@ solid OpenSCAD_Model
       vertex -4.44959 -2.7 33.2328
     endloop
   endfacet
-  facet normal 0.094062 0 -0.995566
-    outer loop
-      vertex -0.689332 -2.7 35.4566
-      vertex -0.345347 0 35.4891
-      vertex -0.345347 -2.7 35.4891
-    endloop
-  endfacet
-  facet normal 0.094062 0 -0.995566
-    outer loop
-      vertex -0.345347 0 35.4891
-      vertex -0.689332 -2.7 35.4566
-      vertex -0.689332 0 35.4566
-    endloop
-  endfacet
-  facet normal 0.661315 0 -0.750108
-    outer loop
-      vertex -3.76501 -2.7 34.0093
-      vertex -3.50583 0 34.2378
-      vertex -3.50583 -2.7 34.2378
-    endloop
-  endfacet
-  facet normal 0.661315 0 -0.750108
-    outer loop
-      vertex -3.50583 0 34.2378
-      vertex -3.76501 -2.7 34.0093
-      vertex -3.76501 0 34.0093
-    endloop
-  endfacet
-  facet normal -0.279 0 -0.960291
-    outer loop
-      vertex 1.36779 -2.7 35.3272
-      vertex 1.69959 0 35.2308
-      vertex 1.69959 -2.7 35.2308
-    endloop
-  endfacet
-  facet normal -0.279 0 -0.960291
-    outer loop
-      vertex 1.69959 0 35.2308
-      vertex 1.36779 -2.7 35.3272
-      vertex 1.36779 0 35.3272
-    endloop
-  endfacet
-  facet normal -0.612964 0 -0.790111
-    outer loop
-      vertex 3.23282 -2.7 34.4496
-      vertex 3.50583 0 34.2378
-      vertex 3.50583 -2.7 34.2378
-    endloop
-  endfacet
-  facet normal -0.612964 0 -0.790111
-    outer loop
-      vertex 3.50583 0 34.2378
-      vertex 3.23282 -2.7 34.4496
-      vertex 3.23282 0 34.4496
-    endloop
-  endfacet
-  facet normal -0.995561 0 -0.0941153
-    outer loop
-      vertex 5.48915 -2.7 30.3453
-      vertex 5.45663 0 30.6893
-      vertex 5.48915 0 30.3453
-    endloop
-  endfacet
-  facet normal -0.995561 -0 -0.0941153
-    outer loop
-      vertex 5.45663 0 30.6893
-      vertex 5.48915 -2.7 30.3453
-      vertex 5.45663 -2.7 30.6893
-    endloop
-  endfacet
-  facet normal 0.940884 -0 0.33873
-    outer loop
-      vertex -5.23081 -2.7 28.3004
-      vertex -5.11377 0 27.9753
-      vertex -5.23081 0 28.3004
-    endloop
-  endfacet
-  facet normal 0.940884 0 0.33873
-    outer loop
-      vertex -5.11377 0 27.9753
-      vertex -5.23081 -2.7 28.3004
-      vertex -5.11377 -2.7 27.9753
-    endloop
-  endfacet
-  facet normal 0.960291 -0 0.279
-    outer loop
-      vertex -5.32721 -2.7 28.6322
-      vertex -5.23081 0 28.3004
-      vertex -5.32721 0 28.6322
-    endloop
-  endfacet
-  facet normal 0.960291 0 0.279
-    outer loop
-      vertex -5.23081 0 28.3004
-      vertex -5.32721 -2.7 28.6322
-      vertex -5.23081 -2.7 28.3004
-    endloop
-  endfacet
-  facet normal 0.860732 -0 0.509059
-    outer loop
-      vertex -4.81969 -2.7 27.3504
-      vertex -4.6438 0 27.053
-      vertex -4.81969 0 27.3504
-    endloop
-  endfacet
-  facet normal 0.860732 0 0.509059
-    outer loop
-      vertex -4.6438 0 27.053
-      vertex -4.81969 -2.7 27.3504
-      vertex -4.6438 -2.7 27.053
-    endloop
-  endfacet
-  facet normal 0.750148 -0 0.66127
-    outer loop
-      vertex -4.23782 -2.7 26.4942
-      vertex -4.00933 0 26.235
-      vertex -4.23782 0 26.4942
-    endloop
-  endfacet
-  facet normal 0.750148 0 0.66127
-    outer loop
-      vertex -4.00933 0 26.235
-      vertex -4.23782 -2.7 26.4942
-      vertex -4.00933 -2.7 26.235
-    endloop
-  endfacet
-  facet normal 0.661315 0 0.750108
-    outer loop
-      vertex -3.76501 0 25.9907
-      vertex -3.50583 -2.7 25.7622
-      vertex -3.50583 0 25.7622
-    endloop
-  endfacet
-  facet normal 0.661315 0 0.750108
-    outer loop
-      vertex -3.50583 -2.7 25.7622
-      vertex -3.76501 0 25.9907
-      vertex -3.76501 -2.7 25.9907
-    endloop
-  endfacet
-  facet normal 0.562065 0 0.827093
-    outer loop
-      vertex -3.23282 0 25.5504
-      vertex -2.94705 -2.7 25.3562
-      vertex -2.94705 0 25.3562
-    endloop
-  endfacet
-  facet normal 0.562065 0 0.827093
-    outer loop
-      vertex -2.94705 -2.7 25.3562
-      vertex -3.23282 0 25.5504
-      vertex -3.23282 -2.7 25.5504
-    endloop
-  endfacet
-  facet normal 0.397329 0 0.917676
-    outer loop
-      vertex -2.34179 0 25.0235
-      vertex -2.02468 -2.7 24.8862
-      vertex -2.02468 0 24.8862
-    endloop
-  endfacet
-  facet normal 0.397329 0 0.917676
-    outer loop
-      vertex -2.02468 -2.7 24.8862
-      vertex -2.34179 0 25.0235
-      vertex -2.34179 -2.7 25.0235
-    endloop
-  endfacet
-  facet normal 0.453859 0 0.891074
-    outer loop
-      vertex -2.64964 0 25.1803
-      vertex -2.34179 -2.7 25.0235
-      vertex -2.34179 0 25.0235
-    endloop
-  endfacet
-  facet normal 0.453859 0 0.891074
-    outer loop
-      vertex -2.34179 -2.7 25.0235
-      vertex -2.64964 0 25.1803
-      vertex -2.64964 -2.7 25.1803
-    endloop
-  endfacet
-  facet normal 0.094062 0 0.995566
-    outer loop
-      vertex -0.689332 0 24.5434
-      vertex -0.345347 -2.7 24.5109
-      vertex -0.345347 0 24.5109
-    endloop
-  endfacet
-  facet normal 0.094062 0 0.995566
-    outer loop
-      vertex -0.345347 -2.7 24.5109
-      vertex -0.689332 0 24.5434
-      vertex -0.689332 -2.7 24.5434
-    endloop
-  endfacet
-  facet normal 0.0315467 0 0.999502
-    outer loop
-      vertex -0.345347 0 24.5109
-      vertex 0 -2.7 24.5
-      vertex 0 0 24.5
-    endloop
-  endfacet
-  facet normal 0.0315467 0 0.999502
-    outer loop
-      vertex 0 -2.7 24.5
-      vertex -0.345347 0 24.5109
-      vertex -0.345347 -2.7 24.5109
-    endloop
-  endfacet
-  facet normal -0.995561 0 0.0941153
-    outer loop
-      vertex 5.45663 -2.7 29.3107
-      vertex 5.48915 0 29.6547
-      vertex 5.45663 0 29.3107
-    endloop
-  endfacet
-  facet normal -0.995561 0 0.0941153
-    outer loop
-      vertex 5.48915 0 29.6547
-      vertex 5.45663 -2.7 29.3107
-      vertex 5.48915 -2.7 29.6547
-    endloop
-  endfacet
-  facet normal -0.999507 0 0.0314065
-    outer loop
-      vertex 5.48915 -2.7 29.6547
-      vertex 5.5 0 30
-      vertex 5.48915 0 29.6547
-    endloop
-  endfacet
-  facet normal -0.999507 0 0.0314065
-    outer loop
-      vertex 5.5 0 30
-      vertex 5.48915 -2.7 29.6547
-      vertex 5.5 -2.7 30
-    endloop
-  endfacet
-  facet normal -0.999507 0 -0.0314065
-    outer loop
-      vertex 5.5 -2.7 30
-      vertex 5.48915 0 30.3453
-      vertex 5.5 0 30
-    endloop
-  endfacet
-  facet normal -0.999507 -0 -0.0314065
-    outer loop
-      vertex 5.48915 0 30.3453
-      vertex 5.5 -2.7 30
-      vertex 5.48915 -2.7 30.3453
-    endloop
-  endfacet
-  facet normal -0.890974 0 0.454055
-    outer loop
-      vertex 4.81969 -2.7 27.3504
-      vertex 4.97655 0 27.6582
-      vertex 4.81969 0 27.3504
-    endloop
-  endfacet
-  facet normal -0.890974 0 0.454055
-    outer loop
-      vertex 4.97655 0 27.6582
-      vertex 4.81969 -2.7 27.3504
-      vertex 4.97655 -2.7 27.6582
-    endloop
-  endfacet
-  facet normal -0.917756 0 0.397144
-    outer loop
-      vertex 4.97655 -2.7 27.6582
-      vertex 5.11377 0 27.9753
-      vertex 4.97655 0 27.6582
-    endloop
-  endfacet
-  facet normal -0.917756 0 0.397144
-    outer loop
-      vertex 5.11377 0 27.9753
-      vertex 4.97655 -2.7 27.6582
-      vertex 5.11377 -2.7 27.9753
-    endloop
-  endfacet
-  facet normal -0.940884 0 0.33873
-    outer loop
-      vertex 5.11377 -2.7 27.9753
-      vertex 5.23081 0 28.3004
-      vertex 5.11377 0 27.9753
-    endloop
-  endfacet
-  facet normal -0.940884 0 0.33873
-    outer loop
-      vertex 5.23081 0 28.3004
-      vertex 5.11377 -2.7 27.9753
-      vertex 5.23081 -2.7 28.3004
-    endloop
-  endfacet
-  facet normal -0.827107 0 0.562045
-    outer loop
-      vertex 4.44959 -2.7 26.7672
-      vertex 4.6438 0 27.053
-      vertex 4.44959 0 26.7672
-    endloop
-  endfacet
-  facet normal -0.827107 0 0.562045
-    outer loop
-      vertex 4.6438 0 27.053
-      vertex 4.44959 -2.7 26.7672
-      vertex 4.6438 -2.7 27.053
-    endloop
-  endfacet
-  facet normal -0.279 0 0.960291
-    outer loop
-      vertex 1.36779 0 24.6728
-      vertex 1.69959 -2.7 24.7692
-      vertex 1.69959 0 24.7692
-    endloop
-  endfacet
-  facet normal -0.279 0 0.960291
-    outer loop
-      vertex 1.69959 -2.7 24.7692
-      vertex 1.36779 0 24.6728
-      vertex 1.36779 -2.7 24.6728
-    endloop
-  endfacet
-  facet normal -0.338636 0 0.940917
-    outer loop
-      vertex 1.69959 0 24.7692
-      vertex 2.02468 -2.7 24.8862
-      vertex 2.02468 0 24.8862
-    endloop
-  endfacet
-  facet normal -0.338636 0 0.940917
-    outer loop
-      vertex 2.02468 -2.7 24.8862
-      vertex 1.69959 0 24.7692
-      vertex 1.69959 -2.7 24.7692
-    endloop
-  endfacet
-  facet normal -0.453859 0 0.891074
-    outer loop
-      vertex 2.34179 0 25.0235
-      vertex 2.64964 -2.7 25.1803
-      vertex 2.64964 0 25.1803
-    endloop
-  endfacet
-  facet normal -0.453859 0 0.891074
-    outer loop
-      vertex 2.64964 -2.7 25.1803
-      vertex 2.34179 0 25.0235
-      vertex 2.34179 -2.7 25.0235
-    endloop
-  endfacet
-  facet normal -0.661315 0 0.750108
-    outer loop
-      vertex 3.50583 0 25.7622
-      vertex 3.76501 -2.7 25.9907
-      vertex 3.76501 0 25.9907
-    endloop
-  endfacet
-  facet normal -0.661315 0 0.750108
-    outer loop
-      vertex 3.76501 -2.7 25.9907
-      vertex 3.50583 0 25.7622
-      vertex 3.50583 -2.7 25.7622
-    endloop
-  endfacet
-  facet normal -0.750148 0 0.66127
-    outer loop
-      vertex 4.00933 -2.7 26.235
-      vertex 4.23782 0 26.4942
-      vertex 4.00933 0 26.235
-    endloop
-  endfacet
-  facet normal -0.750148 0 0.66127
-    outer loop
-      vertex 4.23782 0 26.4942
-      vertex 4.00933 -2.7 26.235
-      vertex 4.23782 -2.7 26.4942
-    endloop
-  endfacet
   facet normal 0.975919 0 -0.218135
     outer loop
       vertex -5.32721 -2.7 31.3678
@@ -7811,102 +7223,74 @@ solid OpenSCAD_Model
       vertex -5.40258 -2.7 31.0306
     endloop
   endfacet
-  facet normal 0.940884 0 -0.33873
+  facet normal -0.960291 0 0.279
     outer loop
-      vertex -5.11377 -2.7 32.0247
-      vertex -5.23081 0 31.6996
-      vertex -5.11377 0 32.0247
+      vertex 5.23081 -2.7 28.3004
+      vertex 5.32721 0 28.6322
+      vertex 5.23081 0 28.3004
     endloop
   endfacet
-  facet normal 0.940884 0 -0.33873
+  facet normal -0.960291 0 0.279
     outer loop
-      vertex -5.23081 0 31.6996
-      vertex -5.11377 -2.7 32.0247
-      vertex -5.23081 -2.7 31.6996
+      vertex 5.32721 0 28.6322
+      vertex 5.23081 -2.7 28.3004
+      vertex 5.32721 -2.7 28.6322
     endloop
   endfacet
-  facet normal 0.397329 0 -0.917676
+  facet normal -0.509068 0 0.860727
     outer loop
-      vertex -2.34179 -2.7 34.9765
-      vertex -2.02468 0 35.1138
-      vertex -2.02468 -2.7 35.1138
+      vertex 2.64964 0 25.1803
+      vertex 2.94705 -2.7 25.3562
+      vertex 2.94705 0 25.3562
     endloop
   endfacet
-  facet normal 0.397329 0 -0.917676
+  facet normal -0.509068 0 0.860727
     outer loop
-      vertex -2.02468 0 35.1138
-      vertex -2.34179 -2.7 34.9765
-      vertex -2.34179 0 34.9765
+      vertex 2.94705 -2.7 25.3562
+      vertex 2.64964 0 25.1803
+      vertex 2.64964 -2.7 25.1803
     endloop
   endfacet
-  facet normal 0.279 0 -0.960291
+  facet normal 0.890974 -0 0.454055
     outer loop
-      vertex -1.69959 -2.7 35.2308
-      vertex -1.36779 0 35.3272
+      vertex -4.97655 -2.7 27.6582
+      vertex -4.81969 0 27.3504
+      vertex -4.97655 0 27.6582
+    endloop
+  endfacet
+  facet normal 0.890974 0 0.454055
+    outer loop
+      vertex -4.81969 0 27.3504
+      vertex -4.97655 -2.7 27.6582
+      vertex -4.81969 -2.7 27.3504
+    endloop
+  endfacet
+  facet normal -0.397329 0 0.917676
+    outer loop
+      vertex 2.02468 0 24.8862
+      vertex 2.34179 -2.7 25.0235
+      vertex 2.34179 0 25.0235
+    endloop
+  endfacet
+  facet normal -0.397329 0 0.917676
+    outer loop
+      vertex 2.34179 -2.7 25.0235
+      vertex 2.02468 0 24.8862
+      vertex 2.02468 -2.7 24.8862
+    endloop
+  endfacet
+  facet normal 0.218223 0 -0.975899
+    outer loop
       vertex -1.36779 -2.7 35.3272
+      vertex -1.0306 0 35.4026
+      vertex -1.0306 -2.7 35.4026
     endloop
   endfacet
-  facet normal 0.279 0 -0.960291
+  facet normal 0.218223 0 -0.975899
     outer loop
+      vertex -1.0306 0 35.4026
+      vertex -1.36779 -2.7 35.3272
       vertex -1.36779 0 35.3272
-      vertex -1.69959 -2.7 35.2308
-      vertex -1.69959 0 35.2308
-    endloop
-  endfacet
-  facet normal 0.453859 0 -0.891074
-    outer loop
-      vertex -2.64964 -2.7 34.8197
-      vertex -2.34179 0 34.9765
-      vertex -2.34179 -2.7 34.9765
-    endloop
-  endfacet
-  facet normal 0.453859 0 -0.891074
-    outer loop
-      vertex -2.34179 0 34.9765
-      vertex -2.64964 -2.7 34.8197
-      vertex -2.64964 0 34.8197
-    endloop
-  endfacet
-  facet normal -0.094062 0 -0.995566
-    outer loop
-      vertex 0.345347 -2.7 35.4891
-      vertex 0.689332 0 35.4566
-      vertex 0.689332 -2.7 35.4566
-    endloop
-  endfacet
-  facet normal -0.094062 0 -0.995566
-    outer loop
-      vertex 0.689332 0 35.4566
-      vertex 0.345347 -2.7 35.4891
-      vertex 0.345347 0 35.4891
-    endloop
-  endfacet
-  facet normal 0.0315467 0 -0.999502
-    outer loop
-      vertex -0.345347 -2.7 35.4891
-      vertex 0 0 35.5
-      vertex 0 -2.7 35.5
-    endloop
-  endfacet
-  facet normal 0.0315467 0 -0.999502
-    outer loop
-      vertex 0 0 35.5
-      vertex -0.345347 -2.7 35.4891
-      vertex -0.345347 0 35.4891
-    endloop
-  endfacet
-  facet normal -0.453859 0 -0.891074
-    outer loop
-      vertex 2.34179 -2.7 34.9765
-      vertex 2.64964 0 34.8197
-      vertex 2.64964 -2.7 34.8197
-    endloop
-  endfacet
-  facet normal -0.453859 0 -0.891074
-    outer loop
-      vertex 2.64964 0 34.8197
-      vertex 2.34179 -2.7 34.9765
-      vertex 2.34179 0 34.9765
     endloop
   endfacet
   facet normal -0.338636 0 -0.940917
@@ -7923,18 +7307,1152 @@ solid OpenSCAD_Model
       vertex 1.69959 0 35.2308
     endloop
   endfacet
-  facet normal -0.509068 0 -0.860727
+  facet normal -0.338636 0 0.940917
+    outer loop
+      vertex 1.69959 0 24.7692
+      vertex 2.02468 -2.7 24.8862
+      vertex 2.02468 0 24.8862
+    endloop
+  endfacet
+  facet normal -0.338636 0 0.940917
+    outer loop
+      vertex 2.02468 -2.7 24.8862
+      vertex 1.69959 0 24.7692
+      vertex 1.69959 -2.7 24.7692
+    endloop
+  endfacet
+  facet normal 0.975919 -0 0.218135
+    outer loop
+      vertex -5.40258 -2.7 28.9694
+      vertex -5.32721 0 28.6322
+      vertex -5.40258 0 28.9694
+    endloop
+  endfacet
+  facet normal 0.975919 0 0.218135
+    outer loop
+      vertex -5.32721 0 28.6322
+      vertex -5.40258 -2.7 28.9694
+      vertex -5.32721 -2.7 28.6322
+    endloop
+  endfacet
+  facet normal 0.218223 0 0.975899
+    outer loop
+      vertex -1.36779 0 24.6728
+      vertex -1.0306 -2.7 24.5974
+      vertex -1.0306 0 24.5974
+    endloop
+  endfacet
+  facet normal 0.218223 0 0.975899
+    outer loop
+      vertex -1.0306 -2.7 24.5974
+      vertex -1.36779 0 24.6728
+      vertex -1.36779 -2.7 24.6728
+    endloop
+  endfacet
+  facet normal 0.917756 0 -0.397144
+    outer loop
+      vertex -4.97655 -2.7 32.3418
+      vertex -5.11377 0 32.0247
+      vertex -4.97655 0 32.3418
+    endloop
+  endfacet
+  facet normal 0.917756 0 -0.397144
+    outer loop
+      vertex -5.11377 0 32.0247
+      vertex -4.97655 -2.7 32.3418
+      vertex -5.11377 -2.7 32.0247
+    endloop
+  endfacet
+  facet normal 0.890974 0 -0.454055
+    outer loop
+      vertex -4.81969 -2.7 32.6496
+      vertex -4.97655 0 32.3418
+      vertex -4.81969 0 32.6496
+    endloop
+  endfacet
+  facet normal 0.890974 0 -0.454055
+    outer loop
+      vertex -4.97655 0 32.3418
+      vertex -4.81969 -2.7 32.6496
+      vertex -4.97655 -2.7 32.3418
+    endloop
+  endfacet
+  facet normal -0.612964 0 -0.790111
+    outer loop
+      vertex 3.23282 -2.7 34.4496
+      vertex 3.50583 0 34.2378
+      vertex 3.50583 -2.7 34.2378
+    endloop
+  endfacet
+  facet normal -0.612964 0 -0.790111
+    outer loop
+      vertex 3.50583 0 34.2378
+      vertex 3.23282 -2.7 34.4496
+      vertex 3.23282 0 34.4496
+    endloop
+  endfacet
+  facet normal 0.860732 -0 0.509059
+    outer loop
+      vertex -4.81969 -2.7 27.3504
+      vertex -4.6438 0 27.053
+      vertex -4.81969 0 27.3504
+    endloop
+  endfacet
+  facet normal 0.860732 0 0.509059
+    outer loop
+      vertex -4.6438 0 27.053
+      vertex -4.81969 -2.7 27.3504
+      vertex -4.6438 -2.7 27.053
+    endloop
+  endfacet
+  facet normal 0.156289 0 -0.987711
+    outer loop
+      vertex -1.0306 -2.7 35.4026
+      vertex -0.689332 0 35.4566
+      vertex -0.689332 -2.7 35.4566
+    endloop
+  endfacet
+  facet normal 0.156289 0 -0.987711
+    outer loop
+      vertex -0.689332 0 35.4566
+      vertex -1.0306 -2.7 35.4026
+      vertex -1.0306 0 35.4026
+    endloop
+  endfacet
+  facet normal 0.860732 0 -0.509059
+    outer loop
+      vertex -4.6438 -2.7 32.947
+      vertex -4.81969 0 32.6496
+      vertex -4.6438 0 32.947
+    endloop
+  endfacet
+  facet normal 0.860732 0 -0.509059
+    outer loop
+      vertex -4.81969 0 32.6496
+      vertex -4.6438 -2.7 32.947
+      vertex -4.81969 -2.7 32.6496
+    endloop
+  endfacet
+  facet normal 0.0315467 0 0.999502
+    outer loop
+      vertex -0.345347 0 24.5109
+      vertex 0 -2.7 24.5
+      vertex 0 0 24.5
+    endloop
+  endfacet
+  facet normal 0.0315467 0 0.999502
+    outer loop
+      vertex 0 -2.7 24.5
+      vertex -0.345347 0 24.5109
+      vertex -0.345347 -2.7 24.5109
+    endloop
+  endfacet
+  facet normal -0.995561 0 -0.0941153
+    outer loop
+      vertex 5.48915 -2.7 30.3453
+      vertex 5.45663 0 30.6893
+      vertex 5.48915 0 30.3453
+    endloop
+  endfacet
+  facet normal -0.995561 -0 -0.0941153
+    outer loop
+      vertex 5.45663 0 30.6893
+      vertex 5.48915 -2.7 30.3453
+      vertex 5.45663 -2.7 30.6893
+    endloop
+  endfacet
+  facet normal -0.890974 0 0.454055
+    outer loop
+      vertex 4.81969 -2.7 27.3504
+      vertex 4.97655 0 27.6582
+      vertex 4.81969 0 27.3504
+    endloop
+  endfacet
+  facet normal -0.890974 0 0.454055
+    outer loop
+      vertex 4.97655 0 27.6582
+      vertex 4.81969 -2.7 27.3504
+      vertex 4.97655 -2.7 27.6582
+    endloop
+  endfacet
+  facet normal 0.960291 -0 0.279
+    outer loop
+      vertex -5.32721 -2.7 28.6322
+      vertex -5.23081 0 28.3004
+      vertex -5.32721 0 28.6322
+    endloop
+  endfacet
+  facet normal 0.960291 0 0.279
+    outer loop
+      vertex -5.23081 0 28.3004
+      vertex -5.32721 -2.7 28.6322
+      vertex -5.23081 -2.7 28.3004
+    endloop
+  endfacet
+  facet normal 0.661315 0 -0.750108
+    outer loop
+      vertex -3.76501 -2.7 34.0093
+      vertex -3.50583 0 34.2378
+      vertex -3.50583 -2.7 34.2378
+    endloop
+  endfacet
+  facet normal 0.661315 0 -0.750108
+    outer loop
+      vertex -3.50583 0 34.2378
+      vertex -3.76501 -2.7 34.0093
+      vertex -3.76501 0 34.0093
+    endloop
+  endfacet
+  facet normal 0.397329 0 0.917676
+    outer loop
+      vertex -2.34179 0 25.0235
+      vertex -2.02468 -2.7 24.8862
+      vertex -2.02468 0 24.8862
+    endloop
+  endfacet
+  facet normal 0.397329 0 0.917676
+    outer loop
+      vertex -2.02468 -2.7 24.8862
+      vertex -2.34179 0 25.0235
+      vertex -2.34179 -2.7 25.0235
+    endloop
+  endfacet
+  facet normal 0.338636 0 -0.940917
+    outer loop
+      vertex -2.02468 -2.7 35.1138
+      vertex -1.69959 0 35.2308
+      vertex -1.69959 -2.7 35.2308
+    endloop
+  endfacet
+  facet normal 0.338636 0 -0.940917
+    outer loop
+      vertex -1.69959 0 35.2308
+      vertex -2.02468 -2.7 35.1138
+      vertex -2.02468 0 35.1138
+    endloop
+  endfacet
+  facet normal 0.987691 0 -0.156416
+    outer loop
+      vertex -5.40258 -2.7 31.0306
+      vertex -5.45663 0 30.6893
+      vertex -5.40258 0 31.0306
+    endloop
+  endfacet
+  facet normal 0.987691 0 -0.156416
+    outer loop
+      vertex -5.45663 0 30.6893
+      vertex -5.40258 -2.7 31.0306
+      vertex -5.45663 -2.7 30.6893
+    endloop
+  endfacet
+  facet normal -0.790142 0 -0.612924
+    outer loop
+      vertex 4.44959 -2.7 33.2328
+      vertex 4.23782 0 33.5058
+      vertex 4.44959 0 33.2328
+    endloop
+  endfacet
+  facet normal -0.790142 -0 -0.612924
+    outer loop
+      vertex 4.23782 0 33.5058
+      vertex 4.44959 -2.7 33.2328
+      vertex 4.23782 -2.7 33.5058
+    endloop
+  endfacet
+  facet normal -0.750148 0 -0.66127
+    outer loop
+      vertex 4.23782 -2.7 33.5058
+      vertex 4.00933 0 33.765
+      vertex 4.23782 0 33.5058
+    endloop
+  endfacet
+  facet normal -0.750148 -0 -0.66127
+    outer loop
+      vertex 4.00933 0 33.765
+      vertex 4.23782 -2.7 33.5058
+      vertex 4.00933 -2.7 33.765
+    endloop
+  endfacet
+  facet normal -0.661315 0 0.750108
+    outer loop
+      vertex 3.50583 0 25.7622
+      vertex 3.76501 -2.7 25.9907
+      vertex 3.76501 0 25.9907
+    endloop
+  endfacet
+  facet normal -0.661315 0 0.750108
+    outer loop
+      vertex 3.76501 -2.7 25.9907
+      vertex 3.50583 0 25.7622
+      vertex 3.50583 -2.7 25.7622
+    endloop
+  endfacet
+  facet normal -0.940884 0 0.33873
+    outer loop
+      vertex 5.11377 -2.7 27.9753
+      vertex 5.23081 0 28.3004
+      vertex 5.11377 0 27.9753
+    endloop
+  endfacet
+  facet normal -0.940884 0 0.33873
+    outer loop
+      vertex 5.23081 0 28.3004
+      vertex 5.11377 -2.7 27.9753
+      vertex 5.23081 -2.7 28.3004
+    endloop
+  endfacet
+  facet normal -0.999507 0 -0.0314065
+    outer loop
+      vertex 5.5 -2.7 30
+      vertex 5.48915 0 30.3453
+      vertex 5.5 0 30
+    endloop
+  endfacet
+  facet normal -0.999507 -0 -0.0314065
+    outer loop
+      vertex 5.48915 0 30.3453
+      vertex 5.5 -2.7 30
+      vertex 5.48915 -2.7 30.3453
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.345347 -2.7 35.4891
+      vertex -0.345347 -2.7 35.4891
+      vertex 0 -2.7 35.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.689332 -2.7 35.4566
+      vertex -0.345347 -2.7 35.4891
+      vertex 0.345347 -2.7 35.4891
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.689332 -2.7 35.4566
+      vertex -0.689332 -2.7 35.4566
+      vertex -0.345347 -2.7 35.4891
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.0306 -2.7 35.4026
+      vertex -0.689332 -2.7 35.4566
+      vertex 0.689332 -2.7 35.4566
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.0306 -2.7 35.4026
+      vertex -1.0306 -2.7 35.4026
+      vertex -0.689332 -2.7 35.4566
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.36779 -2.7 35.3272
+      vertex -1.0306 -2.7 35.4026
+      vertex 1.0306 -2.7 35.4026
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.36779 -2.7 35.3272
+      vertex -1.36779 -2.7 35.3272
+      vertex -1.0306 -2.7 35.4026
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.69959 -2.7 35.2308
+      vertex -1.36779 -2.7 35.3272
+      vertex 1.36779 -2.7 35.3272
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.69959 -2.7 35.2308
+      vertex -1.69959 -2.7 35.2308
+      vertex -1.36779 -2.7 35.3272
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.02468 -2.7 35.1138
+      vertex -1.69959 -2.7 35.2308
+      vertex 1.69959 -2.7 35.2308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.02468 -2.7 35.1138
+      vertex -2.02468 -2.7 35.1138
+      vertex -1.69959 -2.7 35.2308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.34179 -2.7 34.9765
+      vertex -2.02468 -2.7 35.1138
+      vertex 2.02468 -2.7 35.1138
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.34179 -2.7 34.9765
+      vertex -2.34179 -2.7 34.9765
+      vertex -2.02468 -2.7 35.1138
+    endloop
+  endfacet
+  facet normal 0 1 0
     outer loop
       vertex 2.64964 -2.7 34.8197
-      vertex 2.94705 0 34.6438
+      vertex -2.34179 -2.7 34.9765
+      vertex 2.34179 -2.7 34.9765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.64964 -2.7 34.8197
+      vertex -2.64964 -2.7 34.8197
+      vertex -2.34179 -2.7 34.9765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.94705 -2.7 34.6438
+      vertex -2.64964 -2.7 34.8197
+      vertex 2.64964 -2.7 34.8197
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.94705 -2.7 34.6438
+      vertex -2.94705 -2.7 34.6438
+      vertex -2.64964 -2.7 34.8197
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.23282 -2.7 34.4496
+      vertex -2.94705 -2.7 34.6438
       vertex 2.94705 -2.7 34.6438
     endloop
   endfacet
-  facet normal -0.509068 0 -0.860727
+  facet normal 0 1 0
     outer loop
-      vertex 2.94705 0 34.6438
-      vertex 2.64964 -2.7 34.8197
-      vertex 2.64964 0 34.8197
+      vertex 3.23282 -2.7 34.4496
+      vertex -3.23282 -2.7 34.4496
+      vertex -2.94705 -2.7 34.6438
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.50583 -2.7 34.2378
+      vertex -3.23282 -2.7 34.4496
+      vertex 3.23282 -2.7 34.4496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.50583 -2.7 34.2378
+      vertex -3.50583 -2.7 34.2378
+      vertex -3.23282 -2.7 34.4496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.76501 -2.7 34.0093
+      vertex -3.50583 -2.7 34.2378
+      vertex 3.50583 -2.7 34.2378
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.76501 -2.7 34.0093
+      vertex -3.76501 -2.7 34.0093
+      vertex -3.50583 -2.7 34.2378
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.00933 -2.7 33.765
+      vertex -3.76501 -2.7 34.0093
+      vertex 3.76501 -2.7 34.0093
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.00933 -2.7 33.765
+      vertex -4.00933 -2.7 33.765
+      vertex -3.76501 -2.7 34.0093
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.23782 -2.7 33.5058
+      vertex -4.00933 -2.7 33.765
+      vertex 4.00933 -2.7 33.765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.23782 -2.7 33.5058
+      vertex -4.23782 -2.7 33.5058
+      vertex -4.00933 -2.7 33.765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.44959 -2.7 33.2328
+      vertex -4.23782 -2.7 33.5058
+      vertex 4.23782 -2.7 33.5058
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.44959 -2.7 33.2328
+      vertex -4.44959 -2.7 33.2328
+      vertex -4.23782 -2.7 33.5058
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.6438 -2.7 32.947
+      vertex -4.44959 -2.7 33.2328
+      vertex 4.44959 -2.7 33.2328
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.6438 -2.7 32.947
+      vertex -4.6438 -2.7 32.947
+      vertex -4.44959 -2.7 33.2328
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.81969 -2.7 32.6496
+      vertex -4.6438 -2.7 32.947
+      vertex 4.6438 -2.7 32.947
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.81969 -2.7 32.6496
+      vertex -4.81969 -2.7 32.6496
+      vertex -4.6438 -2.7 32.947
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.97655 -2.7 32.3418
+      vertex -4.81969 -2.7 32.6496
+      vertex 4.81969 -2.7 32.6496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.97655 -2.7 32.3418
+      vertex -4.97655 -2.7 32.3418
+      vertex -4.81969 -2.7 32.6496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.11377 -2.7 32.0247
+      vertex -4.97655 -2.7 32.3418
+      vertex 4.97655 -2.7 32.3418
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.11377 -2.7 32.0247
+      vertex -5.11377 -2.7 32.0247
+      vertex -4.97655 -2.7 32.3418
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.23081 -2.7 31.6996
+      vertex -5.11377 -2.7 32.0247
+      vertex 5.11377 -2.7 32.0247
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.23081 -2.7 31.6996
+      vertex -5.23081 -2.7 31.6996
+      vertex -5.11377 -2.7 32.0247
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.32721 -2.7 31.3678
+      vertex -5.23081 -2.7 31.6996
+      vertex 5.23081 -2.7 31.6996
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.32721 -2.7 31.3678
+      vertex -5.32721 -2.7 31.3678
+      vertex -5.23081 -2.7 31.6996
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.40258 -2.7 31.0306
+      vertex -5.32721 -2.7 31.3678
+      vertex 5.32721 -2.7 31.3678
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.40258 -2.7 31.0306
+      vertex -5.40258 -2.7 31.0306
+      vertex -5.32721 -2.7 31.3678
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.45663 -2.7 30.6893
+      vertex -5.40258 -2.7 31.0306
+      vertex 5.40258 -2.7 31.0306
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.45663 -2.7 30.6893
+      vertex -5.45663 -2.7 30.6893
+      vertex -5.40258 -2.7 31.0306
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.48915 -2.7 30.3453
+      vertex -5.45663 -2.7 30.6893
+      vertex 5.45663 -2.7 30.6893
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.48915 -2.7 30.3453
+      vertex -5.48915 -2.7 30.3453
+      vertex -5.45663 -2.7 30.6893
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.5 -2.7 30
+      vertex -5.48915 -2.7 30.3453
+      vertex 5.48915 -2.7 30.3453
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.5 -2.7 30
+      vertex -5.5 -2.7 30
+      vertex -5.48915 -2.7 30.3453
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.48915 -2.7 29.6547
+      vertex -5.5 -2.7 30
+      vertex 5.5 -2.7 30
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.48915 -2.7 29.6547
+      vertex -5.48915 -2.7 29.6547
+      vertex -5.5 -2.7 30
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.45663 -2.7 29.3107
+      vertex -5.48915 -2.7 29.6547
+      vertex 5.48915 -2.7 29.6547
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.45663 -2.7 29.3107
+      vertex -5.45663 -2.7 29.3107
+      vertex -5.48915 -2.7 29.6547
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.40258 -2.7 28.9694
+      vertex -5.45663 -2.7 29.3107
+      vertex 5.45663 -2.7 29.3107
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.40258 -2.7 28.9694
+      vertex -5.40258 -2.7 28.9694
+      vertex -5.45663 -2.7 29.3107
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.32721 -2.7 28.6322
+      vertex -5.40258 -2.7 28.9694
+      vertex 5.40258 -2.7 28.9694
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.32721 -2.7 28.6322
+      vertex -5.32721 -2.7 28.6322
+      vertex -5.40258 -2.7 28.9694
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.23081 -2.7 28.3004
+      vertex -5.32721 -2.7 28.6322
+      vertex 5.32721 -2.7 28.6322
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.23081 -2.7 28.3004
+      vertex -5.23081 -2.7 28.3004
+      vertex -5.32721 -2.7 28.6322
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.11377 -2.7 27.9753
+      vertex -5.23081 -2.7 28.3004
+      vertex 5.23081 -2.7 28.3004
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.11377 -2.7 27.9753
+      vertex -5.11377 -2.7 27.9753
+      vertex -5.23081 -2.7 28.3004
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 4.97655 -2.7 27.6582
+      vertex -5.11377 -2.7 27.9753
+      vertex 5.11377 -2.7 27.9753
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.97655 -2.7 27.6582
+      vertex -4.97655 -2.7 27.6582
+      vertex -5.11377 -2.7 27.9753
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 4.81969 -2.7 27.3504
+      vertex -4.97655 -2.7 27.6582
+      vertex 4.97655 -2.7 27.6582
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.81969 -2.7 27.3504
+      vertex -4.81969 -2.7 27.3504
+      vertex -4.97655 -2.7 27.6582
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 4.6438 -2.7 27.053
+      vertex -4.81969 -2.7 27.3504
+      vertex 4.81969 -2.7 27.3504
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.6438 -2.7 27.053
+      vertex -4.6438 -2.7 27.053
+      vertex -4.81969 -2.7 27.3504
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 4.44959 -2.7 26.7672
+      vertex -4.6438 -2.7 27.053
+      vertex 4.6438 -2.7 27.053
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.44959 -2.7 26.7672
+      vertex -4.44959 -2.7 26.7672
+      vertex -4.6438 -2.7 27.053
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 4.23782 -2.7 26.4942
+      vertex -4.44959 -2.7 26.7672
+      vertex 4.44959 -2.7 26.7672
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.23782 -2.7 26.4942
+      vertex -4.23782 -2.7 26.4942
+      vertex -4.44959 -2.7 26.7672
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 4.00933 -2.7 26.235
+      vertex -4.23782 -2.7 26.4942
+      vertex 4.23782 -2.7 26.4942
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.00933 -2.7 26.235
+      vertex -4.00933 -2.7 26.235
+      vertex -4.23782 -2.7 26.4942
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.76501 -2.7 25.9907
+      vertex -4.00933 -2.7 26.235
+      vertex 4.00933 -2.7 26.235
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.76501 -2.7 25.9907
+      vertex -3.76501 -2.7 25.9907
+      vertex -4.00933 -2.7 26.235
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.50583 -2.7 25.7622
+      vertex -3.76501 -2.7 25.9907
+      vertex 3.76501 -2.7 25.9907
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.50583 -2.7 25.7622
+      vertex -3.50583 -2.7 25.7622
+      vertex -3.76501 -2.7 25.9907
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 3.23282 -2.7 25.5504
+      vertex -3.50583 -2.7 25.7622
+      vertex 3.50583 -2.7 25.7622
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.23282 -2.7 25.5504
+      vertex -3.23282 -2.7 25.5504
+      vertex -3.50583 -2.7 25.7622
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.94705 -2.7 25.3562
+      vertex -3.23282 -2.7 25.5504
+      vertex 3.23282 -2.7 25.5504
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.94705 -2.7 25.3562
+      vertex -2.94705 -2.7 25.3562
+      vertex -3.23282 -2.7 25.5504
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.64964 -2.7 25.1803
+      vertex -2.94705 -2.7 25.3562
+      vertex 2.94705 -2.7 25.3562
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.64964 -2.7 25.1803
+      vertex -2.64964 -2.7 25.1803
+      vertex -2.94705 -2.7 25.3562
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.34179 -2.7 25.0235
+      vertex -2.64964 -2.7 25.1803
+      vertex 2.64964 -2.7 25.1803
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.34179 -2.7 25.0235
+      vertex -2.34179 -2.7 25.0235
+      vertex -2.64964 -2.7 25.1803
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 2.02468 -2.7 24.8862
+      vertex -2.34179 -2.7 25.0235
+      vertex 2.34179 -2.7 25.0235
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.02468 -2.7 24.8862
+      vertex -2.02468 -2.7 24.8862
+      vertex -2.34179 -2.7 25.0235
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.69959 -2.7 24.7692
+      vertex -2.02468 -2.7 24.8862
+      vertex 2.02468 -2.7 24.8862
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.69959 -2.7 24.7692
+      vertex -1.69959 -2.7 24.7692
+      vertex -2.02468 -2.7 24.8862
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.36779 -2.7 24.6728
+      vertex -1.69959 -2.7 24.7692
+      vertex 1.69959 -2.7 24.7692
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.36779 -2.7 24.6728
+      vertex -1.36779 -2.7 24.6728
+      vertex -1.69959 -2.7 24.7692
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.0306 -2.7 24.5974
+      vertex -1.36779 -2.7 24.6728
+      vertex 1.36779 -2.7 24.6728
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.0306 -2.7 24.5974
+      vertex -1.0306 -2.7 24.5974
+      vertex -1.36779 -2.7 24.6728
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.689332 -2.7 24.5434
+      vertex -1.0306 -2.7 24.5974
+      vertex 1.0306 -2.7 24.5974
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.689332 -2.7 24.5434
+      vertex -0.689332 -2.7 24.5434
+      vertex -1.0306 -2.7 24.5974
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.345347 -2.7 24.5109
+      vertex -0.689332 -2.7 24.5434
+      vertex 0.689332 -2.7 24.5434
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.345347 -2.7 24.5109
+      vertex -0.345347 -2.7 24.5109
+      vertex -0.689332 -2.7 24.5434
+    endloop
+  endfacet
+  facet normal -0 1 0
+    outer loop
+      vertex -0.345347 -2.7 24.5109
+      vertex 0.345347 -2.7 24.5109
+      vertex 0 -2.7 24.5
+    endloop
+  endfacet
+  facet normal 0.827107 0 -0.562045
+    outer loop
+      vertex -4.44959 -2.7 33.2328
+      vertex -4.6438 0 32.947
+      vertex -4.44959 0 33.2328
+    endloop
+  endfacet
+  facet normal 0.827107 0 -0.562045
+    outer loop
+      vertex -4.6438 0 32.947
+      vertex -4.44959 -2.7 33.2328
+      vertex -4.6438 -2.7 32.947
+    endloop
+  endfacet
+  facet normal 0.338636 0 0.940917
+    outer loop
+      vertex -2.02468 0 24.8862
+      vertex -1.69959 -2.7 24.7692
+      vertex -1.69959 0 24.7692
+    endloop
+  endfacet
+  facet normal 0.338636 0 0.940917
+    outer loop
+      vertex -1.69959 -2.7 24.7692
+      vertex -2.02468 0 24.8862
+      vertex -2.02468 -2.7 24.8862
+    endloop
+  endfacet
+  facet normal -0.453859 0 0.891074
+    outer loop
+      vertex 2.34179 0 25.0235
+      vertex 2.64964 -2.7 25.1803
+      vertex 2.64964 0 25.1803
+    endloop
+  endfacet
+  facet normal -0.453859 0 0.891074
+    outer loop
+      vertex 2.64964 -2.7 25.1803
+      vertex 2.34179 0 25.0235
+      vertex 2.34179 -2.7 25.0235
+    endloop
+  endfacet
+  facet normal 0.509068 0 0.860727
+    outer loop
+      vertex -2.94705 0 25.3562
+      vertex -2.64964 -2.7 25.1803
+      vertex -2.64964 0 25.1803
+    endloop
+  endfacet
+  facet normal 0.509068 0 0.860727
+    outer loop
+      vertex -2.64964 -2.7 25.1803
+      vertex -2.94705 0 25.3562
+      vertex -2.94705 -2.7 25.3562
+    endloop
+  endfacet
+  facet normal -0.094062 0 0.995566
+    outer loop
+      vertex 0.345347 0 24.5109
+      vertex 0.689332 -2.7 24.5434
+      vertex 0.689332 0 24.5434
+    endloop
+  endfacet
+  facet normal -0.094062 0 0.995566
+    outer loop
+      vertex 0.689332 -2.7 24.5434
+      vertex 0.345347 0 24.5109
+      vertex 0.345347 -2.7 24.5109
+    endloop
+  endfacet
+  facet normal 0.094062 0 -0.995566
+    outer loop
+      vertex -0.689332 -2.7 35.4566
+      vertex -0.345347 0 35.4891
+      vertex -0.345347 -2.7 35.4891
+    endloop
+  endfacet
+  facet normal 0.094062 0 -0.995566
+    outer loop
+      vertex -0.345347 0 35.4891
+      vertex -0.689332 -2.7 35.4566
+      vertex -0.689332 0 35.4566
+    endloop
+  endfacet
+  facet normal 0.790142 -0 0.612924
+    outer loop
+      vertex -4.44959 -2.7 26.7672
+      vertex -4.23782 0 26.4942
+      vertex -4.44959 0 26.7672
+    endloop
+  endfacet
+  facet normal 0.790142 0 0.612924
+    outer loop
+      vertex -4.23782 0 26.4942
+      vertex -4.44959 -2.7 26.7672
+      vertex -4.23782 -2.7 26.4942
+    endloop
+  endfacet
+  facet normal 0.960291 0 -0.279
+    outer loop
+      vertex -5.23081 -2.7 31.6996
+      vertex -5.32721 0 31.3678
+      vertex -5.23081 0 31.6996
+    endloop
+  endfacet
+  facet normal 0.960291 0 -0.279
+    outer loop
+      vertex -5.32721 0 31.3678
+      vertex -5.23081 -2.7 31.6996
+      vertex -5.32721 -2.7 31.3678
+    endloop
+  endfacet
+  facet normal 0.750148 0 -0.66127
+    outer loop
+      vertex -4.00933 -2.7 33.765
+      vertex -4.23782 0 33.5058
+      vertex -4.00933 0 33.765
+    endloop
+  endfacet
+  facet normal 0.750148 0 -0.66127
+    outer loop
+      vertex -4.23782 0 33.5058
+      vertex -4.00933 -2.7 33.765
+      vertex -4.23782 -2.7 33.5058
+    endloop
+  endfacet
+  facet normal -0.0315467 0 -0.999502
+    outer loop
+      vertex 0 -2.7 35.5
+      vertex 0.345347 0 35.4891
+      vertex 0.345347 -2.7 35.4891
+    endloop
+  endfacet
+  facet normal -0.0315467 0 -0.999502
+    outer loop
+      vertex 0.345347 0 35.4891
+      vertex 0 -2.7 35.5
+      vertex 0 0 35.5
+    endloop
+  endfacet
+  facet normal 0.562065 0 0.827093
+    outer loop
+      vertex -3.23282 0 25.5504
+      vertex -2.94705 -2.7 25.3562
+      vertex -2.94705 0 25.3562
+    endloop
+  endfacet
+  facet normal 0.562065 0 0.827093
+    outer loop
+      vertex -2.94705 -2.7 25.3562
+      vertex -3.23282 0 25.5504
+      vertex -3.23282 -2.7 25.5504
     endloop
   endfacet
   facet normal -0.960291 0 -0.279
@@ -7951,6 +8469,132 @@ solid OpenSCAD_Model
       vertex 5.23081 -2.7 31.6996
     endloop
   endfacet
+  facet normal 0.453859 0 0.891074
+    outer loop
+      vertex -2.64964 0 25.1803
+      vertex -2.34179 -2.7 25.0235
+      vertex -2.34179 0 25.0235
+    endloop
+  endfacet
+  facet normal 0.453859 0 0.891074
+    outer loop
+      vertex -2.34179 -2.7 25.0235
+      vertex -2.64964 0 25.1803
+      vertex -2.64964 -2.7 25.1803
+    endloop
+  endfacet
+  facet normal -0.750148 0 0.66127
+    outer loop
+      vertex 4.00933 -2.7 26.235
+      vertex 4.23782 0 26.4942
+      vertex 4.00933 0 26.235
+    endloop
+  endfacet
+  facet normal -0.750148 0 0.66127
+    outer loop
+      vertex 4.23782 0 26.4942
+      vertex 4.00933 -2.7 26.235
+      vertex 4.23782 -2.7 26.4942
+    endloop
+  endfacet
+  facet normal 0.397329 0 -0.917676
+    outer loop
+      vertex -2.34179 -2.7 34.9765
+      vertex -2.02468 0 35.1138
+      vertex -2.02468 -2.7 35.1138
+    endloop
+  endfacet
+  facet normal 0.397329 0 -0.917676
+    outer loop
+      vertex -2.02468 0 35.1138
+      vertex -2.34179 -2.7 34.9765
+      vertex -2.34179 0 34.9765
+    endloop
+  endfacet
+  facet normal 0.917756 -0 0.397144
+    outer loop
+      vertex -5.11377 -2.7 27.9753
+      vertex -4.97655 0 27.6582
+      vertex -5.11377 0 27.9753
+    endloop
+  endfacet
+  facet normal 0.917756 0 0.397144
+    outer loop
+      vertex -4.97655 0 27.6582
+      vertex -5.11377 -2.7 27.9753
+      vertex -4.97655 -2.7 27.6582
+    endloop
+  endfacet
+  facet normal 0.562065 0 -0.827093
+    outer loop
+      vertex -3.23282 -2.7 34.4496
+      vertex -2.94705 0 34.6438
+      vertex -2.94705 -2.7 34.6438
+    endloop
+  endfacet
+  facet normal 0.562065 0 -0.827093
+    outer loop
+      vertex -2.94705 0 34.6438
+      vertex -3.23282 -2.7 34.4496
+      vertex -3.23282 0 34.4496
+    endloop
+  endfacet
+  facet normal 0.509068 0 -0.860727
+    outer loop
+      vertex -2.94705 -2.7 34.6438
+      vertex -2.64964 0 34.8197
+      vertex -2.64964 -2.7 34.8197
+    endloop
+  endfacet
+  facet normal 0.509068 0 -0.860727
+    outer loop
+      vertex -2.64964 0 34.8197
+      vertex -2.94705 -2.7 34.6438
+      vertex -2.94705 0 34.6438
+    endloop
+  endfacet
+  facet normal 0.279 0 -0.960291
+    outer loop
+      vertex -1.69959 -2.7 35.2308
+      vertex -1.36779 0 35.3272
+      vertex -1.36779 -2.7 35.3272
+    endloop
+  endfacet
+  facet normal 0.279 0 -0.960291
+    outer loop
+      vertex -1.36779 0 35.3272
+      vertex -1.69959 -2.7 35.2308
+      vertex -1.69959 0 35.2308
+    endloop
+  endfacet
+  facet normal 0.995561 0 -0.0941153
+    outer loop
+      vertex -5.45663 -2.7 30.6893
+      vertex -5.48915 0 30.3453
+      vertex -5.45663 0 30.6893
+    endloop
+  endfacet
+  facet normal 0.995561 0 -0.0941153
+    outer loop
+      vertex -5.48915 0 30.3453
+      vertex -5.45663 -2.7 30.6893
+      vertex -5.48915 -2.7 30.3453
+    endloop
+  endfacet
+  facet normal 0.094062 0 0.995566
+    outer loop
+      vertex -0.689332 0 24.5434
+      vertex -0.345347 -2.7 24.5109
+      vertex -0.345347 0 24.5109
+    endloop
+  endfacet
+  facet normal 0.094062 0 0.995566
+    outer loop
+      vertex -0.345347 -2.7 24.5109
+      vertex -0.689332 0 24.5434
+      vertex -0.689332 -2.7 24.5434
+    endloop
+  endfacet
   facet normal -0.917756 0 -0.397144
     outer loop
       vertex 5.11377 -2.7 32.0247
@@ -7965,32 +8609,74 @@ solid OpenSCAD_Model
       vertex 4.97655 -2.7 32.3418
     endloop
   endfacet
-  facet normal -0.890974 0 -0.454055
+  facet normal -0.661315 0 -0.750108
     outer loop
-      vertex 4.97655 -2.7 32.3418
-      vertex 4.81969 0 32.6496
-      vertex 4.97655 0 32.3418
+      vertex 3.50583 -2.7 34.2378
+      vertex 3.76501 0 34.0093
+      vertex 3.76501 -2.7 34.0093
     endloop
   endfacet
-  facet normal -0.890974 -0 -0.454055
+  facet normal -0.661315 0 -0.750108
     outer loop
-      vertex 4.81969 0 32.6496
-      vertex 4.97655 -2.7 32.3418
-      vertex 4.81969 -2.7 32.6496
+      vertex 3.76501 0 34.0093
+      vertex 3.50583 -2.7 34.2378
+      vertex 3.50583 0 34.2378
     endloop
   endfacet
-  facet normal -0.750148 0 -0.66127
+  facet normal -0.940884 0 -0.33873
     outer loop
-      vertex 4.23782 -2.7 33.5058
-      vertex 4.00933 0 33.765
-      vertex 4.23782 0 33.5058
+      vertex 5.23081 -2.7 31.6996
+      vertex 5.11377 0 32.0247
+      vertex 5.23081 0 31.6996
     endloop
   endfacet
-  facet normal -0.750148 -0 -0.66127
+  facet normal -0.940884 -0 -0.33873
     outer loop
-      vertex 4.00933 0 33.765
-      vertex 4.23782 -2.7 33.5058
-      vertex 4.00933 -2.7 33.765
+      vertex 5.11377 0 32.0247
+      vertex 5.23081 -2.7 31.6996
+      vertex 5.11377 -2.7 32.0247
+    endloop
+  endfacet
+  facet normal -0.279 0 -0.960291
+    outer loop
+      vertex 1.36779 -2.7 35.3272
+      vertex 1.69959 0 35.2308
+      vertex 1.69959 -2.7 35.2308
+    endloop
+  endfacet
+  facet normal -0.279 0 -0.960291
+    outer loop
+      vertex 1.69959 0 35.2308
+      vertex 1.36779 -2.7 35.3272
+      vertex 1.36779 0 35.3272
+    endloop
+  endfacet
+  facet normal 0.612964 0 0.790111
+    outer loop
+      vertex -3.50583 0 25.7622
+      vertex -3.23282 -2.7 25.5504
+      vertex -3.23282 0 25.5504
+    endloop
+  endfacet
+  facet normal 0.612964 0 0.790111
+    outer loop
+      vertex -3.23282 -2.7 25.5504
+      vertex -3.50583 0 25.7622
+      vertex -3.50583 -2.7 25.7622
+    endloop
+  endfacet
+  facet normal -0.509068 0 -0.860727
+    outer loop
+      vertex 2.64964 -2.7 34.8197
+      vertex 2.94705 0 34.6438
+      vertex 2.94705 -2.7 34.6438
+    endloop
+  endfacet
+  facet normal -0.509068 0 -0.860727
+    outer loop
+      vertex 2.94705 0 34.6438
+      vertex 2.64964 -2.7 34.8197
+      vertex 2.64964 0 34.8197
     endloop
   endfacet
   facet normal 0.987691 -0 0.156416
@@ -8021,774 +8707,144 @@ solid OpenSCAD_Model
       vertex -4.44959 -2.7 26.7672
     endloop
   endfacet
-  facet normal 0.790142 -0 0.612924
+  facet normal 0.940884 0 -0.33873
     outer loop
-      vertex -4.44959 -2.7 26.7672
-      vertex -4.23782 0 26.4942
-      vertex -4.44959 0 26.7672
-    endloop
-  endfacet
-  facet normal 0.790142 0 0.612924
-    outer loop
-      vertex -4.23782 0 26.4942
-      vertex -4.44959 -2.7 26.7672
-      vertex -4.23782 -2.7 26.4942
-    endloop
-  endfacet
-  facet normal 0.707078 -0 0.707136
-    outer loop
-      vertex -4.00933 -2.7 26.235
-      vertex -3.76501 0 25.9907
-      vertex -4.00933 0 26.235
-    endloop
-  endfacet
-  facet normal 0.707078 0 0.707136
-    outer loop
-      vertex -3.76501 0 25.9907
-      vertex -4.00933 -2.7 26.235
-      vertex -3.76501 -2.7 25.9907
-    endloop
-  endfacet
-  facet normal 0.218223 0 0.975899
-    outer loop
-      vertex -1.36779 0 24.6728
-      vertex -1.0306 -2.7 24.5974
-      vertex -1.0306 0 24.5974
-    endloop
-  endfacet
-  facet normal 0.218223 0 0.975899
-    outer loop
-      vertex -1.0306 -2.7 24.5974
-      vertex -1.36779 0 24.6728
-      vertex -1.36779 -2.7 24.6728
-    endloop
-  endfacet
-  facet normal 0.156289 0 0.987711
-    outer loop
-      vertex -1.0306 0 24.5974
-      vertex -0.689332 -2.7 24.5434
-      vertex -0.689332 0 24.5434
-    endloop
-  endfacet
-  facet normal 0.156289 0 0.987711
-    outer loop
-      vertex -0.689332 -2.7 24.5434
-      vertex -1.0306 0 24.5974
-      vertex -1.0306 -2.7 24.5974
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.345347 -2.7 35.4891
-      vertex -0.345347 -2.7 35.4891
-      vertex 0 -2.7 35.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.689332 -2.7 35.4566
-      vertex -0.345347 -2.7 35.4891
-      vertex 0.345347 -2.7 35.4891
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.689332 -2.7 35.4566
-      vertex -0.689332 -2.7 35.4566
-      vertex -0.345347 -2.7 35.4891
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.0306 -2.7 35.4026
-      vertex -0.689332 -2.7 35.4566
-      vertex 0.689332 -2.7 35.4566
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.0306 -2.7 35.4026
-      vertex -1.0306 -2.7 35.4026
-      vertex -0.689332 -2.7 35.4566
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.36779 -2.7 35.3272
-      vertex -1.0306 -2.7 35.4026
-      vertex 1.0306 -2.7 35.4026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.36779 -2.7 35.3272
-      vertex -1.36779 -2.7 35.3272
-      vertex -1.0306 -2.7 35.4026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.69959 -2.7 35.2308
-      vertex -1.36779 -2.7 35.3272
-      vertex 1.36779 -2.7 35.3272
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.69959 -2.7 35.2308
-      vertex -1.69959 -2.7 35.2308
-      vertex -1.36779 -2.7 35.3272
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.02468 -2.7 35.1138
-      vertex -1.69959 -2.7 35.2308
-      vertex 1.69959 -2.7 35.2308
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.02468 -2.7 35.1138
-      vertex -2.02468 -2.7 35.1138
-      vertex -1.69959 -2.7 35.2308
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.34179 -2.7 34.9765
-      vertex -2.02468 -2.7 35.1138
-      vertex 2.02468 -2.7 35.1138
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.34179 -2.7 34.9765
-      vertex -2.34179 -2.7 34.9765
-      vertex -2.02468 -2.7 35.1138
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.64964 -2.7 34.8197
-      vertex -2.34179 -2.7 34.9765
-      vertex 2.34179 -2.7 34.9765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.64964 -2.7 34.8197
-      vertex -2.64964 -2.7 34.8197
-      vertex -2.34179 -2.7 34.9765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.94705 -2.7 34.6438
-      vertex -2.64964 -2.7 34.8197
-      vertex 2.64964 -2.7 34.8197
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.94705 -2.7 34.6438
-      vertex -2.94705 -2.7 34.6438
-      vertex -2.64964 -2.7 34.8197
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.23282 -2.7 34.4496
-      vertex -2.94705 -2.7 34.6438
-      vertex 2.94705 -2.7 34.6438
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.23282 -2.7 34.4496
-      vertex -3.23282 -2.7 34.4496
-      vertex -2.94705 -2.7 34.6438
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.50583 -2.7 34.2378
-      vertex -3.23282 -2.7 34.4496
-      vertex 3.23282 -2.7 34.4496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.50583 -2.7 34.2378
-      vertex -3.50583 -2.7 34.2378
-      vertex -3.23282 -2.7 34.4496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.76501 -2.7 34.0093
-      vertex -3.50583 -2.7 34.2378
-      vertex 3.50583 -2.7 34.2378
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.76501 -2.7 34.0093
-      vertex -3.76501 -2.7 34.0093
-      vertex -3.50583 -2.7 34.2378
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.00933 -2.7 33.765
-      vertex -3.76501 -2.7 34.0093
-      vertex 3.76501 -2.7 34.0093
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.00933 -2.7 33.765
-      vertex -4.00933 -2.7 33.765
-      vertex -3.76501 -2.7 34.0093
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.23782 -2.7 33.5058
-      vertex -4.00933 -2.7 33.765
-      vertex 4.00933 -2.7 33.765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.23782 -2.7 33.5058
-      vertex -4.23782 -2.7 33.5058
-      vertex -4.00933 -2.7 33.765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.44959 -2.7 33.2328
-      vertex -4.23782 -2.7 33.5058
-      vertex 4.23782 -2.7 33.5058
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.44959 -2.7 33.2328
-      vertex -4.44959 -2.7 33.2328
-      vertex -4.23782 -2.7 33.5058
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.6438 -2.7 32.947
-      vertex -4.44959 -2.7 33.2328
-      vertex 4.44959 -2.7 33.2328
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.6438 -2.7 32.947
-      vertex -4.6438 -2.7 32.947
-      vertex -4.44959 -2.7 33.2328
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.81969 -2.7 32.6496
-      vertex -4.6438 -2.7 32.947
-      vertex 4.6438 -2.7 32.947
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.81969 -2.7 32.6496
-      vertex -4.81969 -2.7 32.6496
-      vertex -4.6438 -2.7 32.947
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.97655 -2.7 32.3418
-      vertex -4.81969 -2.7 32.6496
-      vertex 4.81969 -2.7 32.6496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.97655 -2.7 32.3418
-      vertex -4.97655 -2.7 32.3418
-      vertex -4.81969 -2.7 32.6496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.11377 -2.7 32.0247
-      vertex -4.97655 -2.7 32.3418
-      vertex 4.97655 -2.7 32.3418
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.11377 -2.7 32.0247
       vertex -5.11377 -2.7 32.0247
-      vertex -4.97655 -2.7 32.3418
+      vertex -5.23081 0 31.6996
+      vertex -5.11377 0 32.0247
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.940884 0 -0.33873
     outer loop
-      vertex 5.23081 -2.7 31.6996
+      vertex -5.23081 0 31.6996
       vertex -5.11377 -2.7 32.0247
-      vertex 5.11377 -2.7 32.0247
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.23081 -2.7 31.6996
-      vertex -5.23081 -2.7 31.6996
-      vertex -5.11377 -2.7 32.0247
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.32721 -2.7 31.3678
-      vertex -5.23081 -2.7 31.6996
-      vertex 5.23081 -2.7 31.6996
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.32721 -2.7 31.3678
-      vertex -5.32721 -2.7 31.3678
       vertex -5.23081 -2.7 31.6996
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal -0.890974 0 -0.454055
     outer loop
-      vertex 5.40258 -2.7 31.0306
-      vertex -5.32721 -2.7 31.3678
-      vertex 5.32721 -2.7 31.3678
+      vertex 4.97655 -2.7 32.3418
+      vertex 4.81969 0 32.6496
+      vertex 4.97655 0 32.3418
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal -0.890974 -0 -0.454055
     outer loop
-      vertex 5.40258 -2.7 31.0306
-      vertex -5.40258 -2.7 31.0306
-      vertex -5.32721 -2.7 31.3678
+      vertex 4.81969 0 32.6496
+      vertex 4.97655 -2.7 32.3418
+      vertex 4.81969 -2.7 32.6496
     endloop
   endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.45663 -2.7 30.6893
-      vertex -5.40258 -2.7 31.0306
-      vertex 5.40258 -2.7 31.0306
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.45663 -2.7 30.6893
-      vertex -5.45663 -2.7 30.6893
-      vertex -5.40258 -2.7 31.0306
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.48915 -2.7 30.3453
-      vertex -5.45663 -2.7 30.6893
-      vertex 5.45663 -2.7 30.6893
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.48915 -2.7 30.3453
-      vertex -5.48915 -2.7 30.3453
-      vertex -5.45663 -2.7 30.6893
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.5 -2.7 30
-      vertex -5.48915 -2.7 30.3453
-      vertex 5.48915 -2.7 30.3453
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.5 -2.7 30
-      vertex -5.5 -2.7 30
-      vertex -5.48915 -2.7 30.3453
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 5.48915 -2.7 29.6547
-      vertex -5.5 -2.7 30
-      vertex 5.5 -2.7 30
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.48915 -2.7 29.6547
-      vertex -5.48915 -2.7 29.6547
-      vertex -5.5 -2.7 30
-    endloop
-  endfacet
-  facet normal 0 1 -0
+  facet normal -0.995561 0 0.0941153
     outer loop
       vertex 5.45663 -2.7 29.3107
-      vertex -5.48915 -2.7 29.6547
+      vertex 5.48915 0 29.6547
+      vertex 5.45663 0 29.3107
+    endloop
+  endfacet
+  facet normal -0.995561 0 0.0941153
+    outer loop
+      vertex 5.48915 0 29.6547
+      vertex 5.45663 -2.7 29.3107
       vertex 5.48915 -2.7 29.6547
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal -0.0315467 0 0.999502
     outer loop
-      vertex 5.45663 -2.7 29.3107
-      vertex -5.45663 -2.7 29.3107
-      vertex -5.48915 -2.7 29.6547
+      vertex 0 0 24.5
+      vertex 0.345347 -2.7 24.5109
+      vertex 0.345347 0 24.5109
     endloop
   endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 5.40258 -2.7 28.9694
-      vertex -5.45663 -2.7 29.3107
-      vertex 5.45663 -2.7 29.3107
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.40258 -2.7 28.9694
-      vertex -5.40258 -2.7 28.9694
-      vertex -5.45663 -2.7 29.3107
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 5.32721 -2.7 28.6322
-      vertex -5.40258 -2.7 28.9694
-      vertex 5.40258 -2.7 28.9694
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.32721 -2.7 28.6322
-      vertex -5.32721 -2.7 28.6322
-      vertex -5.40258 -2.7 28.9694
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 5.23081 -2.7 28.3004
-      vertex -5.32721 -2.7 28.6322
-      vertex 5.32721 -2.7 28.6322
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.23081 -2.7 28.3004
-      vertex -5.23081 -2.7 28.3004
-      vertex -5.32721 -2.7 28.6322
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 5.11377 -2.7 27.9753
-      vertex -5.23081 -2.7 28.3004
-      vertex 5.23081 -2.7 28.3004
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.11377 -2.7 27.9753
-      vertex -5.11377 -2.7 27.9753
-      vertex -5.23081 -2.7 28.3004
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 4.97655 -2.7 27.6582
-      vertex -5.11377 -2.7 27.9753
-      vertex 5.11377 -2.7 27.9753
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.97655 -2.7 27.6582
-      vertex -4.97655 -2.7 27.6582
-      vertex -5.11377 -2.7 27.9753
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 4.81969 -2.7 27.3504
-      vertex -4.97655 -2.7 27.6582
-      vertex 4.97655 -2.7 27.6582
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.81969 -2.7 27.3504
-      vertex -4.81969 -2.7 27.3504
-      vertex -4.97655 -2.7 27.6582
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 4.6438 -2.7 27.053
-      vertex -4.81969 -2.7 27.3504
-      vertex 4.81969 -2.7 27.3504
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.6438 -2.7 27.053
-      vertex -4.6438 -2.7 27.053
-      vertex -4.81969 -2.7 27.3504
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 4.44959 -2.7 26.7672
-      vertex -4.6438 -2.7 27.053
-      vertex 4.6438 -2.7 27.053
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.44959 -2.7 26.7672
-      vertex -4.44959 -2.7 26.7672
-      vertex -4.6438 -2.7 27.053
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 4.23782 -2.7 26.4942
-      vertex -4.44959 -2.7 26.7672
-      vertex 4.44959 -2.7 26.7672
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.23782 -2.7 26.4942
-      vertex -4.23782 -2.7 26.4942
-      vertex -4.44959 -2.7 26.7672
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 4.00933 -2.7 26.235
-      vertex -4.23782 -2.7 26.4942
-      vertex 4.23782 -2.7 26.4942
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.00933 -2.7 26.235
-      vertex -4.00933 -2.7 26.235
-      vertex -4.23782 -2.7 26.4942
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 3.76501 -2.7 25.9907
-      vertex -4.00933 -2.7 26.235
-      vertex 4.00933 -2.7 26.235
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.76501 -2.7 25.9907
-      vertex -3.76501 -2.7 25.9907
-      vertex -4.00933 -2.7 26.235
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 3.50583 -2.7 25.7622
-      vertex -3.76501 -2.7 25.9907
-      vertex 3.76501 -2.7 25.9907
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.50583 -2.7 25.7622
-      vertex -3.50583 -2.7 25.7622
-      vertex -3.76501 -2.7 25.9907
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 3.23282 -2.7 25.5504
-      vertex -3.50583 -2.7 25.7622
-      vertex 3.50583 -2.7 25.7622
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.23282 -2.7 25.5504
-      vertex -3.23282 -2.7 25.5504
-      vertex -3.50583 -2.7 25.7622
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 2.94705 -2.7 25.3562
-      vertex -3.23282 -2.7 25.5504
-      vertex 3.23282 -2.7 25.5504
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.94705 -2.7 25.3562
-      vertex -2.94705 -2.7 25.3562
-      vertex -3.23282 -2.7 25.5504
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 2.64964 -2.7 25.1803
-      vertex -2.94705 -2.7 25.3562
-      vertex 2.94705 -2.7 25.3562
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.64964 -2.7 25.1803
-      vertex -2.64964 -2.7 25.1803
-      vertex -2.94705 -2.7 25.3562
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 2.34179 -2.7 25.0235
-      vertex -2.64964 -2.7 25.1803
-      vertex 2.64964 -2.7 25.1803
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.34179 -2.7 25.0235
-      vertex -2.34179 -2.7 25.0235
-      vertex -2.64964 -2.7 25.1803
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 2.02468 -2.7 24.8862
-      vertex -2.34179 -2.7 25.0235
-      vertex 2.34179 -2.7 25.0235
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.02468 -2.7 24.8862
-      vertex -2.02468 -2.7 24.8862
-      vertex -2.34179 -2.7 25.0235
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.69959 -2.7 24.7692
-      vertex -2.02468 -2.7 24.8862
-      vertex 2.02468 -2.7 24.8862
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.69959 -2.7 24.7692
-      vertex -1.69959 -2.7 24.7692
-      vertex -2.02468 -2.7 24.8862
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.36779 -2.7 24.6728
-      vertex -1.69959 -2.7 24.7692
-      vertex 1.69959 -2.7 24.7692
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.36779 -2.7 24.6728
-      vertex -1.36779 -2.7 24.6728
-      vertex -1.69959 -2.7 24.7692
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.0306 -2.7 24.5974
-      vertex -1.36779 -2.7 24.6728
-      vertex 1.36779 -2.7 24.6728
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.0306 -2.7 24.5974
-      vertex -1.0306 -2.7 24.5974
-      vertex -1.36779 -2.7 24.6728
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.689332 -2.7 24.5434
-      vertex -1.0306 -2.7 24.5974
-      vertex 1.0306 -2.7 24.5974
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.689332 -2.7 24.5434
-      vertex -0.689332 -2.7 24.5434
-      vertex -1.0306 -2.7 24.5974
-    endloop
-  endfacet
-  facet normal 0 1 -0
+  facet normal -0.0315467 0 0.999502
     outer loop
       vertex 0.345347 -2.7 24.5109
-      vertex -0.689332 -2.7 24.5434
-      vertex 0.689332 -2.7 24.5434
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.345347 -2.7 24.5109
-      vertex -0.345347 -2.7 24.5109
-      vertex -0.689332 -2.7 24.5434
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex -0.345347 -2.7 24.5109
-      vertex 0.345347 -2.7 24.5109
+      vertex 0 0 24.5
       vertex 0 -2.7 24.5
     endloop
   endfacet
-  facet normal -0.975919 0 0.218135
+  facet normal 0.661315 0 0.750108
     outer loop
-      vertex 5.32721 -2.7 28.6322
-      vertex 5.40258 0 28.9694
-      vertex 5.32721 0 28.6322
+      vertex -3.76501 0 25.9907
+      vertex -3.50583 -2.7 25.7622
+      vertex -3.50583 0 25.7622
     endloop
   endfacet
-  facet normal -0.975919 0 0.218135
+  facet normal 0.661315 0 0.750108
     outer loop
-      vertex 5.40258 0 28.9694
-      vertex 5.32721 -2.7 28.6322
-      vertex 5.40258 -2.7 28.9694
+      vertex -3.50583 -2.7 25.7622
+      vertex -3.76501 0 25.9907
+      vertex -3.76501 -2.7 25.9907
     endloop
   endfacet
-  facet normal -0.987691 0 0.156416
+  facet normal -0.790142 0 0.612924
     outer loop
-      vertex 5.40258 -2.7 28.9694
-      vertex 5.45663 0 29.3107
-      vertex 5.40258 0 28.9694
+      vertex 4.23782 -2.7 26.4942
+      vertex 4.44959 0 26.7672
+      vertex 4.23782 0 26.4942
     endloop
   endfacet
-  facet normal -0.987691 0 0.156416
+  facet normal -0.790142 0 0.612924
     outer loop
-      vertex 5.45663 0 29.3107
-      vertex 5.40258 -2.7 28.9694
-      vertex 5.45663 -2.7 29.3107
+      vertex 4.44959 0 26.7672
+      vertex 4.23782 -2.7 26.4942
+      vertex 4.44959 -2.7 26.7672
+    endloop
+  endfacet
+  facet normal -0.218223 0 -0.975899
+    outer loop
+      vertex 1.0306 -2.7 35.4026
+      vertex 1.36779 0 35.3272
+      vertex 1.36779 -2.7 35.3272
+    endloop
+  endfacet
+  facet normal -0.218223 0 -0.975899
+    outer loop
+      vertex 1.36779 0 35.3272
+      vertex 1.0306 -2.7 35.4026
+      vertex 1.0306 0 35.4026
+    endloop
+  endfacet
+  facet normal -0.707078 0 0.707136
+    outer loop
+      vertex 3.76501 -2.7 25.9907
+      vertex 4.00933 0 26.235
+      vertex 3.76501 0 25.9907
+    endloop
+  endfacet
+  facet normal -0.707078 0 0.707136
+    outer loop
+      vertex 4.00933 0 26.235
+      vertex 3.76501 -2.7 25.9907
+      vertex 4.00933 -2.7 26.235
+    endloop
+  endfacet
+  facet normal 0.940884 -0 0.33873
+    outer loop
+      vertex -5.23081 -2.7 28.3004
+      vertex -5.11377 0 27.9753
+      vertex -5.23081 0 28.3004
+    endloop
+  endfacet
+  facet normal 0.940884 0 0.33873
+    outer loop
+      vertex -5.11377 0 27.9753
+      vertex -5.23081 -2.7 28.3004
+      vertex -5.11377 -2.7 27.9753
+    endloop
+  endfacet
+  facet normal 0.999507 0 -0.0314065
+    outer loop
+      vertex -5.48915 -2.7 30.3453
+      vertex -5.5 0 30
+      vertex -5.48915 0 30.3453
+    endloop
+  endfacet
+  facet normal 0.999507 0 -0.0314065
+    outer loop
+      vertex -5.5 0 30
+      vertex -5.48915 -2.7 30.3453
+      vertex -5.5 -2.7 30
     endloop
   endfacet
   facet normal -0.156289 0 0.987711
@@ -8819,244 +8875,6 @@ solid OpenSCAD_Model
       vertex 1.0306 -2.7 24.5974
     endloop
   endfacet
-  facet normal -0.562065 0 0.827093
-    outer loop
-      vertex 2.94705 0 25.3562
-      vertex 3.23282 -2.7 25.5504
-      vertex 3.23282 0 25.5504
-    endloop
-  endfacet
-  facet normal -0.562065 0 0.827093
-    outer loop
-      vertex 3.23282 -2.7 25.5504
-      vertex 2.94705 0 25.3562
-      vertex 2.94705 -2.7 25.3562
-    endloop
-  endfacet
-  facet normal -0.612964 0 0.790111
-    outer loop
-      vertex 3.23282 0 25.5504
-      vertex 3.50583 -2.7 25.7622
-      vertex 3.50583 0 25.7622
-    endloop
-  endfacet
-  facet normal -0.612964 0 0.790111
-    outer loop
-      vertex 3.50583 -2.7 25.7622
-      vertex 3.23282 0 25.5504
-      vertex 3.23282 -2.7 25.5504
-    endloop
-  endfacet
-  facet normal -0.707078 0 0.707136
-    outer loop
-      vertex 3.76501 -2.7 25.9907
-      vertex 4.00933 0 26.235
-      vertex 3.76501 0 25.9907
-    endloop
-  endfacet
-  facet normal -0.707078 0 0.707136
-    outer loop
-      vertex 4.00933 0 26.235
-      vertex 3.76501 -2.7 25.9907
-      vertex 4.00933 -2.7 26.235
-    endloop
-  endfacet
-  facet normal 0.995561 0 -0.0941153
-    outer loop
-      vertex -5.45663 -2.7 30.6893
-      vertex -5.48915 0 30.3453
-      vertex -5.45663 0 30.6893
-    endloop
-  endfacet
-  facet normal 0.995561 0 -0.0941153
-    outer loop
-      vertex -5.48915 0 30.3453
-      vertex -5.45663 -2.7 30.6893
-      vertex -5.48915 -2.7 30.3453
-    endloop
-  endfacet
-  facet normal 0.999507 0 -0.0314065
-    outer loop
-      vertex -5.48915 -2.7 30.3453
-      vertex -5.5 0 30
-      vertex -5.48915 0 30.3453
-    endloop
-  endfacet
-  facet normal 0.999507 0 -0.0314065
-    outer loop
-      vertex -5.5 0 30
-      vertex -5.48915 -2.7 30.3453
-      vertex -5.5 -2.7 30
-    endloop
-  endfacet
-  facet normal 0.860732 0 -0.509059
-    outer loop
-      vertex -4.6438 -2.7 32.947
-      vertex -4.81969 0 32.6496
-      vertex -4.6438 0 32.947
-    endloop
-  endfacet
-  facet normal 0.860732 0 -0.509059
-    outer loop
-      vertex -4.81969 0 32.6496
-      vertex -4.6438 -2.7 32.947
-      vertex -4.81969 -2.7 32.6496
-    endloop
-  endfacet
-  facet normal 0.827107 0 -0.562045
-    outer loop
-      vertex -4.44959 -2.7 33.2328
-      vertex -4.6438 0 32.947
-      vertex -4.44959 0 33.2328
-    endloop
-  endfacet
-  facet normal 0.827107 0 -0.562045
-    outer loop
-      vertex -4.6438 0 32.947
-      vertex -4.44959 -2.7 33.2328
-      vertex -4.6438 -2.7 32.947
-    endloop
-  endfacet
-  facet normal 0.156289 0 -0.987711
-    outer loop
-      vertex -1.0306 -2.7 35.4026
-      vertex -0.689332 0 35.4566
-      vertex -0.689332 -2.7 35.4566
-    endloop
-  endfacet
-  facet normal 0.156289 0 -0.987711
-    outer loop
-      vertex -0.689332 0 35.4566
-      vertex -1.0306 -2.7 35.4026
-      vertex -1.0306 0 35.4026
-    endloop
-  endfacet
-  facet normal 0.218223 0 -0.975899
-    outer loop
-      vertex -1.36779 -2.7 35.3272
-      vertex -1.0306 0 35.4026
-      vertex -1.0306 -2.7 35.4026
-    endloop
-  endfacet
-  facet normal 0.218223 0 -0.975899
-    outer loop
-      vertex -1.0306 0 35.4026
-      vertex -1.36779 -2.7 35.3272
-      vertex -1.36779 0 35.3272
-    endloop
-  endfacet
-  facet normal 0.338636 0 -0.940917
-    outer loop
-      vertex -2.02468 -2.7 35.1138
-      vertex -1.69959 0 35.2308
-      vertex -1.69959 -2.7 35.2308
-    endloop
-  endfacet
-  facet normal 0.338636 0 -0.940917
-    outer loop
-      vertex -1.69959 0 35.2308
-      vertex -2.02468 -2.7 35.1138
-      vertex -2.02468 0 35.1138
-    endloop
-  endfacet
-  facet normal 0.707078 0 -0.707136
-    outer loop
-      vertex -4.00933 -2.7 33.765
-      vertex -3.76501 0 34.0093
-      vertex -3.76501 -2.7 34.0093
-    endloop
-  endfacet
-  facet normal 0.707078 0 -0.707136
-    outer loop
-      vertex -3.76501 0 34.0093
-      vertex -4.00933 -2.7 33.765
-      vertex -4.00933 0 33.765
-    endloop
-  endfacet
-  facet normal 0.750148 0 -0.66127
-    outer loop
-      vertex -4.00933 -2.7 33.765
-      vertex -4.23782 0 33.5058
-      vertex -4.00933 0 33.765
-    endloop
-  endfacet
-  facet normal 0.750148 0 -0.66127
-    outer loop
-      vertex -4.23782 0 33.5058
-      vertex -4.00933 -2.7 33.765
-      vertex -4.23782 -2.7 33.5058
-    endloop
-  endfacet
-  facet normal 0.562065 0 -0.827093
-    outer loop
-      vertex -3.23282 -2.7 34.4496
-      vertex -2.94705 0 34.6438
-      vertex -2.94705 -2.7 34.6438
-    endloop
-  endfacet
-  facet normal 0.562065 0 -0.827093
-    outer loop
-      vertex -2.94705 0 34.6438
-      vertex -3.23282 -2.7 34.4496
-      vertex -3.23282 0 34.4496
-    endloop
-  endfacet
-  facet normal 0.612964 0 -0.790111
-    outer loop
-      vertex -3.50583 -2.7 34.2378
-      vertex -3.23282 0 34.4496
-      vertex -3.23282 -2.7 34.4496
-    endloop
-  endfacet
-  facet normal 0.612964 0 -0.790111
-    outer loop
-      vertex -3.23282 0 34.4496
-      vertex -3.50583 -2.7 34.2378
-      vertex -3.50583 0 34.2378
-    endloop
-  endfacet
-  facet normal 0.509068 0 -0.860727
-    outer loop
-      vertex -2.94705 -2.7 34.6438
-      vertex -2.64964 0 34.8197
-      vertex -2.64964 -2.7 34.8197
-    endloop
-  endfacet
-  facet normal 0.509068 0 -0.860727
-    outer loop
-      vertex -2.64964 0 34.8197
-      vertex -2.94705 -2.7 34.6438
-      vertex -2.94705 0 34.6438
-    endloop
-  endfacet
-  facet normal -0.0315467 0 -0.999502
-    outer loop
-      vertex 0 -2.7 35.5
-      vertex 0.345347 0 35.4891
-      vertex 0.345347 -2.7 35.4891
-    endloop
-  endfacet
-  facet normal -0.0315467 0 -0.999502
-    outer loop
-      vertex 0.345347 0 35.4891
-      vertex 0 -2.7 35.5
-      vertex 0 0 35.5
-    endloop
-  endfacet
-  facet normal -0.218223 0 -0.975899
-    outer loop
-      vertex 1.0306 -2.7 35.4026
-      vertex 1.36779 0 35.3272
-      vertex 1.36779 -2.7 35.3272
-    endloop
-  endfacet
-  facet normal -0.218223 0 -0.975899
-    outer loop
-      vertex 1.36779 0 35.3272
-      vertex 1.0306 -2.7 35.4026
-      vertex 1.0306 0 35.4026
-    endloop
-  endfacet
   facet normal -0.156289 0 -0.987711
     outer loop
       vertex 0.689332 -2.7 35.4566
@@ -9069,62 +8887,6 @@ solid OpenSCAD_Model
       vertex 1.0306 0 35.4026
       vertex 0.689332 -2.7 35.4566
       vertex 0.689332 0 35.4566
-    endloop
-  endfacet
-  facet normal -0.397329 0 -0.917676
-    outer loop
-      vertex 2.02468 -2.7 35.1138
-      vertex 2.34179 0 34.9765
-      vertex 2.34179 -2.7 34.9765
-    endloop
-  endfacet
-  facet normal -0.397329 0 -0.917676
-    outer loop
-      vertex 2.34179 0 34.9765
-      vertex 2.02468 -2.7 35.1138
-      vertex 2.02468 0 35.1138
-    endloop
-  endfacet
-  facet normal -0.562065 0 -0.827093
-    outer loop
-      vertex 2.94705 -2.7 34.6438
-      vertex 3.23282 0 34.4496
-      vertex 3.23282 -2.7 34.4496
-    endloop
-  endfacet
-  facet normal -0.562065 0 -0.827093
-    outer loop
-      vertex 3.23282 0 34.4496
-      vertex 2.94705 -2.7 34.6438
-      vertex 2.94705 0 34.6438
-    endloop
-  endfacet
-  facet normal -0.940884 0 -0.33873
-    outer loop
-      vertex 5.23081 -2.7 31.6996
-      vertex 5.11377 0 32.0247
-      vertex 5.23081 0 31.6996
-    endloop
-  endfacet
-  facet normal -0.940884 -0 -0.33873
-    outer loop
-      vertex 5.11377 0 32.0247
-      vertex 5.23081 -2.7 31.6996
-      vertex 5.11377 -2.7 32.0247
-    endloop
-  endfacet
-  facet normal -0.987691 0 -0.156416
-    outer loop
-      vertex 5.45663 -2.7 30.6893
-      vertex 5.40258 0 31.0306
-      vertex 5.45663 0 30.6893
-    endloop
-  endfacet
-  facet normal -0.987691 -0 -0.156416
-    outer loop
-      vertex 5.40258 0 31.0306
-      vertex 5.45663 -2.7 30.6893
-      vertex 5.40258 -2.7 31.0306
     endloop
   endfacet
   facet normal -0.975919 0 -0.218135
@@ -9141,46 +8903,74 @@ solid OpenSCAD_Model
       vertex 5.32721 -2.7 31.3678
     endloop
   endfacet
-  facet normal -0.827107 0 -0.562045
+  facet normal -0.987691 0 -0.156416
     outer loop
-      vertex 4.6438 -2.7 32.947
-      vertex 4.44959 0 33.2328
-      vertex 4.6438 0 32.947
+      vertex 5.45663 -2.7 30.6893
+      vertex 5.40258 0 31.0306
+      vertex 5.45663 0 30.6893
     endloop
   endfacet
-  facet normal -0.827107 -0 -0.562045
+  facet normal -0.987691 -0 -0.156416
     outer loop
-      vertex 4.44959 0 33.2328
-      vertex 4.6438 -2.7 32.947
-      vertex 4.44959 -2.7 33.2328
+      vertex 5.40258 0 31.0306
+      vertex 5.45663 -2.7 30.6893
+      vertex 5.40258 -2.7 31.0306
     endloop
   endfacet
-  facet normal -0.790142 0 -0.612924
+  facet normal -0.612964 0 0.790111
     outer loop
-      vertex 4.44959 -2.7 33.2328
-      vertex 4.23782 0 33.5058
-      vertex 4.44959 0 33.2328
+      vertex 3.23282 0 25.5504
+      vertex 3.50583 -2.7 25.7622
+      vertex 3.50583 0 25.7622
     endloop
   endfacet
-  facet normal -0.790142 -0 -0.612924
+  facet normal -0.612964 0 0.790111
     outer loop
-      vertex 4.23782 0 33.5058
-      vertex 4.44959 -2.7 33.2328
-      vertex 4.23782 -2.7 33.5058
+      vertex 3.50583 -2.7 25.7622
+      vertex 3.23282 0 25.5504
+      vertex 3.23282 -2.7 25.5504
     endloop
   endfacet
-  facet normal -0.860732 0 -0.509059
+  facet normal 0.612964 0 -0.790111
     outer loop
-      vertex 4.81969 -2.7 32.6496
-      vertex 4.6438 0 32.947
-      vertex 4.81969 0 32.6496
+      vertex -3.50583 -2.7 34.2378
+      vertex -3.23282 0 34.4496
+      vertex -3.23282 -2.7 34.4496
     endloop
   endfacet
-  facet normal -0.860732 -0 -0.509059
+  facet normal 0.612964 0 -0.790111
     outer loop
-      vertex 4.6438 0 32.947
-      vertex 4.81969 -2.7 32.6496
-      vertex 4.6438 -2.7 32.947
+      vertex -3.23282 0 34.4496
+      vertex -3.50583 -2.7 34.2378
+      vertex -3.50583 0 34.2378
+    endloop
+  endfacet
+  facet normal -0.562065 0 0.827093
+    outer loop
+      vertex 2.94705 0 25.3562
+      vertex 3.23282 -2.7 25.5504
+      vertex 3.23282 0 25.5504
+    endloop
+  endfacet
+  facet normal -0.562065 0 0.827093
+    outer loop
+      vertex 3.23282 -2.7 25.5504
+      vertex 2.94705 0 25.3562
+      vertex 2.94705 -2.7 25.3562
+    endloop
+  endfacet
+  facet normal 0.279 0 0.960291
+    outer loop
+      vertex -1.69959 0 24.7692
+      vertex -1.36779 -2.7 24.6728
+      vertex -1.36779 0 24.6728
+    endloop
+  endfacet
+  facet normal 0.279 0 0.960291
+    outer loop
+      vertex -1.36779 -2.7 24.6728
+      vertex -1.69959 0 24.7692
+      vertex -1.69959 -2.7 24.7692
     endloop
   endfacet
   facet normal -0.707078 0 -0.707136
@@ -9197,74 +8987,270 @@ solid OpenSCAD_Model
       vertex 3.76501 0 34.0093
     endloop
   endfacet
-  facet normal -0.661315 0 -0.750108
+  facet normal 0.0315467 0 -0.999502
     outer loop
-      vertex 3.50583 -2.7 34.2378
-      vertex 3.76501 0 34.0093
-      vertex 3.76501 -2.7 34.0093
+      vertex -0.345347 -2.7 35.4891
+      vertex 0 0 35.5
+      vertex 0 -2.7 35.5
     endloop
   endfacet
-  facet normal -0.661315 0 -0.750108
+  facet normal 0.0315467 0 -0.999502
     outer loop
-      vertex 3.76501 0 34.0093
-      vertex 3.50583 -2.7 34.2378
-      vertex 3.50583 0 34.2378
+      vertex 0 0 35.5
+      vertex -0.345347 -2.7 35.4891
+      vertex -0.345347 0 35.4891
     endloop
   endfacet
-  facet normal 0.987691 0 -0.156416
+  facet normal 0.453859 0 -0.891074
     outer loop
-      vertex -5.40258 -2.7 31.0306
-      vertex -5.45663 0 30.6893
-      vertex -5.40258 0 31.0306
+      vertex -2.64964 -2.7 34.8197
+      vertex -2.34179 0 34.9765
+      vertex -2.34179 -2.7 34.9765
     endloop
   endfacet
-  facet normal 0.987691 0 -0.156416
+  facet normal 0.453859 0 -0.891074
     outer loop
-      vertex -5.45663 0 30.6893
-      vertex -5.40258 -2.7 31.0306
-      vertex -5.45663 -2.7 30.6893
+      vertex -2.34179 0 34.9765
+      vertex -2.64964 -2.7 34.8197
+      vertex -2.64964 0 34.8197
     endloop
   endfacet
-  facet normal 0.890974 0 -0.454055
+  facet normal 0.750148 -0 0.66127
     outer loop
-      vertex -4.81969 -2.7 32.6496
-      vertex -4.97655 0 32.3418
-      vertex -4.81969 0 32.6496
+      vertex -4.23782 -2.7 26.4942
+      vertex -4.00933 0 26.235
+      vertex -4.23782 0 26.4942
     endloop
   endfacet
-  facet normal 0.890974 0 -0.454055
+  facet normal 0.750148 0 0.66127
     outer loop
-      vertex -4.97655 0 32.3418
-      vertex -4.81969 -2.7 32.6496
-      vertex -4.97655 -2.7 32.3418
+      vertex -4.00933 0 26.235
+      vertex -4.23782 -2.7 26.4942
+      vertex -4.00933 -2.7 26.235
     endloop
   endfacet
-  facet normal 0.917756 0 -0.397144
+  facet normal -0.860732 0 0.509059
     outer loop
-      vertex -4.97655 -2.7 32.3418
-      vertex -5.11377 0 32.0247
-      vertex -4.97655 0 32.3418
+      vertex 4.6438 -2.7 27.053
+      vertex 4.81969 0 27.3504
+      vertex 4.6438 0 27.053
     endloop
   endfacet
-  facet normal 0.917756 0 -0.397144
+  facet normal -0.860732 0 0.509059
     outer loop
-      vertex -5.11377 0 32.0247
-      vertex -4.97655 -2.7 32.3418
-      vertex -5.11377 -2.7 32.0247
+      vertex 4.81969 0 27.3504
+      vertex 4.6438 -2.7 27.053
+      vertex 4.81969 -2.7 27.3504
     endloop
   endfacet
-  facet normal 0.999507 -0 0.0314019
+  facet normal -0.094062 0 -0.995566
     outer loop
-      vertex -5.5 -2.7 10
-      vertex -5.48915 0 9.65465
-      vertex -5.5 0 10
+      vertex 0.345347 -2.7 35.4891
+      vertex 0.689332 0 35.4566
+      vertex 0.689332 -2.7 35.4566
     endloop
   endfacet
-  facet normal 0.999507 0 0.0314019
+  facet normal -0.094062 0 -0.995566
     outer loop
-      vertex -5.48915 0 9.65465
-      vertex -5.5 -2.7 10
-      vertex -5.48915 -2.7 9.65465
+      vertex 0.689332 0 35.4566
+      vertex 0.345347 -2.7 35.4891
+      vertex 0.345347 0 35.4891
+    endloop
+  endfacet
+  facet normal 0.156289 0 0.987711
+    outer loop
+      vertex -1.0306 0 24.5974
+      vertex -0.689332 -2.7 24.5434
+      vertex -0.689332 0 24.5434
+    endloop
+  endfacet
+  facet normal 0.156289 0 0.987711
+    outer loop
+      vertex -0.689332 -2.7 24.5434
+      vertex -1.0306 0 24.5974
+      vertex -1.0306 -2.7 24.5974
+    endloop
+  endfacet
+  facet normal -0.987691 0 0.156416
+    outer loop
+      vertex 5.40258 -2.7 28.9694
+      vertex 5.45663 0 29.3107
+      vertex 5.40258 0 28.9694
+    endloop
+  endfacet
+  facet normal -0.987691 0 0.156416
+    outer loop
+      vertex 5.45663 0 29.3107
+      vertex 5.40258 -2.7 28.9694
+      vertex 5.45663 -2.7 29.3107
+    endloop
+  endfacet
+  facet normal -0.827107 0 0.562045
+    outer loop
+      vertex 4.44959 -2.7 26.7672
+      vertex 4.6438 0 27.053
+      vertex 4.44959 0 26.7672
+    endloop
+  endfacet
+  facet normal -0.827107 0 0.562045
+    outer loop
+      vertex 4.6438 0 27.053
+      vertex 4.44959 -2.7 26.7672
+      vertex 4.6438 -2.7 27.053
+    endloop
+  endfacet
+  facet normal -0.860732 0 -0.509059
+    outer loop
+      vertex 4.81969 -2.7 32.6496
+      vertex 4.6438 0 32.947
+      vertex 4.81969 0 32.6496
+    endloop
+  endfacet
+  facet normal -0.860732 -0 -0.509059
+    outer loop
+      vertex 4.6438 0 32.947
+      vertex 4.81969 -2.7 32.6496
+      vertex 4.6438 -2.7 32.947
+    endloop
+  endfacet
+  facet normal -0.397329 0 -0.917676
+    outer loop
+      vertex 2.02468 -2.7 35.1138
+      vertex 2.34179 0 34.9765
+      vertex 2.34179 -2.7 34.9765
+    endloop
+  endfacet
+  facet normal -0.397329 0 -0.917676
+    outer loop
+      vertex 2.34179 0 34.9765
+      vertex 2.02468 -2.7 35.1138
+      vertex 2.02468 0 35.1138
+    endloop
+  endfacet
+  facet normal 0.707078 0 -0.707136
+    outer loop
+      vertex -4.00933 -2.7 33.765
+      vertex -3.76501 0 34.0093
+      vertex -3.76501 -2.7 34.0093
+    endloop
+  endfacet
+  facet normal 0.707078 0 -0.707136
+    outer loop
+      vertex -3.76501 0 34.0093
+      vertex -4.00933 -2.7 33.765
+      vertex -4.00933 0 33.765
+    endloop
+  endfacet
+  facet normal -0.279 0 0.960291
+    outer loop
+      vertex 1.36779 0 24.6728
+      vertex 1.69959 -2.7 24.7692
+      vertex 1.69959 0 24.7692
+    endloop
+  endfacet
+  facet normal -0.279 0 0.960291
+    outer loop
+      vertex 1.69959 -2.7 24.7692
+      vertex 1.36779 0 24.6728
+      vertex 1.36779 -2.7 24.6728
+    endloop
+  endfacet
+  facet normal -0.975919 0 0.218135
+    outer loop
+      vertex 5.32721 -2.7 28.6322
+      vertex 5.40258 0 28.9694
+      vertex 5.32721 0 28.6322
+    endloop
+  endfacet
+  facet normal -0.975919 0 0.218135
+    outer loop
+      vertex 5.40258 0 28.9694
+      vertex 5.32721 -2.7 28.6322
+      vertex 5.40258 -2.7 28.9694
+    endloop
+  endfacet
+  facet normal -0.999507 0 0.0314065
+    outer loop
+      vertex 5.48915 -2.7 29.6547
+      vertex 5.5 0 30
+      vertex 5.48915 0 29.6547
+    endloop
+  endfacet
+  facet normal -0.999507 0 0.0314065
+    outer loop
+      vertex 5.5 0 30
+      vertex 5.48915 -2.7 29.6547
+      vertex 5.5 -2.7 30
+    endloop
+  endfacet
+  facet normal -0.562065 0 -0.827093
+    outer loop
+      vertex 2.94705 -2.7 34.6438
+      vertex 3.23282 0 34.4496
+      vertex 3.23282 -2.7 34.4496
+    endloop
+  endfacet
+  facet normal -0.562065 0 -0.827093
+    outer loop
+      vertex 3.23282 0 34.4496
+      vertex 2.94705 -2.7 34.6438
+      vertex 2.94705 0 34.6438
+    endloop
+  endfacet
+  facet normal 0.707078 -0 0.707136
+    outer loop
+      vertex -4.00933 -2.7 26.235
+      vertex -3.76501 0 25.9907
+      vertex -4.00933 0 26.235
+    endloop
+  endfacet
+  facet normal 0.707078 0 0.707136
+    outer loop
+      vertex -3.76501 0 25.9907
+      vertex -4.00933 -2.7 26.235
+      vertex -3.76501 -2.7 25.9907
+    endloop
+  endfacet
+  facet normal -0.827107 0 -0.562045
+    outer loop
+      vertex 4.6438 -2.7 32.947
+      vertex 4.44959 0 33.2328
+      vertex 4.6438 0 32.947
+    endloop
+  endfacet
+  facet normal -0.827107 -0 -0.562045
+    outer loop
+      vertex 4.44959 0 33.2328
+      vertex 4.6438 -2.7 32.947
+      vertex 4.44959 -2.7 33.2328
+    endloop
+  endfacet
+  facet normal -0.453859 0 -0.891074
+    outer loop
+      vertex 2.34179 -2.7 34.9765
+      vertex 2.64964 0 34.8197
+      vertex 2.64964 -2.7 34.8197
+    endloop
+  endfacet
+  facet normal -0.453859 0 -0.891074
+    outer loop
+      vertex 2.64964 0 34.8197
+      vertex 2.34179 -2.7 34.9765
+      vertex 2.34179 0 34.9765
+    endloop
+  endfacet
+  facet normal -0.917756 0 0.397144
+    outer loop
+      vertex 4.97655 -2.7 27.6582
+      vertex 5.11377 0 27.9753
+      vertex 4.97655 0 27.6582
+    endloop
+  endfacet
+  facet normal -0.917756 0 0.397144
+    outer loop
+      vertex 5.11377 0 27.9753
+      vertex 4.97655 -2.7 27.6582
+      vertex 5.11377 -2.7 27.9753
     endloop
   endfacet
   facet normal 0.995561 -0 0.0941207
@@ -9281,872 +9267,60 @@ solid OpenSCAD_Model
       vertex -5.45663 -2.7 9.31067
     endloop
   endfacet
-  facet normal -0.0314022 0 0.999507
+  facet normal 0.999507 -0 0.0314019
     outer loop
-      vertex 0 0 4.5
-      vertex 0.345347 -2.7 4.51085
-      vertex 0.345347 0 4.51085
-    endloop
-  endfacet
-  facet normal -0.0314022 0 0.999507
-    outer loop
-      vertex 0.345347 -2.7 4.51085
-      vertex 0 0 4.5
-      vertex 0 -2.7 4.5
-    endloop
-  endfacet
-  facet normal 0.661299 0 0.750122
-    outer loop
-      vertex -3.76501 0 5.99067
-      vertex -3.50583 -2.7 5.76218
-      vertex -3.50583 0 5.76218
-    endloop
-  endfacet
-  facet normal 0.661299 0 0.750122
-    outer loop
-      vertex -3.50583 -2.7 5.76218
-      vertex -3.76501 0 5.99067
-      vertex -3.76501 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal -0.750122 0 0.661299
-    outer loop
-      vertex 4.00933 -2.7 6.23499
-      vertex 4.23782 0 6.49417
-      vertex 4.00933 0 6.23499
-    endloop
-  endfacet
-  facet normal -0.750122 0 0.661299
-    outer loop
-      vertex 4.23782 0 6.49417
-      vertex 4.00933 -2.7 6.23499
-      vertex 4.23782 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal -0.397134 0 0.917761
-    outer loop
-      vertex 2.02468 0 4.88623
-      vertex 2.34179 -2.7 5.02345
-      vertex 2.34179 0 5.02345
-    endloop
-  endfacet
-  facet normal -0.397134 0 0.917761
-    outer loop
-      vertex 2.34179 -2.7 5.02345
-      vertex 2.02468 0 4.88623
-      vertex 2.02468 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal 0.094062 0 -0.995566
-    outer loop
-      vertex -0.689332 -2.7 15.4566
-      vertex -0.345347 0 15.4891
-      vertex -0.345347 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal 0.094062 0 -0.995566
-    outer loop
-      vertex -0.345347 0 15.4891
-      vertex -0.689332 -2.7 15.4566
-      vertex -0.689332 0 15.4566
-    endloop
-  endfacet
-  facet normal 0.917761 -0 0.397134
-    outer loop
-      vertex -5.11377 -2.7 7.97532
-      vertex -4.97655 0 7.65821
-      vertex -5.11377 0 7.97532
-    endloop
-  endfacet
-  facet normal 0.917761 0 0.397134
-    outer loop
-      vertex -4.97655 0 7.65821
-      vertex -5.11377 -2.7 7.97532
-      vertex -4.97655 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal 0.338739 0 0.94088
-    outer loop
-      vertex -2.02468 0 4.88623
-      vertex -1.69959 -2.7 4.76919
-      vertex -1.69959 0 4.76919
-    endloop
-  endfacet
-  facet normal 0.338739 0 0.94088
-    outer loop
-      vertex -1.69959 -2.7 4.76919
-      vertex -2.02468 0 4.88623
-      vertex -2.02468 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal 0.509046 0 0.860739
-    outer loop
-      vertex -2.94705 0 5.3562
-      vertex -2.64964 -2.7 5.18031
-      vertex -2.64964 0 5.18031
-    endloop
-  endfacet
-  facet normal 0.509046 0 0.860739
-    outer loop
-      vertex -2.64964 -2.7 5.18031
-      vertex -2.94705 0 5.3562
-      vertex -2.94705 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal -0.94088 0 0.338739
-    outer loop
-      vertex 5.11377 -2.7 7.97532
-      vertex 5.23081 0 8.30041
-      vertex 5.11377 0 7.97532
-    endloop
-  endfacet
-  facet normal -0.94088 0 0.338739
-    outer loop
-      vertex 5.23081 0 8.30041
-      vertex 5.11377 -2.7 7.97532
-      vertex 5.23081 -2.7 8.30041
-    endloop
-  endfacet
-  facet normal -0.827079 0 0.562085
-    outer loop
-      vertex 4.44959 -2.7 6.76718
-      vertex 4.6438 0 7.05295
-      vertex 4.44959 0 6.76718
-    endloop
-  endfacet
-  facet normal -0.827079 0 0.562085
-    outer loop
-      vertex 4.6438 0 7.05295
-      vertex 4.44959 -2.7 6.76718
-      vertex 4.6438 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal -0.218141 0 0.975917
-    outer loop
-      vertex 1.0306 0 4.59742
-      vertex 1.36779 -2.7 4.67279
-      vertex 1.36779 0 4.67279
-    endloop
-  endfacet
-  facet normal -0.218141 0 0.975917
-    outer loop
-      vertex 1.36779 -2.7 4.67279
-      vertex 1.0306 0 4.59742
-      vertex 1.0306 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal 0.960291 0 -0.279
-    outer loop
-      vertex -5.23081 -2.7 11.6996
-      vertex -5.32721 0 11.3678
-      vertex -5.23081 0 11.6996
-    endloop
-  endfacet
-  facet normal 0.960291 0 -0.279
-    outer loop
-      vertex -5.32721 0 11.3678
-      vertex -5.23081 -2.7 11.6996
-      vertex -5.32721 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal -0.917756 0 -0.397144
-    outer loop
-      vertex 5.11377 -2.7 12.0247
-      vertex 4.97655 0 12.3418
-      vertex 5.11377 0 12.0247
-    endloop
-  endfacet
-  facet normal -0.917756 -0 -0.397144
-    outer loop
-      vertex 4.97655 0 12.3418
-      vertex 5.11377 -2.7 12.0247
-      vertex 4.97655 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal 0.790153 -0 0.61291
-    outer loop
-      vertex -4.44959 -2.7 6.76718
-      vertex -4.23782 0 6.49417
-      vertex -4.44959 0 6.76718
-    endloop
-  endfacet
-  facet normal 0.790153 0 0.61291
-    outer loop
-      vertex -4.23782 0 6.49417
-      vertex -4.44959 -2.7 6.76718
-      vertex -4.23782 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal 0.279 0 0.960291
-    outer loop
-      vertex -1.69959 0 4.76919
-      vertex -1.36779 -2.7 4.67279
-      vertex -1.36779 0 4.67279
-    endloop
-  endfacet
-  facet normal 0.279 0 0.960291
-    outer loop
-      vertex -1.36779 -2.7 4.67279
-      vertex -1.69959 0 4.76919
-      vertex -1.69959 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal 0.0314022 0 0.999507
-    outer loop
-      vertex -0.345347 0 4.51085
-      vertex 0 -2.7 4.5
-      vertex 0 0 4.5
-    endloop
-  endfacet
-  facet normal 0.0314022 0 0.999507
-    outer loop
-      vertex 0 -2.7 4.5
-      vertex -0.345347 0 4.51085
-      vertex -0.345347 -2.7 4.51085
-    endloop
-  endfacet
-  facet normal 0.397134 0 0.917761
-    outer loop
-      vertex -2.34179 0 5.02345
-      vertex -2.02468 -2.7 4.88623
-      vertex -2.02468 0 4.88623
-    endloop
-  endfacet
-  facet normal 0.397134 0 0.917761
-    outer loop
-      vertex -2.02468 -2.7 4.88623
-      vertex -2.34179 0 5.02345
-      vertex -2.34179 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal -0.860739 0 0.509046
-    outer loop
-      vertex 4.6438 -2.7 7.05295
-      vertex 4.81969 0 7.35036
-      vertex 4.6438 0 7.05295
-    endloop
-  endfacet
-  facet normal -0.860739 0 0.509046
-    outer loop
-      vertex 4.81969 0 7.35036
-      vertex 4.6438 -2.7 7.05295
-      vertex 4.81969 -2.7 7.35036
-    endloop
-  endfacet
-  facet normal -0.960291 0 0.279
-    outer loop
-      vertex 5.23081 -2.7 8.30041
-      vertex 5.32721 0 8.63221
-      vertex 5.23081 0 8.30041
-    endloop
-  endfacet
-  facet normal -0.960291 0 0.279
-    outer loop
-      vertex 5.32721 0 8.63221
-      vertex 5.23081 -2.7 8.30041
-      vertex 5.32721 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal -0.999507 0 0.0314019
-    outer loop
-      vertex 5.48915 -2.7 9.65465
-      vertex 5.5 0 10
-      vertex 5.48915 0 9.65465
-    endloop
-  endfacet
-  facet normal -0.999507 0 0.0314019
-    outer loop
-      vertex 5.5 0 10
-      vertex 5.48915 -2.7 9.65465
-      vertex 5.5 -2.7 10
-    endloop
-  endfacet
-  facet normal -0.509046 0 0.860739
-    outer loop
-      vertex 2.64964 0 5.18031
-      vertex 2.94705 -2.7 5.3562
-      vertex 2.94705 0 5.3562
-    endloop
-  endfacet
-  facet normal -0.509046 0 0.860739
-    outer loop
-      vertex 2.94705 -2.7 5.3562
-      vertex 2.64964 0 5.18031
-      vertex 2.64964 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal -0.338739 0 0.94088
-    outer loop
-      vertex 1.69959 0 4.76919
-      vertex 2.02468 -2.7 4.88623
-      vertex 2.02468 0 4.88623
-    endloop
-  endfacet
-  facet normal -0.338739 0 0.94088
-    outer loop
-      vertex 2.02468 -2.7 4.88623
-      vertex 1.69959 0 4.76919
-      vertex 1.69959 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal 0.750148 0 -0.66127
-    outer loop
-      vertex -4.00933 -2.7 13.765
-      vertex -4.23782 0 13.5058
-      vertex -4.00933 0 13.765
-    endloop
-  endfacet
-  facet normal 0.750148 0 -0.66127
-    outer loop
-      vertex -4.23782 0 13.5058
-      vertex -4.00933 -2.7 13.765
-      vertex -4.23782 -2.7 13.5058
-    endloop
-  endfacet
-  facet normal 0.612964 0 -0.790111
-    outer loop
-      vertex -3.50583 -2.7 14.2378
-      vertex -3.23282 0 14.4496
-      vertex -3.23282 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal 0.612964 0 -0.790111
-    outer loop
-      vertex -3.23282 0 14.4496
-      vertex -3.50583 -2.7 14.2378
-      vertex -3.50583 0 14.2378
-    endloop
-  endfacet
-  facet normal 0.999507 0 -0.0314065
-    outer loop
-      vertex -5.48915 -2.7 10.3453
-      vertex -5.5 0 10
-      vertex -5.48915 0 10.3453
-    endloop
-  endfacet
-  facet normal 0.999507 0 -0.0314065
-    outer loop
-      vertex -5.5 0 10
-      vertex -5.48915 -2.7 10.3453
       vertex -5.5 -2.7 10
+      vertex -5.48915 0 9.65465
+      vertex -5.5 0 10
     endloop
   endfacet
-  facet normal -0.279 0 -0.960291
+  facet normal 0.999507 0 0.0314019
     outer loop
-      vertex 1.36779 -2.7 15.3272
-      vertex 1.69959 0 15.2308
-      vertex 1.69959 -2.7 15.2308
+      vertex -5.48915 0 9.65465
+      vertex -5.5 -2.7 10
+      vertex -5.48915 -2.7 9.65465
     endloop
   endfacet
-  facet normal -0.279 0 -0.960291
+  facet normal 0.790142 0 -0.612924
     outer loop
-      vertex 1.69959 0 15.2308
-      vertex 1.36779 -2.7 15.3272
-      vertex 1.36779 0 15.3272
-    endloop
-  endfacet
-  facet normal 0.975917 -0 0.218141
-    outer loop
-      vertex -5.40258 -2.7 8.9694
-      vertex -5.32721 0 8.63221
-      vertex -5.40258 0 8.9694
-    endloop
-  endfacet
-  facet normal 0.975917 0 0.218141
-    outer loop
-      vertex -5.32721 0 8.63221
-      vertex -5.40258 -2.7 8.9694
-      vertex -5.32721 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal 0.987689 -0 0.156429
-    outer loop
-      vertex -5.45663 -2.7 9.31067
-      vertex -5.40258 0 8.9694
-      vertex -5.45663 0 9.31067
-    endloop
-  endfacet
-  facet normal 0.987689 0 0.156429
-    outer loop
-      vertex -5.40258 0 8.9694
-      vertex -5.45663 -2.7 9.31067
-      vertex -5.40258 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal 0.94088 -0 0.338739
-    outer loop
-      vertex -5.23081 -2.7 8.30041
-      vertex -5.11377 0 7.97532
-      vertex -5.23081 0 8.30041
-    endloop
-  endfacet
-  facet normal 0.94088 0 0.338739
-    outer loop
-      vertex -5.11377 0 7.97532
-      vertex -5.23081 -2.7 8.30041
-      vertex -5.11377 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal 0.750122 -0 0.661299
-    outer loop
-      vertex -4.23782 -2.7 6.49417
-      vertex -4.00933 0 6.23499
-      vertex -4.23782 0 6.49417
-    endloop
-  endfacet
-  facet normal 0.750122 0 0.661299
-    outer loop
-      vertex -4.00933 0 6.23499
-      vertex -4.23782 -2.7 6.49417
-      vertex -4.00933 -2.7 6.23499
-    endloop
-  endfacet
-  facet normal 0.860739 -0 0.509046
-    outer loop
-      vertex -4.81969 -2.7 7.35036
-      vertex -4.6438 0 7.05295
-      vertex -4.81969 0 7.35036
-    endloop
-  endfacet
-  facet normal 0.860739 0 0.509046
-    outer loop
-      vertex -4.6438 0 7.05295
-      vertex -4.81969 -2.7 7.35036
-      vertex -4.6438 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal 0.15643 0 0.987689
-    outer loop
-      vertex -1.0306 0 4.59742
-      vertex -0.689332 -2.7 4.54337
-      vertex -0.689332 0 4.54337
-    endloop
-  endfacet
-  facet normal 0.15643 0 0.987689
-    outer loop
-      vertex -0.689332 -2.7 4.54337
-      vertex -1.0306 0 4.59742
-      vertex -1.0306 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal 0.218141 0 0.975917
-    outer loop
-      vertex -1.36779 0 4.67279
-      vertex -1.0306 -2.7 4.59742
-      vertex -1.0306 0 4.59742
-    endloop
-  endfacet
-  facet normal 0.218141 0 0.975917
-    outer loop
-      vertex -1.0306 -2.7 4.59742
-      vertex -1.36779 0 4.67279
-      vertex -1.36779 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal 0.562085 0 0.827079
-    outer loop
-      vertex -3.23282 0 5.55041
-      vertex -2.94705 -2.7 5.3562
-      vertex -2.94705 0 5.3562
-    endloop
-  endfacet
-  facet normal 0.562085 0 0.827079
-    outer loop
-      vertex -2.94705 -2.7 5.3562
-      vertex -3.23282 0 5.55041
-      vertex -3.23282 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal -0.917761 0 0.397134
-    outer loop
-      vertex 4.97655 -2.7 7.65821
-      vertex 5.11377 0 7.97532
-      vertex 4.97655 0 7.65821
-    endloop
-  endfacet
-  facet normal -0.917761 0 0.397134
-    outer loop
-      vertex 5.11377 0 7.97532
-      vertex 4.97655 -2.7 7.65821
-      vertex 5.11377 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal -0.987689 0 0.156429
-    outer loop
-      vertex 5.40258 -2.7 8.9694
-      vertex 5.45663 0 9.31067
-      vertex 5.40258 0 8.9694
-    endloop
-  endfacet
-  facet normal -0.987689 0 0.156429
-    outer loop
-      vertex 5.45663 0 9.31067
-      vertex 5.40258 -2.7 8.9694
-      vertex 5.45663 -2.7 9.31067
-    endloop
-  endfacet
-  facet normal -0.975917 0 0.218141
-    outer loop
-      vertex 5.32721 -2.7 8.63221
-      vertex 5.40258 0 8.9694
-      vertex 5.32721 0 8.63221
-    endloop
-  endfacet
-  facet normal -0.975917 0 0.218141
-    outer loop
-      vertex 5.40258 0 8.9694
-      vertex 5.32721 -2.7 8.63221
-      vertex 5.40258 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal -0.999507 0 -0.0314065
-    outer loop
-      vertex 5.5 -2.7 10
-      vertex 5.48915 0 10.3453
-      vertex 5.5 0 10
-    endloop
-  endfacet
-  facet normal -0.999507 -0 -0.0314065
-    outer loop
-      vertex 5.48915 0 10.3453
-      vertex 5.5 -2.7 10
-      vertex 5.48915 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal -0.61291 0 0.790153
-    outer loop
-      vertex 3.23282 0 5.55041
-      vertex 3.50583 -2.7 5.76218
-      vertex 3.50583 0 5.76218
-    endloop
-  endfacet
-  facet normal -0.61291 0 0.790153
-    outer loop
-      vertex 3.50583 -2.7 5.76218
-      vertex 3.23282 0 5.55041
-      vertex 3.23282 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal -0.562085 0 0.827079
-    outer loop
-      vertex 2.94705 0 5.3562
-      vertex 3.23282 -2.7 5.55041
-      vertex 3.23282 0 5.55041
-    endloop
-  endfacet
-  facet normal -0.562085 0 0.827079
-    outer loop
-      vertex 3.23282 -2.7 5.55041
-      vertex 2.94705 0 5.3562
-      vertex 2.94705 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal -0.661299 0 0.750122
-    outer loop
-      vertex 3.50583 0 5.76218
-      vertex 3.76501 -2.7 5.99067
-      vertex 3.76501 0 5.99067
-    endloop
-  endfacet
-  facet normal -0.661299 0 0.750122
-    outer loop
-      vertex 3.76501 -2.7 5.99067
-      vertex 3.50583 0 5.76218
-      vertex 3.50583 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal -0.0941193 0 0.995561
-    outer loop
-      vertex 0.345347 0 4.51085
-      vertex 0.689332 -2.7 4.54337
-      vertex 0.689332 0 4.54337
-    endloop
-  endfacet
-  facet normal -0.0941193 0 0.995561
-    outer loop
-      vertex 0.689332 -2.7 4.54337
-      vertex 0.345347 0 4.51085
-      vertex 0.345347 -2.7 4.51085
-    endloop
-  endfacet
-  facet normal 0.156289 0 -0.987711
-    outer loop
-      vertex -1.0306 -2.7 15.4026
-      vertex -0.689332 0 15.4566
-      vertex -0.689332 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal 0.156289 0 -0.987711
-    outer loop
-      vertex -0.689332 0 15.4566
-      vertex -1.0306 -2.7 15.4026
-      vertex -1.0306 0 15.4026
-    endloop
-  endfacet
-  facet normal 0.397329 0 -0.917676
-    outer loop
-      vertex -2.34179 -2.7 14.9765
-      vertex -2.02468 0 15.1138
-      vertex -2.02468 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal 0.397329 0 -0.917676
-    outer loop
-      vertex -2.02468 0 15.1138
-      vertex -2.34179 -2.7 14.9765
-      vertex -2.34179 0 14.9765
-    endloop
-  endfacet
-  facet normal 0.661315 0 -0.750108
-    outer loop
-      vertex -3.76501 -2.7 14.0093
-      vertex -3.50583 0 14.2378
-      vertex -3.50583 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal 0.661315 0 -0.750108
-    outer loop
-      vertex -3.50583 0 14.2378
-      vertex -3.76501 -2.7 14.0093
-      vertex -3.76501 0 14.0093
-    endloop
-  endfacet
-  facet normal 0.562065 0 -0.827093
-    outer loop
-      vertex -3.23282 -2.7 14.4496
-      vertex -2.94705 0 14.6438
-      vertex -2.94705 -2.7 14.6438
-    endloop
-  endfacet
-  facet normal 0.562065 0 -0.827093
-    outer loop
-      vertex -2.94705 0 14.6438
-      vertex -3.23282 -2.7 14.4496
-      vertex -3.23282 0 14.4496
-    endloop
-  endfacet
-  facet normal 0.860732 0 -0.509059
-    outer loop
-      vertex -4.6438 -2.7 12.947
-      vertex -4.81969 0 12.6496
-      vertex -4.6438 0 12.947
-    endloop
-  endfacet
-  facet normal 0.860732 0 -0.509059
-    outer loop
-      vertex -4.81969 0 12.6496
-      vertex -4.6438 -2.7 12.947
-      vertex -4.81969 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal 0.827107 0 -0.562045
-    outer loop
-      vertex -4.44959 -2.7 13.2328
-      vertex -4.6438 0 12.947
+      vertex -4.23782 -2.7 13.5058
       vertex -4.44959 0 13.2328
+      vertex -4.23782 0 13.5058
     endloop
   endfacet
-  facet normal 0.827107 0 -0.562045
+  facet normal 0.790142 0 -0.612924
     outer loop
-      vertex -4.6438 0 12.947
+      vertex -4.44959 0 13.2328
+      vertex -4.23782 -2.7 13.5058
       vertex -4.44959 -2.7 13.2328
-      vertex -4.6438 -2.7 12.947
     endloop
   endfacet
-  facet normal 0.940884 0 -0.33873
+  facet normal 0.975919 0 -0.218135
     outer loop
-      vertex -5.11377 -2.7 12.0247
-      vertex -5.23081 0 11.6996
-      vertex -5.11377 0 12.0247
+      vertex -5.32721 -2.7 11.3678
+      vertex -5.40258 0 11.0306
+      vertex -5.32721 0 11.3678
     endloop
   endfacet
-  facet normal 0.940884 0 -0.33873
+  facet normal 0.975919 0 -0.218135
     outer loop
-      vertex -5.23081 0 11.6996
-      vertex -5.11377 -2.7 12.0247
-      vertex -5.23081 -2.7 11.6996
+      vertex -5.40258 0 11.0306
+      vertex -5.32721 -2.7 11.3678
+      vertex -5.40258 -2.7 11.0306
     endloop
   endfacet
-  facet normal -0.509068 0 -0.860727
+  facet normal -0.960291 0 0.279
     outer loop
-      vertex 2.64964 -2.7 14.8197
-      vertex 2.94705 0 14.6438
-      vertex 2.94705 -2.7 14.6438
+      vertex 5.23081 -2.7 8.30041
+      vertex 5.32721 0 8.63221
+      vertex 5.23081 0 8.30041
     endloop
   endfacet
-  facet normal -0.509068 0 -0.860727
+  facet normal -0.960291 0 0.279
     outer loop
-      vertex 2.94705 0 14.6438
-      vertex 2.64964 -2.7 14.8197
-      vertex 2.64964 0 14.8197
-    endloop
-  endfacet
-  facet normal -0.562065 0 -0.827093
-    outer loop
-      vertex 2.94705 -2.7 14.6438
-      vertex 3.23282 0 14.4496
-      vertex 3.23282 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal -0.562065 0 -0.827093
-    outer loop
-      vertex 3.23282 0 14.4496
-      vertex 2.94705 -2.7 14.6438
-      vertex 2.94705 0 14.6438
-    endloop
-  endfacet
-  facet normal -0.338636 0 -0.940917
-    outer loop
-      vertex 1.69959 -2.7 15.2308
-      vertex 2.02468 0 15.1138
-      vertex 2.02468 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal -0.338636 0 -0.940917
-    outer loop
-      vertex 2.02468 0 15.1138
-      vertex 1.69959 -2.7 15.2308
-      vertex 1.69959 0 15.2308
-    endloop
-  endfacet
-  facet normal -0.218223 0 -0.975899
-    outer loop
-      vertex 1.0306 -2.7 15.4026
-      vertex 1.36779 0 15.3272
-      vertex 1.36779 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal -0.218223 0 -0.975899
-    outer loop
-      vertex 1.36779 0 15.3272
-      vertex 1.0306 -2.7 15.4026
-      vertex 1.0306 0 15.4026
-    endloop
-  endfacet
-  facet normal -0.094062 0 -0.995566
-    outer loop
-      vertex 0.345347 -2.7 15.4891
-      vertex 0.689332 0 15.4566
-      vertex 0.689332 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal -0.094062 0 -0.995566
-    outer loop
-      vertex 0.689332 0 15.4566
-      vertex 0.345347 -2.7 15.4891
-      vertex 0.345347 0 15.4891
-    endloop
-  endfacet
-  facet normal 0.0315467 0 -0.999502
-    outer loop
-      vertex -0.345347 -2.7 15.4891
-      vertex 0 0 15.5
-      vertex 0 -2.7 15.5
-    endloop
-  endfacet
-  facet normal 0.0315467 0 -0.999502
-    outer loop
-      vertex 0 0 15.5
-      vertex -0.345347 -2.7 15.4891
-      vertex -0.345347 0 15.4891
-    endloop
-  endfacet
-  facet normal -0.750148 0 -0.66127
-    outer loop
-      vertex 4.23782 -2.7 13.5058
-      vertex 4.00933 0 13.765
-      vertex 4.23782 0 13.5058
-    endloop
-  endfacet
-  facet normal -0.750148 -0 -0.66127
-    outer loop
-      vertex 4.00933 0 13.765
-      vertex 4.23782 -2.7 13.5058
-      vertex 4.00933 -2.7 13.765
-    endloop
-  endfacet
-  facet normal -0.890974 0 -0.454055
-    outer loop
-      vertex 4.97655 -2.7 12.3418
-      vertex 4.81969 0 12.6496
-      vertex 4.97655 0 12.3418
-    endloop
-  endfacet
-  facet normal -0.890974 -0 -0.454055
-    outer loop
-      vertex 4.81969 0 12.6496
-      vertex 4.97655 -2.7 12.3418
-      vertex 4.81969 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal -0.960291 0 -0.279
-    outer loop
-      vertex 5.32721 -2.7 11.3678
-      vertex 5.23081 0 11.6996
-      vertex 5.32721 0 11.3678
-    endloop
-  endfacet
-  facet normal -0.960291 -0 -0.279
-    outer loop
-      vertex 5.23081 0 11.6996
-      vertex 5.32721 -2.7 11.3678
-      vertex 5.23081 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal -0.995561 0 -0.0941153
-    outer loop
-      vertex 5.48915 -2.7 10.3453
-      vertex 5.45663 0 10.6893
-      vertex 5.48915 0 10.3453
-    endloop
-  endfacet
-  facet normal -0.995561 -0 -0.0941153
-    outer loop
-      vertex 5.45663 0 10.6893
-      vertex 5.48915 -2.7 10.3453
-      vertex 5.45663 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0.960291 -0 0.279
-    outer loop
-      vertex -5.32721 -2.7 8.63221
-      vertex -5.23081 0 8.30041
-      vertex -5.32721 0 8.63221
-    endloop
-  endfacet
-  facet normal 0.960291 0 0.279
-    outer loop
-      vertex -5.23081 0 8.30041
-      vertex -5.32721 -2.7 8.63221
-      vertex -5.23081 -2.7 8.30041
-    endloop
-  endfacet
-  facet normal 0.707107 -0 0.707107
-    outer loop
-      vertex -4.00933 -2.7 6.23499
-      vertex -3.76501 0 5.99067
-      vertex -4.00933 0 6.23499
-    endloop
-  endfacet
-  facet normal 0.707107 0 0.707107
-    outer loop
-      vertex -3.76501 0 5.99067
-      vertex -4.00933 -2.7 6.23499
-      vertex -3.76501 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal 0.827079 -0 0.562085
-    outer loop
-      vertex -4.6438 -2.7 7.05295
-      vertex -4.44959 0 6.76718
-      vertex -4.6438 0 7.05295
-    endloop
-  endfacet
-  facet normal 0.827079 0 0.562085
-    outer loop
-      vertex -4.44959 0 6.76718
-      vertex -4.6438 -2.7 7.05295
-      vertex -4.44959 -2.7 6.76718
+      vertex 5.32721 0 8.63221
+      vertex 5.23081 -2.7 8.30041
+      vertex 5.32721 -2.7 8.63221
     endloop
   endfacet
   facet normal 0.891003 -0 0.453996
@@ -10163,60 +9337,186 @@ solid OpenSCAD_Model
       vertex -4.81969 -2.7 7.35036
     endloop
   endfacet
-  facet normal 0.0941193 0 0.995561
+  facet normal -0.397134 0 0.917761
     outer loop
-      vertex -0.689332 0 4.54337
-      vertex -0.345347 -2.7 4.51085
+      vertex 2.02468 0 4.88623
+      vertex 2.34179 -2.7 5.02345
+      vertex 2.34179 0 5.02345
+    endloop
+  endfacet
+  facet normal -0.397134 0 0.917761
+    outer loop
+      vertex 2.34179 -2.7 5.02345
+      vertex 2.02468 0 4.88623
+      vertex 2.02468 -2.7 4.88623
+    endloop
+  endfacet
+  facet normal 0.218223 0 -0.975899
+    outer loop
+      vertex -1.36779 -2.7 15.3272
+      vertex -1.0306 0 15.4026
+      vertex -1.0306 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal 0.218223 0 -0.975899
+    outer loop
+      vertex -1.0306 0 15.4026
+      vertex -1.36779 -2.7 15.3272
+      vertex -1.36779 0 15.3272
+    endloop
+  endfacet
+  facet normal -0.338636 0 -0.940917
+    outer loop
+      vertex 1.69959 -2.7 15.2308
+      vertex 2.02468 0 15.1138
+      vertex 2.02468 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal -0.338636 0 -0.940917
+    outer loop
+      vertex 2.02468 0 15.1138
+      vertex 1.69959 -2.7 15.2308
+      vertex 1.69959 0 15.2308
+    endloop
+  endfacet
+  facet normal -0.707078 0 -0.707136
+    outer loop
+      vertex 4.00933 -2.7 13.765
+      vertex 3.76501 0 14.0093
+      vertex 4.00933 0 13.765
+    endloop
+  endfacet
+  facet normal -0.707078 -0 -0.707136
+    outer loop
+      vertex 3.76501 0 14.0093
+      vertex 4.00933 -2.7 13.765
+      vertex 3.76501 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal -0.338739 0 0.94088
+    outer loop
+      vertex 1.69959 0 4.76919
+      vertex 2.02468 -2.7 4.88623
+      vertex 2.02468 0 4.88623
+    endloop
+  endfacet
+  facet normal -0.338739 0 0.94088
+    outer loop
+      vertex 2.02468 -2.7 4.88623
+      vertex 1.69959 0 4.76919
+      vertex 1.69959 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal 0.750122 -0 0.661299
+    outer loop
+      vertex -4.23782 -2.7 6.49417
+      vertex -4.00933 0 6.23499
+      vertex -4.23782 0 6.49417
+    endloop
+  endfacet
+  facet normal 0.750122 0 0.661299
+    outer loop
+      vertex -4.00933 0 6.23499
+      vertex -4.23782 -2.7 6.49417
+      vertex -4.00933 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal 0.975917 -0 0.218141
+    outer loop
+      vertex -5.40258 -2.7 8.9694
+      vertex -5.32721 0 8.63221
+      vertex -5.40258 0 8.9694
+    endloop
+  endfacet
+  facet normal 0.975917 0 0.218141
+    outer loop
+      vertex -5.32721 0 8.63221
+      vertex -5.40258 -2.7 8.9694
+      vertex -5.32721 -2.7 8.63221
+    endloop
+  endfacet
+  facet normal 0.917756 0 -0.397144
+    outer loop
+      vertex -4.97655 -2.7 12.3418
+      vertex -5.11377 0 12.0247
+      vertex -4.97655 0 12.3418
+    endloop
+  endfacet
+  facet normal 0.917756 0 -0.397144
+    outer loop
+      vertex -5.11377 0 12.0247
+      vertex -4.97655 -2.7 12.3418
+      vertex -5.11377 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal 0.890974 0 -0.454055
+    outer loop
+      vertex -4.81969 -2.7 12.6496
+      vertex -4.97655 0 12.3418
+      vertex -4.81969 0 12.6496
+    endloop
+  endfacet
+  facet normal 0.890974 0 -0.454055
+    outer loop
+      vertex -4.97655 0 12.3418
+      vertex -4.81969 -2.7 12.6496
+      vertex -4.97655 -2.7 12.3418
+    endloop
+  endfacet
+  facet normal 0.860739 -0 0.509046
+    outer loop
+      vertex -4.81969 -2.7 7.35036
+      vertex -4.6438 0 7.05295
+      vertex -4.81969 0 7.35036
+    endloop
+  endfacet
+  facet normal 0.860739 0 0.509046
+    outer loop
+      vertex -4.6438 0 7.05295
+      vertex -4.81969 -2.7 7.35036
+      vertex -4.6438 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal 0.156289 0 -0.987711
+    outer loop
+      vertex -1.0306 -2.7 15.4026
+      vertex -0.689332 0 15.4566
+      vertex -0.689332 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal 0.156289 0 -0.987711
+    outer loop
+      vertex -0.689332 0 15.4566
+      vertex -1.0306 -2.7 15.4026
+      vertex -1.0306 0 15.4026
+    endloop
+  endfacet
+  facet normal 0.860732 0 -0.509059
+    outer loop
+      vertex -4.6438 -2.7 12.947
+      vertex -4.81969 0 12.6496
+      vertex -4.6438 0 12.947
+    endloop
+  endfacet
+  facet normal 0.860732 0 -0.509059
+    outer loop
+      vertex -4.81969 0 12.6496
+      vertex -4.6438 -2.7 12.947
+      vertex -4.81969 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal 0.0314022 0 0.999507
+    outer loop
       vertex -0.345347 0 4.51085
+      vertex 0 -2.7 4.5
+      vertex 0 0 4.5
     endloop
   endfacet
-  facet normal 0.0941193 0 0.995561
+  facet normal 0.0314022 0 0.999507
     outer loop
+      vertex 0 -2.7 4.5
+      vertex -0.345347 0 4.51085
       vertex -0.345347 -2.7 4.51085
-      vertex -0.689332 0 4.54337
-      vertex -0.689332 -2.7 4.54337
-    endloop
-  endfacet
-  facet normal 0.453996 0 0.891003
-    outer loop
-      vertex -2.64964 0 5.18031
-      vertex -2.34179 -2.7 5.02345
-      vertex -2.34179 0 5.02345
-    endloop
-  endfacet
-  facet normal 0.453996 0 0.891003
-    outer loop
-      vertex -2.34179 -2.7 5.02345
-      vertex -2.64964 0 5.18031
-      vertex -2.64964 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal 0.61291 0 0.790153
-    outer loop
-      vertex -3.50583 0 5.76218
-      vertex -3.23282 -2.7 5.55041
-      vertex -3.23282 0 5.55041
-    endloop
-  endfacet
-  facet normal 0.61291 0 0.790153
-    outer loop
-      vertex -3.23282 -2.7 5.55041
-      vertex -3.50583 0 5.76218
-      vertex -3.50583 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal -0.790153 0 0.61291
-    outer loop
-      vertex 4.23782 -2.7 6.49417
-      vertex 4.44959 0 6.76718
-      vertex 4.23782 0 6.49417
-    endloop
-  endfacet
-  facet normal -0.790153 0 0.61291
-    outer loop
-      vertex 4.44959 0 6.76718
-      vertex 4.23782 -2.7 6.49417
-      vertex 4.44959 -2.7 6.76718
     endloop
   endfacet
   facet normal -0.891003 0 0.453996
@@ -10231,6 +9531,146 @@ solid OpenSCAD_Model
       vertex 4.97655 0 7.65821
       vertex 4.81969 -2.7 7.35036
       vertex 4.97655 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0.960291 -0 0.279
+    outer loop
+      vertex -5.32721 -2.7 8.63221
+      vertex -5.23081 0 8.30041
+      vertex -5.32721 0 8.63221
+    endloop
+  endfacet
+  facet normal 0.960291 0 0.279
+    outer loop
+      vertex -5.23081 0 8.30041
+      vertex -5.32721 -2.7 8.63221
+      vertex -5.23081 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal 0.661315 0 -0.750108
+    outer loop
+      vertex -3.76501 -2.7 14.0093
+      vertex -3.50583 0 14.2378
+      vertex -3.50583 -2.7 14.2378
+    endloop
+  endfacet
+  facet normal 0.661315 0 -0.750108
+    outer loop
+      vertex -3.50583 0 14.2378
+      vertex -3.76501 -2.7 14.0093
+      vertex -3.76501 0 14.0093
+    endloop
+  endfacet
+  facet normal 0.397134 0 0.917761
+    outer loop
+      vertex -2.34179 0 5.02345
+      vertex -2.02468 -2.7 4.88623
+      vertex -2.02468 0 4.88623
+    endloop
+  endfacet
+  facet normal 0.397134 0 0.917761
+    outer loop
+      vertex -2.02468 -2.7 4.88623
+      vertex -2.34179 0 5.02345
+      vertex -2.34179 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal 0.338636 0 -0.940917
+    outer loop
+      vertex -2.02468 -2.7 15.1138
+      vertex -1.69959 0 15.2308
+      vertex -1.69959 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal 0.338636 0 -0.940917
+    outer loop
+      vertex -1.69959 0 15.2308
+      vertex -2.02468 -2.7 15.1138
+      vertex -2.02468 0 15.1138
+    endloop
+  endfacet
+  facet normal 0.987691 0 -0.156416
+    outer loop
+      vertex -5.40258 -2.7 11.0306
+      vertex -5.45663 0 10.6893
+      vertex -5.40258 0 11.0306
+    endloop
+  endfacet
+  facet normal 0.987691 0 -0.156416
+    outer loop
+      vertex -5.45663 0 10.6893
+      vertex -5.40258 -2.7 11.0306
+      vertex -5.45663 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal 0.707078 0 -0.707136
+    outer loop
+      vertex -3.76501 -2.7 14.0093
+      vertex -4.00933 0 13.765
+      vertex -3.76501 0 14.0093
+    endloop
+  endfacet
+  facet normal 0.707078 0 -0.707136
+    outer loop
+      vertex -4.00933 0 13.765
+      vertex -3.76501 -2.7 14.0093
+      vertex -4.00933 -2.7 13.765
+    endloop
+  endfacet
+  facet normal -0.750148 0 -0.66127
+    outer loop
+      vertex 4.23782 -2.7 13.5058
+      vertex 4.00933 0 13.765
+      vertex 4.23782 0 13.5058
+    endloop
+  endfacet
+  facet normal -0.750148 -0 -0.66127
+    outer loop
+      vertex 4.00933 0 13.765
+      vertex 4.23782 -2.7 13.5058
+      vertex 4.00933 -2.7 13.765
+    endloop
+  endfacet
+  facet normal -0.661299 0 0.750122
+    outer loop
+      vertex 3.50583 0 5.76218
+      vertex 3.76501 -2.7 5.99067
+      vertex 3.76501 0 5.99067
+    endloop
+  endfacet
+  facet normal -0.661299 0 0.750122
+    outer loop
+      vertex 3.76501 -2.7 5.99067
+      vertex 3.50583 0 5.76218
+      vertex 3.50583 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal -0.94088 0 0.338739
+    outer loop
+      vertex 5.11377 -2.7 7.97532
+      vertex 5.23081 0 8.30041
+      vertex 5.11377 0 7.97532
+    endloop
+  endfacet
+  facet normal -0.94088 0 0.338739
+    outer loop
+      vertex 5.23081 0 8.30041
+      vertex 5.11377 -2.7 7.97532
+      vertex 5.23081 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal -0.999507 0 -0.0314065
+    outer loop
+      vertex 5.5 -2.7 10
+      vertex 5.48915 0 10.3453
+      vertex 5.5 0 10
+    endloop
+  endfacet
+  facet normal -0.999507 -0 -0.0314065
+    outer loop
+      vertex 5.48915 0 10.3453
+      vertex 5.5 -2.7 10
+      vertex 5.48915 -2.7 10.3453
     endloop
   endfacet
   facet normal 0 1 0
@@ -10919,18 +10359,32 @@ solid OpenSCAD_Model
       vertex 0 -2.7 4.5
     endloop
   endfacet
-  facet normal -0.995561 0 0.0941207
+  facet normal 0.827107 0 -0.562045
     outer loop
-      vertex 5.45663 -2.7 9.31067
-      vertex 5.48915 0 9.65465
-      vertex 5.45663 0 9.31067
+      vertex -4.44959 -2.7 13.2328
+      vertex -4.6438 0 12.947
+      vertex -4.44959 0 13.2328
     endloop
   endfacet
-  facet normal -0.995561 0 0.0941207
+  facet normal 0.827107 0 -0.562045
     outer loop
-      vertex 5.48915 0 9.65465
-      vertex 5.45663 -2.7 9.31067
-      vertex 5.48915 -2.7 9.65465
+      vertex -4.6438 0 12.947
+      vertex -4.44959 -2.7 13.2328
+      vertex -4.6438 -2.7 12.947
+    endloop
+  endfacet
+  facet normal 0.338739 0 0.94088
+    outer loop
+      vertex -2.02468 0 4.88623
+      vertex -1.69959 -2.7 4.76919
+      vertex -1.69959 0 4.76919
+    endloop
+  endfacet
+  facet normal 0.338739 0 0.94088
+    outer loop
+      vertex -1.69959 -2.7 4.76919
+      vertex -2.02468 0 4.88623
+      vertex -2.02468 -2.7 4.88623
     endloop
   endfacet
   facet normal -0.453996 0 0.891003
@@ -10947,242 +10401,88 @@ solid OpenSCAD_Model
       vertex 2.34179 -2.7 5.02345
     endloop
   endfacet
-  facet normal -0.707107 0 0.707107
+  facet normal 0.509046 0 0.860739
     outer loop
-      vertex 3.76501 -2.7 5.99067
-      vertex 4.00933 0 6.23499
-      vertex 3.76501 0 5.99067
+      vertex -2.94705 0 5.3562
+      vertex -2.64964 -2.7 5.18031
+      vertex -2.64964 0 5.18031
     endloop
   endfacet
-  facet normal -0.707107 0 0.707107
+  facet normal 0.509046 0 0.860739
     outer loop
-      vertex 4.00933 0 6.23499
-      vertex 3.76501 -2.7 5.99067
-      vertex 4.00933 -2.7 6.23499
+      vertex -2.64964 -2.7 5.18031
+      vertex -2.94705 0 5.3562
+      vertex -2.94705 -2.7 5.3562
     endloop
   endfacet
-  facet normal -0.279 0 0.960291
+  facet normal -0.0941193 0 0.995561
     outer loop
-      vertex 1.36779 0 4.67279
-      vertex 1.69959 -2.7 4.76919
-      vertex 1.69959 0 4.76919
-    endloop
-  endfacet
-  facet normal -0.279 0 0.960291
-    outer loop
-      vertex 1.69959 -2.7 4.76919
-      vertex 1.36779 0 4.67279
-      vertex 1.36779 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal -0.15643 0 0.987689
-    outer loop
-      vertex 0.689332 0 4.54337
-      vertex 1.0306 -2.7 4.59742
-      vertex 1.0306 0 4.59742
-    endloop
-  endfacet
-  facet normal -0.15643 0 0.987689
-    outer loop
-      vertex 1.0306 -2.7 4.59742
-      vertex 0.689332 0 4.54337
+      vertex 0.345347 0 4.51085
       vertex 0.689332 -2.7 4.54337
+      vertex 0.689332 0 4.54337
     endloop
   endfacet
-  facet normal 0.218223 0 -0.975899
+  facet normal -0.0941193 0 0.995561
     outer loop
-      vertex -1.36779 -2.7 15.3272
-      vertex -1.0306 0 15.4026
-      vertex -1.0306 -2.7 15.4026
+      vertex 0.689332 -2.7 4.54337
+      vertex 0.345347 0 4.51085
+      vertex 0.345347 -2.7 4.51085
     endloop
   endfacet
-  facet normal 0.218223 0 -0.975899
+  facet normal 0.094062 0 -0.995566
     outer loop
-      vertex -1.0306 0 15.4026
-      vertex -1.36779 -2.7 15.3272
-      vertex -1.36779 0 15.3272
+      vertex -0.689332 -2.7 15.4566
+      vertex -0.345347 0 15.4891
+      vertex -0.345347 -2.7 15.4891
     endloop
   endfacet
-  facet normal 0.279 0 -0.960291
+  facet normal 0.094062 0 -0.995566
     outer loop
-      vertex -1.69959 -2.7 15.2308
-      vertex -1.36779 0 15.3272
-      vertex -1.36779 -2.7 15.3272
+      vertex -0.345347 0 15.4891
+      vertex -0.689332 -2.7 15.4566
+      vertex -0.689332 0 15.4566
     endloop
   endfacet
-  facet normal 0.279 0 -0.960291
+  facet normal 0.790153 -0 0.61291
     outer loop
-      vertex -1.36779 0 15.3272
-      vertex -1.69959 -2.7 15.2308
-      vertex -1.69959 0 15.2308
+      vertex -4.44959 -2.7 6.76718
+      vertex -4.23782 0 6.49417
+      vertex -4.44959 0 6.76718
     endloop
   endfacet
-  facet normal 0.338636 0 -0.940917
+  facet normal 0.790153 0 0.61291
     outer loop
-      vertex -2.02468 -2.7 15.1138
-      vertex -1.69959 0 15.2308
-      vertex -1.69959 -2.7 15.2308
+      vertex -4.23782 0 6.49417
+      vertex -4.44959 -2.7 6.76718
+      vertex -4.23782 -2.7 6.49417
     endloop
   endfacet
-  facet normal 0.338636 0 -0.940917
+  facet normal 0.960291 0 -0.279
     outer loop
-      vertex -1.69959 0 15.2308
-      vertex -2.02468 -2.7 15.1138
-      vertex -2.02468 0 15.1138
+      vertex -5.23081 -2.7 11.6996
+      vertex -5.32721 0 11.3678
+      vertex -5.23081 0 11.6996
     endloop
   endfacet
-  facet normal 0.707078 0 -0.707136
+  facet normal 0.960291 0 -0.279
     outer loop
-      vertex -3.76501 -2.7 14.0093
-      vertex -4.00933 0 13.765
-      vertex -3.76501 0 14.0093
+      vertex -5.32721 0 11.3678
+      vertex -5.23081 -2.7 11.6996
+      vertex -5.32721 -2.7 11.3678
     endloop
   endfacet
-  facet normal 0.707078 0 -0.707136
+  facet normal 0.750148 0 -0.66127
     outer loop
-      vertex -4.00933 0 13.765
-      vertex -3.76501 -2.7 14.0093
       vertex -4.00933 -2.7 13.765
-    endloop
-  endfacet
-  facet normal 0.453859 0 -0.891074
-    outer loop
-      vertex -2.64964 -2.7 14.8197
-      vertex -2.34179 0 14.9765
-      vertex -2.34179 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal 0.453859 0 -0.891074
-    outer loop
-      vertex -2.34179 0 14.9765
-      vertex -2.64964 -2.7 14.8197
-      vertex -2.64964 0 14.8197
-    endloop
-  endfacet
-  facet normal 0.509068 0 -0.860727
-    outer loop
-      vertex -2.94705 -2.7 14.6438
-      vertex -2.64964 0 14.8197
-      vertex -2.64964 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal 0.509068 0 -0.860727
-    outer loop
-      vertex -2.64964 0 14.8197
-      vertex -2.94705 -2.7 14.6438
-      vertex -2.94705 0 14.6438
-    endloop
-  endfacet
-  facet normal 0.790142 0 -0.612924
-    outer loop
-      vertex -4.23782 -2.7 13.5058
-      vertex -4.44959 0 13.2328
       vertex -4.23782 0 13.5058
+      vertex -4.00933 0 13.765
     endloop
   endfacet
-  facet normal 0.790142 0 -0.612924
+  facet normal 0.750148 0 -0.66127
     outer loop
-      vertex -4.44959 0 13.2328
+      vertex -4.23782 0 13.5058
+      vertex -4.00933 -2.7 13.765
       vertex -4.23782 -2.7 13.5058
-      vertex -4.44959 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal 0.890974 0 -0.454055
-    outer loop
-      vertex -4.81969 -2.7 12.6496
-      vertex -4.97655 0 12.3418
-      vertex -4.81969 0 12.6496
-    endloop
-  endfacet
-  facet normal 0.890974 0 -0.454055
-    outer loop
-      vertex -4.97655 0 12.3418
-      vertex -4.81969 -2.7 12.6496
-      vertex -4.97655 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal 0.917756 0 -0.397144
-    outer loop
-      vertex -4.97655 -2.7 12.3418
-      vertex -5.11377 0 12.0247
-      vertex -4.97655 0 12.3418
-    endloop
-  endfacet
-  facet normal 0.917756 0 -0.397144
-    outer loop
-      vertex -5.11377 0 12.0247
-      vertex -4.97655 -2.7 12.3418
-      vertex -5.11377 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal 0.995561 0 -0.0941153
-    outer loop
-      vertex -5.45663 -2.7 10.6893
-      vertex -5.48915 0 10.3453
-      vertex -5.45663 0 10.6893
-    endloop
-  endfacet
-  facet normal 0.995561 0 -0.0941153
-    outer loop
-      vertex -5.48915 0 10.3453
-      vertex -5.45663 -2.7 10.6893
-      vertex -5.48915 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal -0.612964 0 -0.790111
-    outer loop
-      vertex 3.23282 -2.7 14.4496
-      vertex 3.50583 0 14.2378
-      vertex 3.50583 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal -0.612964 0 -0.790111
-    outer loop
-      vertex 3.50583 0 14.2378
-      vertex 3.23282 -2.7 14.4496
-      vertex 3.23282 0 14.4496
-    endloop
-  endfacet
-  facet normal -0.453859 0 -0.891074
-    outer loop
-      vertex 2.34179 -2.7 14.9765
-      vertex 2.64964 0 14.8197
-      vertex 2.64964 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal -0.453859 0 -0.891074
-    outer loop
-      vertex 2.64964 0 14.8197
-      vertex 2.34179 -2.7 14.9765
-      vertex 2.34179 0 14.9765
-    endloop
-  endfacet
-  facet normal -0.397329 0 -0.917676
-    outer loop
-      vertex 2.02468 -2.7 15.1138
-      vertex 2.34179 0 14.9765
-      vertex 2.34179 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal -0.397329 0 -0.917676
-    outer loop
-      vertex 2.34179 0 14.9765
-      vertex 2.02468 -2.7 15.1138
-      vertex 2.02468 0 15.1138
-    endloop
-  endfacet
-  facet normal -0.156289 0 -0.987711
-    outer loop
-      vertex 0.689332 -2.7 15.4566
-      vertex 1.0306 0 15.4026
-      vertex 1.0306 -2.7 15.4026
-    endloop
-  endfacet
-  facet normal -0.156289 0 -0.987711
-    outer loop
-      vertex 1.0306 0 15.4026
-      vertex 0.689332 -2.7 15.4566
-      vertex 0.689332 0 15.4566
     endloop
   endfacet
   facet normal -0.0315467 0 -0.999502
@@ -11199,18 +10499,172 @@ solid OpenSCAD_Model
       vertex 0 0 15.5
     endloop
   endfacet
-  facet normal -0.707078 0 -0.707136
+  facet normal 0.562085 0 0.827079
     outer loop
-      vertex 4.00933 -2.7 13.765
-      vertex 3.76501 0 14.0093
-      vertex 4.00933 0 13.765
+      vertex -3.23282 0 5.55041
+      vertex -2.94705 -2.7 5.3562
+      vertex -2.94705 0 5.3562
     endloop
   endfacet
-  facet normal -0.707078 -0 -0.707136
+  facet normal 0.562085 0 0.827079
     outer loop
-      vertex 3.76501 0 14.0093
-      vertex 4.00933 -2.7 13.765
-      vertex 3.76501 -2.7 14.0093
+      vertex -2.94705 -2.7 5.3562
+      vertex -3.23282 0 5.55041
+      vertex -3.23282 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal -0.960291 0 -0.279
+    outer loop
+      vertex 5.32721 -2.7 11.3678
+      vertex 5.23081 0 11.6996
+      vertex 5.32721 0 11.3678
+    endloop
+  endfacet
+  facet normal -0.960291 -0 -0.279
+    outer loop
+      vertex 5.23081 0 11.6996
+      vertex 5.32721 -2.7 11.3678
+      vertex 5.23081 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal 0.453996 0 0.891003
+    outer loop
+      vertex -2.64964 0 5.18031
+      vertex -2.34179 -2.7 5.02345
+      vertex -2.34179 0 5.02345
+    endloop
+  endfacet
+  facet normal 0.453996 0 0.891003
+    outer loop
+      vertex -2.34179 -2.7 5.02345
+      vertex -2.64964 0 5.18031
+      vertex -2.64964 -2.7 5.18031
+    endloop
+  endfacet
+  facet normal -0.750122 0 0.661299
+    outer loop
+      vertex 4.00933 -2.7 6.23499
+      vertex 4.23782 0 6.49417
+      vertex 4.00933 0 6.23499
+    endloop
+  endfacet
+  facet normal -0.750122 0 0.661299
+    outer loop
+      vertex 4.23782 0 6.49417
+      vertex 4.00933 -2.7 6.23499
+      vertex 4.23782 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal 0.397329 0 -0.917676
+    outer loop
+      vertex -2.34179 -2.7 14.9765
+      vertex -2.02468 0 15.1138
+      vertex -2.02468 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal 0.397329 0 -0.917676
+    outer loop
+      vertex -2.02468 0 15.1138
+      vertex -2.34179 -2.7 14.9765
+      vertex -2.34179 0 14.9765
+    endloop
+  endfacet
+  facet normal 0.917761 -0 0.397134
+    outer loop
+      vertex -5.11377 -2.7 7.97532
+      vertex -4.97655 0 7.65821
+      vertex -5.11377 0 7.97532
+    endloop
+  endfacet
+  facet normal 0.917761 0 0.397134
+    outer loop
+      vertex -4.97655 0 7.65821
+      vertex -5.11377 -2.7 7.97532
+      vertex -4.97655 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0.562065 0 -0.827093
+    outer loop
+      vertex -3.23282 -2.7 14.4496
+      vertex -2.94705 0 14.6438
+      vertex -2.94705 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal 0.562065 0 -0.827093
+    outer loop
+      vertex -2.94705 0 14.6438
+      vertex -3.23282 -2.7 14.4496
+      vertex -3.23282 0 14.4496
+    endloop
+  endfacet
+  facet normal 0.509068 0 -0.860727
+    outer loop
+      vertex -2.94705 -2.7 14.6438
+      vertex -2.64964 0 14.8197
+      vertex -2.64964 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal 0.509068 0 -0.860727
+    outer loop
+      vertex -2.64964 0 14.8197
+      vertex -2.94705 -2.7 14.6438
+      vertex -2.94705 0 14.6438
+    endloop
+  endfacet
+  facet normal 0.279 0 -0.960291
+    outer loop
+      vertex -1.69959 -2.7 15.2308
+      vertex -1.36779 0 15.3272
+      vertex -1.36779 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal 0.279 0 -0.960291
+    outer loop
+      vertex -1.36779 0 15.3272
+      vertex -1.69959 -2.7 15.2308
+      vertex -1.69959 0 15.2308
+    endloop
+  endfacet
+  facet normal 0.995561 0 -0.0941153
+    outer loop
+      vertex -5.45663 -2.7 10.6893
+      vertex -5.48915 0 10.3453
+      vertex -5.45663 0 10.6893
+    endloop
+  endfacet
+  facet normal 0.995561 0 -0.0941153
+    outer loop
+      vertex -5.48915 0 10.3453
+      vertex -5.45663 -2.7 10.6893
+      vertex -5.48915 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal 0.0941193 0 0.995561
+    outer loop
+      vertex -0.689332 0 4.54337
+      vertex -0.345347 -2.7 4.51085
+      vertex -0.345347 0 4.51085
+    endloop
+  endfacet
+  facet normal 0.0941193 0 0.995561
+    outer loop
+      vertex -0.345347 -2.7 4.51085
+      vertex -0.689332 0 4.54337
+      vertex -0.689332 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal -0.917756 0 -0.397144
+    outer loop
+      vertex 5.11377 -2.7 12.0247
+      vertex 4.97655 0 12.3418
+      vertex 5.11377 0 12.0247
+    endloop
+  endfacet
+  facet normal -0.917756 -0 -0.397144
+    outer loop
+      vertex 4.97655 0 12.3418
+      vertex 5.11377 -2.7 12.0247
+      vertex 4.97655 -2.7 12.3418
     endloop
   endfacet
   facet normal -0.661315 0 -0.750108
@@ -11227,6 +10681,468 @@ solid OpenSCAD_Model
       vertex 3.50583 0 14.2378
     endloop
   endfacet
+  facet normal -0.940884 0 -0.33873
+    outer loop
+      vertex 5.23081 -2.7 11.6996
+      vertex 5.11377 0 12.0247
+      vertex 5.23081 0 11.6996
+    endloop
+  endfacet
+  facet normal -0.940884 -0 -0.33873
+    outer loop
+      vertex 5.11377 0 12.0247
+      vertex 5.23081 -2.7 11.6996
+      vertex 5.11377 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal -0.279 0 -0.960291
+    outer loop
+      vertex 1.36779 -2.7 15.3272
+      vertex 1.69959 0 15.2308
+      vertex 1.69959 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal -0.279 0 -0.960291
+    outer loop
+      vertex 1.69959 0 15.2308
+      vertex 1.36779 -2.7 15.3272
+      vertex 1.36779 0 15.3272
+    endloop
+  endfacet
+  facet normal 0.61291 0 0.790153
+    outer loop
+      vertex -3.50583 0 5.76218
+      vertex -3.23282 -2.7 5.55041
+      vertex -3.23282 0 5.55041
+    endloop
+  endfacet
+  facet normal 0.61291 0 0.790153
+    outer loop
+      vertex -3.23282 -2.7 5.55041
+      vertex -3.50583 0 5.76218
+      vertex -3.50583 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal -0.509068 0 -0.860727
+    outer loop
+      vertex 2.64964 -2.7 14.8197
+      vertex 2.94705 0 14.6438
+      vertex 2.94705 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal -0.509068 0 -0.860727
+    outer loop
+      vertex 2.94705 0 14.6438
+      vertex 2.64964 -2.7 14.8197
+      vertex 2.64964 0 14.8197
+    endloop
+  endfacet
+  facet normal -0.995561 0 -0.0941153
+    outer loop
+      vertex 5.48915 -2.7 10.3453
+      vertex 5.45663 0 10.6893
+      vertex 5.48915 0 10.3453
+    endloop
+  endfacet
+  facet normal -0.995561 -0 -0.0941153
+    outer loop
+      vertex 5.45663 0 10.6893
+      vertex 5.48915 -2.7 10.3453
+      vertex 5.45663 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal 0.987689 -0 0.156429
+    outer loop
+      vertex -5.45663 -2.7 9.31067
+      vertex -5.40258 0 8.9694
+      vertex -5.45663 0 9.31067
+    endloop
+  endfacet
+  facet normal 0.987689 0 0.156429
+    outer loop
+      vertex -5.40258 0 8.9694
+      vertex -5.45663 -2.7 9.31067
+      vertex -5.40258 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal 0.827079 -0 0.562085
+    outer loop
+      vertex -4.6438 -2.7 7.05295
+      vertex -4.44959 0 6.76718
+      vertex -4.6438 0 7.05295
+    endloop
+  endfacet
+  facet normal 0.827079 0 0.562085
+    outer loop
+      vertex -4.44959 0 6.76718
+      vertex -4.6438 -2.7 7.05295
+      vertex -4.44959 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal 0.940884 0 -0.33873
+    outer loop
+      vertex -5.11377 -2.7 12.0247
+      vertex -5.23081 0 11.6996
+      vertex -5.11377 0 12.0247
+    endloop
+  endfacet
+  facet normal 0.940884 0 -0.33873
+    outer loop
+      vertex -5.23081 0 11.6996
+      vertex -5.11377 -2.7 12.0247
+      vertex -5.23081 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal -0.890974 0 -0.454055
+    outer loop
+      vertex 4.97655 -2.7 12.3418
+      vertex 4.81969 0 12.6496
+      vertex 4.97655 0 12.3418
+    endloop
+  endfacet
+  facet normal -0.890974 -0 -0.454055
+    outer loop
+      vertex 4.81969 0 12.6496
+      vertex 4.97655 -2.7 12.3418
+      vertex 4.81969 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal -0.995561 0 0.0941207
+    outer loop
+      vertex 5.45663 -2.7 9.31067
+      vertex 5.48915 0 9.65465
+      vertex 5.45663 0 9.31067
+    endloop
+  endfacet
+  facet normal -0.995561 0 0.0941207
+    outer loop
+      vertex 5.48915 0 9.65465
+      vertex 5.45663 -2.7 9.31067
+      vertex 5.48915 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal -0.0314022 0 0.999507
+    outer loop
+      vertex 0 0 4.5
+      vertex 0.345347 -2.7 4.51085
+      vertex 0.345347 0 4.51085
+    endloop
+  endfacet
+  facet normal -0.0314022 0 0.999507
+    outer loop
+      vertex 0.345347 -2.7 4.51085
+      vertex 0 0 4.5
+      vertex 0 -2.7 4.5
+    endloop
+  endfacet
+  facet normal 0.661299 0 0.750122
+    outer loop
+      vertex -3.76501 0 5.99067
+      vertex -3.50583 -2.7 5.76218
+      vertex -3.50583 0 5.76218
+    endloop
+  endfacet
+  facet normal 0.661299 0 0.750122
+    outer loop
+      vertex -3.50583 -2.7 5.76218
+      vertex -3.76501 0 5.99067
+      vertex -3.76501 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal -0.790153 0 0.61291
+    outer loop
+      vertex 4.23782 -2.7 6.49417
+      vertex 4.44959 0 6.76718
+      vertex 4.23782 0 6.49417
+    endloop
+  endfacet
+  facet normal -0.790153 0 0.61291
+    outer loop
+      vertex 4.44959 0 6.76718
+      vertex 4.23782 -2.7 6.49417
+      vertex 4.44959 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal -0.218223 0 -0.975899
+    outer loop
+      vertex 1.0306 -2.7 15.4026
+      vertex 1.36779 0 15.3272
+      vertex 1.36779 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal -0.218223 0 -0.975899
+    outer loop
+      vertex 1.36779 0 15.3272
+      vertex 1.0306 -2.7 15.4026
+      vertex 1.0306 0 15.4026
+    endloop
+  endfacet
+  facet normal -0.707107 0 0.707107
+    outer loop
+      vertex 3.76501 -2.7 5.99067
+      vertex 4.00933 0 6.23499
+      vertex 3.76501 0 5.99067
+    endloop
+  endfacet
+  facet normal -0.707107 0 0.707107
+    outer loop
+      vertex 4.00933 0 6.23499
+      vertex 3.76501 -2.7 5.99067
+      vertex 4.00933 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal 0.94088 -0 0.338739
+    outer loop
+      vertex -5.23081 -2.7 8.30041
+      vertex -5.11377 0 7.97532
+      vertex -5.23081 0 8.30041
+    endloop
+  endfacet
+  facet normal 0.94088 0 0.338739
+    outer loop
+      vertex -5.11377 0 7.97532
+      vertex -5.23081 -2.7 8.30041
+      vertex -5.11377 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal 0.999507 0 -0.0314065
+    outer loop
+      vertex -5.48915 -2.7 10.3453
+      vertex -5.5 0 10
+      vertex -5.48915 0 10.3453
+    endloop
+  endfacet
+  facet normal 0.999507 0 -0.0314065
+    outer loop
+      vertex -5.5 0 10
+      vertex -5.48915 -2.7 10.3453
+      vertex -5.5 -2.7 10
+    endloop
+  endfacet
+  facet normal -0.15643 0 0.987689
+    outer loop
+      vertex 0.689332 0 4.54337
+      vertex 1.0306 -2.7 4.59742
+      vertex 1.0306 0 4.59742
+    endloop
+  endfacet
+  facet normal -0.15643 0 0.987689
+    outer loop
+      vertex 1.0306 -2.7 4.59742
+      vertex 0.689332 0 4.54337
+      vertex 0.689332 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal -0.218141 0 0.975917
+    outer loop
+      vertex 1.0306 0 4.59742
+      vertex 1.36779 -2.7 4.67279
+      vertex 1.36779 0 4.67279
+    endloop
+  endfacet
+  facet normal -0.218141 0 0.975917
+    outer loop
+      vertex 1.36779 -2.7 4.67279
+      vertex 1.0306 0 4.59742
+      vertex 1.0306 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal -0.156289 0 -0.987711
+    outer loop
+      vertex 0.689332 -2.7 15.4566
+      vertex 1.0306 0 15.4026
+      vertex 1.0306 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal -0.156289 0 -0.987711
+    outer loop
+      vertex 1.0306 0 15.4026
+      vertex 0.689332 -2.7 15.4566
+      vertex 0.689332 0 15.4566
+    endloop
+  endfacet
+  facet normal -0.975919 0 -0.218135
+    outer loop
+      vertex 5.40258 -2.7 11.0306
+      vertex 5.32721 0 11.3678
+      vertex 5.40258 0 11.0306
+    endloop
+  endfacet
+  facet normal -0.975919 -0 -0.218135
+    outer loop
+      vertex 5.32721 0 11.3678
+      vertex 5.40258 -2.7 11.0306
+      vertex 5.32721 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal -0.987691 0 -0.156416
+    outer loop
+      vertex 5.45663 -2.7 10.6893
+      vertex 5.40258 0 11.0306
+      vertex 5.45663 0 10.6893
+    endloop
+  endfacet
+  facet normal -0.987691 -0 -0.156416
+    outer loop
+      vertex 5.40258 0 11.0306
+      vertex 5.45663 -2.7 10.6893
+      vertex 5.40258 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal -0.61291 0 0.790153
+    outer loop
+      vertex 3.23282 0 5.55041
+      vertex 3.50583 -2.7 5.76218
+      vertex 3.50583 0 5.76218
+    endloop
+  endfacet
+  facet normal -0.61291 0 0.790153
+    outer loop
+      vertex 3.50583 -2.7 5.76218
+      vertex 3.23282 0 5.55041
+      vertex 3.23282 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal 0.612964 0 -0.790111
+    outer loop
+      vertex -3.50583 -2.7 14.2378
+      vertex -3.23282 0 14.4496
+      vertex -3.23282 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal 0.612964 0 -0.790111
+    outer loop
+      vertex -3.23282 0 14.4496
+      vertex -3.50583 -2.7 14.2378
+      vertex -3.50583 0 14.2378
+    endloop
+  endfacet
+  facet normal -0.562085 0 0.827079
+    outer loop
+      vertex 2.94705 0 5.3562
+      vertex 3.23282 -2.7 5.55041
+      vertex 3.23282 0 5.55041
+    endloop
+  endfacet
+  facet normal -0.562085 0 0.827079
+    outer loop
+      vertex 3.23282 -2.7 5.55041
+      vertex 2.94705 0 5.3562
+      vertex 2.94705 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal 0.279 0 0.960291
+    outer loop
+      vertex -1.69959 0 4.76919
+      vertex -1.36779 -2.7 4.67279
+      vertex -1.36779 0 4.67279
+    endloop
+  endfacet
+  facet normal 0.279 0 0.960291
+    outer loop
+      vertex -1.36779 -2.7 4.67279
+      vertex -1.69959 0 4.76919
+      vertex -1.69959 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal 0.0315467 0 -0.999502
+    outer loop
+      vertex -0.345347 -2.7 15.4891
+      vertex 0 0 15.5
+      vertex 0 -2.7 15.5
+    endloop
+  endfacet
+  facet normal 0.0315467 0 -0.999502
+    outer loop
+      vertex 0 0 15.5
+      vertex -0.345347 -2.7 15.4891
+      vertex -0.345347 0 15.4891
+    endloop
+  endfacet
+  facet normal 0.453859 0 -0.891074
+    outer loop
+      vertex -2.64964 -2.7 14.8197
+      vertex -2.34179 0 14.9765
+      vertex -2.34179 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal 0.453859 0 -0.891074
+    outer loop
+      vertex -2.34179 0 14.9765
+      vertex -2.64964 -2.7 14.8197
+      vertex -2.64964 0 14.8197
+    endloop
+  endfacet
+  facet normal -0.860739 0 0.509046
+    outer loop
+      vertex 4.6438 -2.7 7.05295
+      vertex 4.81969 0 7.35036
+      vertex 4.6438 0 7.05295
+    endloop
+  endfacet
+  facet normal -0.860739 0 0.509046
+    outer loop
+      vertex 4.81969 0 7.35036
+      vertex 4.6438 -2.7 7.05295
+      vertex 4.81969 -2.7 7.35036
+    endloop
+  endfacet
+  facet normal -0.094062 0 -0.995566
+    outer loop
+      vertex 0.345347 -2.7 15.4891
+      vertex 0.689332 0 15.4566
+      vertex 0.689332 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal -0.094062 0 -0.995566
+    outer loop
+      vertex 0.689332 0 15.4566
+      vertex 0.345347 -2.7 15.4891
+      vertex 0.345347 0 15.4891
+    endloop
+  endfacet
+  facet normal 0.15643 0 0.987689
+    outer loop
+      vertex -1.0306 0 4.59742
+      vertex -0.689332 -2.7 4.54337
+      vertex -0.689332 0 4.54337
+    endloop
+  endfacet
+  facet normal 0.15643 0 0.987689
+    outer loop
+      vertex -0.689332 -2.7 4.54337
+      vertex -1.0306 0 4.59742
+      vertex -1.0306 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal -0.987689 0 0.156429
+    outer loop
+      vertex 5.40258 -2.7 8.9694
+      vertex 5.45663 0 9.31067
+      vertex 5.40258 0 8.9694
+    endloop
+  endfacet
+  facet normal -0.987689 0 0.156429
+    outer loop
+      vertex 5.45663 0 9.31067
+      vertex 5.40258 -2.7 8.9694
+      vertex 5.45663 -2.7 9.31067
+    endloop
+  endfacet
+  facet normal -0.827079 0 0.562085
+    outer loop
+      vertex 4.44959 -2.7 6.76718
+      vertex 4.6438 0 7.05295
+      vertex 4.44959 0 6.76718
+    endloop
+  endfacet
+  facet normal -0.827079 0 0.562085
+    outer loop
+      vertex 4.6438 0 7.05295
+      vertex 4.44959 -2.7 6.76718
+      vertex 4.6438 -2.7 7.05295
+    endloop
+  endfacet
   facet normal -0.860732 0 -0.509059
     outer loop
       vertex 4.81969 -2.7 12.6496
@@ -11239,6 +11155,104 @@ solid OpenSCAD_Model
       vertex 4.6438 0 12.947
       vertex 4.81969 -2.7 12.6496
       vertex 4.6438 -2.7 12.947
+    endloop
+  endfacet
+  facet normal -0.397329 0 -0.917676
+    outer loop
+      vertex 2.02468 -2.7 15.1138
+      vertex 2.34179 0 14.9765
+      vertex 2.34179 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal -0.397329 0 -0.917676
+    outer loop
+      vertex 2.34179 0 14.9765
+      vertex 2.02468 -2.7 15.1138
+      vertex 2.02468 0 15.1138
+    endloop
+  endfacet
+  facet normal -0.279 0 0.960291
+    outer loop
+      vertex 1.36779 0 4.67279
+      vertex 1.69959 -2.7 4.76919
+      vertex 1.69959 0 4.76919
+    endloop
+  endfacet
+  facet normal -0.279 0 0.960291
+    outer loop
+      vertex 1.69959 -2.7 4.76919
+      vertex 1.36779 0 4.67279
+      vertex 1.36779 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal -0.975917 0 0.218141
+    outer loop
+      vertex 5.32721 -2.7 8.63221
+      vertex 5.40258 0 8.9694
+      vertex 5.32721 0 8.63221
+    endloop
+  endfacet
+  facet normal -0.975917 0 0.218141
+    outer loop
+      vertex 5.40258 0 8.9694
+      vertex 5.32721 -2.7 8.63221
+      vertex 5.40258 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal -0.999507 0 0.0314019
+    outer loop
+      vertex 5.48915 -2.7 9.65465
+      vertex 5.5 0 10
+      vertex 5.48915 0 9.65465
+    endloop
+  endfacet
+  facet normal -0.999507 0 0.0314019
+    outer loop
+      vertex 5.5 0 10
+      vertex 5.48915 -2.7 9.65465
+      vertex 5.5 -2.7 10
+    endloop
+  endfacet
+  facet normal 0.218141 0 0.975917
+    outer loop
+      vertex -1.36779 0 4.67279
+      vertex -1.0306 -2.7 4.59742
+      vertex -1.0306 0 4.59742
+    endloop
+  endfacet
+  facet normal 0.218141 0 0.975917
+    outer loop
+      vertex -1.0306 -2.7 4.59742
+      vertex -1.36779 0 4.67279
+      vertex -1.36779 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal -0.562065 0 -0.827093
+    outer loop
+      vertex 2.94705 -2.7 14.6438
+      vertex 3.23282 0 14.4496
+      vertex 3.23282 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal -0.562065 0 -0.827093
+    outer loop
+      vertex 3.23282 0 14.4496
+      vertex 2.94705 -2.7 14.6438
+      vertex 2.94705 0 14.6438
+    endloop
+  endfacet
+  facet normal 0.707107 -0 0.707107
+    outer loop
+      vertex -4.00933 -2.7 6.23499
+      vertex -3.76501 0 5.99067
+      vertex -4.00933 0 6.23499
+    endloop
+  endfacet
+  facet normal 0.707107 0 0.707107
+    outer loop
+      vertex -3.76501 0 5.99067
+      vertex -4.00933 -2.7 6.23499
+      vertex -3.76501 -2.7 5.99067
     endloop
   endfacet
   facet normal -0.827107 0 -0.562045
@@ -11269,4246 +11283,4232 @@ solid OpenSCAD_Model
       vertex 4.23782 -2.7 13.5058
     endloop
   endfacet
-  facet normal -0.940884 0 -0.33873
+  facet normal -0.509046 0 0.860739
     outer loop
-      vertex 5.23081 -2.7 11.6996
-      vertex 5.11377 0 12.0247
-      vertex 5.23081 0 11.6996
+      vertex 2.64964 0 5.18031
+      vertex 2.94705 -2.7 5.3562
+      vertex 2.94705 0 5.3562
     endloop
   endfacet
-  facet normal -0.940884 -0 -0.33873
+  facet normal -0.509046 0 0.860739
     outer loop
-      vertex 5.11377 0 12.0247
-      vertex 5.23081 -2.7 11.6996
-      vertex 5.11377 -2.7 12.0247
+      vertex 2.94705 -2.7 5.3562
+      vertex 2.64964 0 5.18031
+      vertex 2.64964 -2.7 5.18031
     endloop
   endfacet
-  facet normal -0.987691 0 -0.156416
+  facet normal -0.453859 0 -0.891074
     outer loop
-      vertex 5.45663 -2.7 10.6893
-      vertex 5.40258 0 11.0306
-      vertex 5.45663 0 10.6893
+      vertex 2.34179 -2.7 14.9765
+      vertex 2.64964 0 14.8197
+      vertex 2.64964 -2.7 14.8197
     endloop
   endfacet
-  facet normal -0.987691 -0 -0.156416
+  facet normal -0.453859 0 -0.891074
     outer loop
-      vertex 5.40258 0 11.0306
-      vertex 5.45663 -2.7 10.6893
-      vertex 5.40258 -2.7 11.0306
+      vertex 2.64964 0 14.8197
+      vertex 2.34179 -2.7 14.9765
+      vertex 2.34179 0 14.9765
     endloop
   endfacet
-  facet normal -0.975919 0 -0.218135
+  facet normal -0.612964 0 -0.790111
     outer loop
-      vertex 5.40258 -2.7 11.0306
-      vertex 5.32721 0 11.3678
-      vertex 5.40258 0 11.0306
+      vertex 3.23282 -2.7 14.4496
+      vertex 3.50583 0 14.2378
+      vertex 3.50583 -2.7 14.2378
     endloop
   endfacet
-  facet normal -0.975919 -0 -0.218135
+  facet normal -0.612964 0 -0.790111
     outer loop
-      vertex 5.32721 0 11.3678
-      vertex 5.40258 -2.7 11.0306
-      vertex 5.32721 -2.7 11.3678
+      vertex 3.50583 0 14.2378
+      vertex 3.23282 -2.7 14.4496
+      vertex 3.23282 0 14.4496
     endloop
   endfacet
-  facet normal 0.975919 0 -0.218135
+  facet normal -0.917761 0 0.397134
     outer loop
-      vertex -5.32721 -2.7 11.3678
-      vertex -5.40258 0 11.0306
-      vertex -5.32721 0 11.3678
+      vertex 4.97655 -2.7 7.65821
+      vertex 5.11377 0 7.97532
+      vertex 4.97655 0 7.65821
     endloop
   endfacet
-  facet normal 0.975919 0 -0.218135
+  facet normal -0.917761 0 0.397134
     outer loop
-      vertex -5.40258 0 11.0306
-      vertex -5.32721 -2.7 11.3678
-      vertex -5.40258 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal 0.987691 0 -0.156416
-    outer loop
-      vertex -5.40258 -2.7 11.0306
-      vertex -5.45663 0 10.6893
-      vertex -5.40258 0 11.0306
-    endloop
-  endfacet
-  facet normal 0.987691 0 -0.156416
-    outer loop
-      vertex -5.45663 0 10.6893
-      vertex -5.40258 -2.7 11.0306
-      vertex -5.45663 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0.999502 -0 0.0315465
-    outer loop
-      vertex -20.5 -2.7 10
-      vertex -20.4891 0 9.65465
-      vertex -20.5 0 10
-    endloop
-  endfacet
-  facet normal 0.999502 0 0.0315465
-    outer loop
-      vertex -20.4891 0 9.65465
-      vertex -20.5 -2.7 10
-      vertex -20.4891 -2.7 9.65465
-    endloop
-  endfacet
-  facet normal 0.509059 0 0.860732
-    outer loop
-      vertex -17.947 0 5.3562
-      vertex -17.6496 -2.7 5.18031
-      vertex -17.6496 0 5.18031
-    endloop
-  endfacet
-  facet normal 0.509059 0 0.860732
-    outer loop
-      vertex -17.6496 -2.7 5.18031
-      vertex -17.947 0 5.3562
-      vertex -17.947 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal -0.397144 0 0.917756
-    outer loop
-      vertex -12.9753 0 4.88623
-      vertex -12.6582 -2.7 5.02345
-      vertex -12.6582 0 5.02345
-    endloop
-  endfacet
-  facet normal -0.397144 0 0.917756
-    outer loop
-      vertex -12.6582 -2.7 5.02345
-      vertex -12.9753 0 4.88623
-      vertex -12.9753 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal -0.94088 0 0.338739
-    outer loop
-      vertex -9.88623 -2.7 7.97532
-      vertex -9.76919 0 8.30041
-      vertex -9.88623 0 7.97532
-    endloop
-  endfacet
-  facet normal -0.94088 0 0.338739
-    outer loop
-      vertex -9.76919 0 8.30041
-      vertex -9.88623 -2.7 7.97532
-      vertex -9.76919 -2.7 8.30041
-    endloop
-  endfacet
-  facet normal 0.999502 0 -0.031551
-    outer loop
-      vertex -20.4891 -2.7 10.3453
-      vertex -20.5 0 10
-      vertex -20.4891 0 10.3453
-    endloop
-  endfacet
-  facet normal 0.999502 0 -0.031551
-    outer loop
-      vertex -20.5 0 10
-      vertex -20.4891 -2.7 10.3453
-      vertex -20.5 -2.7 10
-    endloop
-  endfacet
-  facet normal 0.987712 -0 0.156288
-    outer loop
-      vertex -20.4566 -2.7 9.31067
-      vertex -20.4026 0 8.9694
-      vertex -20.4566 0 9.31067
-    endloop
-  endfacet
-  facet normal 0.987712 0 0.156288
-    outer loop
-      vertex -20.4026 0 8.9694
-      vertex -20.4566 -2.7 9.31067
-      vertex -20.4026 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal -0.999507 0 -0.0314065
-    outer loop
-      vertex -9.5 -2.7 10
-      vertex -9.51085 0 10.3453
-      vertex -9.5 0 10
-    endloop
-  endfacet
-  facet normal -0.999507 -0 -0.0314065
-    outer loop
-      vertex -9.51085 0 10.3453
-      vertex -9.5 -2.7 10
-      vertex -9.51085 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal 0.279 0 -0.960291
-    outer loop
-      vertex -16.6996 -2.7 15.2308
-      vertex -16.3678 0 15.3272
-      vertex -16.3678 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal 0.279 0 -0.960291
-    outer loop
-      vertex -16.3678 0 15.3272
-      vertex -16.6996 -2.7 15.2308
-      vertex -16.6996 0 15.2308
-    endloop
-  endfacet
-  facet normal 0.750133 0 -0.661287
-    outer loop
-      vertex -19.0093 -2.7 13.765
-      vertex -19.2378 0 13.5058
-      vertex -19.0093 0 13.765
-    endloop
-  endfacet
-  facet normal 0.750133 0 -0.661287
-    outer loop
-      vertex -19.2378 0 13.5058
-      vertex -19.0093 -2.7 13.765
-      vertex -19.2378 -2.7 13.5058
-    endloop
-  endfacet
-  facet normal 0.031551 0 -0.999502
-    outer loop
-      vertex -15.3453 -2.7 15.4891
-      vertex -15 0 15.5
-      vertex -15 -2.7 15.5
-    endloop
-  endfacet
-  facet normal 0.031551 0 -0.999502
-    outer loop
-      vertex -15 0 15.5
-      vertex -15.3453 -2.7 15.4891
-      vertex -15.3453 0 15.4891
-    endloop
-  endfacet
-  facet normal 0.975899 -0 0.218223
-    outer loop
-      vertex -20.4026 -2.7 8.9694
-      vertex -20.3272 0 8.63221
-      vertex -20.4026 0 8.9694
-    endloop
-  endfacet
-  facet normal 0.975899 0 0.218223
-    outer loop
-      vertex -20.3272 0 8.63221
-      vertex -20.4026 -2.7 8.9694
-      vertex -20.3272 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal 0.917676 -0 0.397329
-    outer loop
-      vertex -20.1138 -2.7 7.97532
-      vertex -19.9765 0 7.65821
-      vertex -20.1138 0 7.97532
-    endloop
-  endfacet
-  facet normal 0.917676 0 0.397329
-    outer loop
-      vertex -19.9765 0 7.65821
-      vertex -20.1138 -2.7 7.97532
-      vertex -19.9765 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal 0.940917 -0 0.338636
-    outer loop
-      vertex -20.2308 -2.7 8.30041
-      vertex -20.1138 0 7.97532
-      vertex -20.2308 0 8.30041
-    endloop
-  endfacet
-  facet normal 0.940917 0 0.338636
-    outer loop
-      vertex -20.1138 0 7.97532
-      vertex -20.2308 -2.7 8.30041
-      vertex -20.1138 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal -0.0314065 0 0.999507
-    outer loop
-      vertex -15 0 4.5
-      vertex -14.6547 -2.7 4.51085
-      vertex -14.6547 0 4.51085
-    endloop
-  endfacet
-  facet normal -0.0314065 0 0.999507
-    outer loop
-      vertex -14.6547 -2.7 4.51085
-      vertex -15 0 4.5
-      vertex -15 -2.7 4.5
-    endloop
-  endfacet
-  facet normal 0.562045 0 0.827107
-    outer loop
-      vertex -18.2328 0 5.55041
-      vertex -17.947 -2.7 5.3562
-      vertex -17.947 0 5.3562
-    endloop
-  endfacet
-  facet normal 0.562045 0 0.827107
-    outer loop
-      vertex -17.947 -2.7 5.3562
-      vertex -18.2328 0 5.55041
-      vertex -18.2328 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal 0.33873 0 0.940884
-    outer loop
-      vertex -17.0247 0 4.88623
-      vertex -16.6996 -2.7 4.76919
-      vertex -16.6996 0 4.76919
-    endloop
-  endfacet
-  facet normal 0.33873 0 0.940884
-    outer loop
-      vertex -16.6996 -2.7 4.76919
-      vertex -17.0247 0 4.88623
-      vertex -17.0247 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal 0.397144 0 0.917756
-    outer loop
-      vertex -17.3418 0 5.02345
-      vertex -17.0247 -2.7 4.88623
-      vertex -17.0247 0 4.88623
-    endloop
-  endfacet
-  facet normal 0.397144 0 0.917756
-    outer loop
-      vertex -17.0247 -2.7 4.88623
-      vertex -17.3418 0 5.02345
-      vertex -17.3418 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -14.6547 -2.7 15.4891
-      vertex -15.3453 -2.7 15.4891
-      vertex -15 -2.7 15.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -14.3107 -2.7 15.4566
-      vertex -15.3453 -2.7 15.4891
-      vertex -14.6547 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -14.3107 -2.7 15.4566
-      vertex -15.6893 -2.7 15.4566
-      vertex -15.3453 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.9694 -2.7 15.4026
-      vertex -15.6893 -2.7 15.4566
-      vertex -14.3107 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.9694 -2.7 15.4026
-      vertex -16.0306 -2.7 15.4026
-      vertex -15.6893 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.6322 -2.7 15.3272
-      vertex -16.0306 -2.7 15.4026
-      vertex -13.9694 -2.7 15.4026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.6322 -2.7 15.3272
-      vertex -16.3678 -2.7 15.3272
-      vertex -16.0306 -2.7 15.4026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.3004 -2.7 15.2308
-      vertex -16.3678 -2.7 15.3272
-      vertex -13.6322 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.3004 -2.7 15.2308
-      vertex -16.6996 -2.7 15.2308
-      vertex -16.3678 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.9753 -2.7 15.1138
-      vertex -16.6996 -2.7 15.2308
-      vertex -13.3004 -2.7 15.2308
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.9753 -2.7 15.1138
-      vertex -17.0247 -2.7 15.1138
-      vertex -16.6996 -2.7 15.2308
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.6582 -2.7 14.9765
-      vertex -17.0247 -2.7 15.1138
-      vertex -12.9753 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.6582 -2.7 14.9765
-      vertex -17.3418 -2.7 14.9765
-      vertex -17.0247 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.3504 -2.7 14.8197
-      vertex -17.3418 -2.7 14.9765
-      vertex -12.6582 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.3504 -2.7 14.8197
-      vertex -17.6496 -2.7 14.8197
-      vertex -17.3418 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.053 -2.7 14.6438
-      vertex -17.6496 -2.7 14.8197
-      vertex -12.3504 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.053 -2.7 14.6438
-      vertex -17.947 -2.7 14.6438
-      vertex -17.6496 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.7672 -2.7 14.4496
-      vertex -17.947 -2.7 14.6438
-      vertex -12.053 -2.7 14.6438
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.7672 -2.7 14.4496
-      vertex -18.2328 -2.7 14.4496
-      vertex -17.947 -2.7 14.6438
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.4942 -2.7 14.2378
-      vertex -18.2328 -2.7 14.4496
-      vertex -11.7672 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.4942 -2.7 14.2378
-      vertex -18.5058 -2.7 14.2378
-      vertex -18.2328 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.235 -2.7 14.0093
-      vertex -18.5058 -2.7 14.2378
-      vertex -11.4942 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.235 -2.7 14.0093
-      vertex -18.765 -2.7 14.0093
-      vertex -18.5058 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.9907 -2.7 13.765
-      vertex -18.765 -2.7 14.0093
-      vertex -11.235 -2.7 14.0093
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.9907 -2.7 13.765
-      vertex -19.0093 -2.7 13.765
-      vertex -18.765 -2.7 14.0093
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.7622 -2.7 13.5058
-      vertex -19.0093 -2.7 13.765
-      vertex -10.9907 -2.7 13.765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.7622 -2.7 13.5058
-      vertex -19.2378 -2.7 13.5058
-      vertex -19.0093 -2.7 13.765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.5504 -2.7 13.2328
-      vertex -19.2378 -2.7 13.5058
-      vertex -10.7622 -2.7 13.5058
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.5504 -2.7 13.2328
-      vertex -19.4496 -2.7 13.2328
-      vertex -19.2378 -2.7 13.5058
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.3562 -2.7 12.947
-      vertex -19.4496 -2.7 13.2328
-      vertex -10.5504 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.3562 -2.7 12.947
-      vertex -19.6438 -2.7 12.947
-      vertex -19.4496 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.1803 -2.7 12.6496
-      vertex -19.6438 -2.7 12.947
-      vertex -10.3562 -2.7 12.947
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.1803 -2.7 12.6496
-      vertex -19.8197 -2.7 12.6496
-      vertex -19.6438 -2.7 12.947
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.0235 -2.7 12.3418
-      vertex -19.8197 -2.7 12.6496
-      vertex -10.1803 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.0235 -2.7 12.3418
-      vertex -19.9765 -2.7 12.3418
-      vertex -19.8197 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.88623 -2.7 12.0247
-      vertex -19.9765 -2.7 12.3418
-      vertex -10.0235 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.88623 -2.7 12.0247
-      vertex -20.1138 -2.7 12.0247
-      vertex -19.9765 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.76919 -2.7 11.6996
-      vertex -20.1138 -2.7 12.0247
-      vertex -9.88623 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.76919 -2.7 11.6996
-      vertex -20.2308 -2.7 11.6996
-      vertex -20.1138 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.67279 -2.7 11.3678
-      vertex -20.2308 -2.7 11.6996
-      vertex -9.76919 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.67279 -2.7 11.3678
-      vertex -20.3272 -2.7 11.3678
-      vertex -20.2308 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.59742 -2.7 11.0306
-      vertex -20.3272 -2.7 11.3678
-      vertex -9.67279 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.59742 -2.7 11.0306
-      vertex -20.4026 -2.7 11.0306
-      vertex -20.3272 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.54337 -2.7 10.6893
-      vertex -20.4026 -2.7 11.0306
-      vertex -9.59742 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.54337 -2.7 10.6893
-      vertex -20.4566 -2.7 10.6893
-      vertex -20.4026 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.51085 -2.7 10.3453
-      vertex -20.4566 -2.7 10.6893
-      vertex -9.54337 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.51085 -2.7 10.3453
-      vertex -20.4891 -2.7 10.3453
-      vertex -20.4566 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.5 -2.7 10
-      vertex -20.4891 -2.7 10.3453
-      vertex -9.51085 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.5 -2.7 10
-      vertex -20.5 -2.7 10
-      vertex -20.4891 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.51085 -2.7 9.65465
-      vertex -20.5 -2.7 10
-      vertex -9.5 -2.7 10
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.51085 -2.7 9.65465
-      vertex -20.4891 -2.7 9.65465
-      vertex -20.5 -2.7 10
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.54337 -2.7 9.31067
-      vertex -20.4891 -2.7 9.65465
-      vertex -9.51085 -2.7 9.65465
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.54337 -2.7 9.31067
-      vertex -20.4566 -2.7 9.31067
-      vertex -20.4891 -2.7 9.65465
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.59742 -2.7 8.9694
-      vertex -20.4566 -2.7 9.31067
-      vertex -9.54337 -2.7 9.31067
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.59742 -2.7 8.9694
-      vertex -20.4026 -2.7 8.9694
-      vertex -20.4566 -2.7 9.31067
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.67279 -2.7 8.63221
-      vertex -20.4026 -2.7 8.9694
-      vertex -9.59742 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.67279 -2.7 8.63221
-      vertex -20.3272 -2.7 8.63221
-      vertex -20.4026 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.76919 -2.7 8.30041
-      vertex -20.3272 -2.7 8.63221
-      vertex -9.67279 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.76919 -2.7 8.30041
-      vertex -20.2308 -2.7 8.30041
-      vertex -20.3272 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.88623 -2.7 7.97532
-      vertex -20.2308 -2.7 8.30041
-      vertex -9.76919 -2.7 8.30041
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.88623 -2.7 7.97532
-      vertex -20.1138 -2.7 7.97532
-      vertex -20.2308 -2.7 8.30041
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.0235 -2.7 7.65821
-      vertex -20.1138 -2.7 7.97532
-      vertex -9.88623 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.0235 -2.7 7.65821
-      vertex -19.9765 -2.7 7.65821
-      vertex -20.1138 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.1803 -2.7 7.35036
-      vertex -19.9765 -2.7 7.65821
-      vertex -10.0235 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.1803 -2.7 7.35036
-      vertex -19.8197 -2.7 7.35036
-      vertex -19.9765 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.3562 -2.7 7.05295
-      vertex -19.8197 -2.7 7.35036
-      vertex -10.1803 -2.7 7.35036
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.3562 -2.7 7.05295
-      vertex -19.6438 -2.7 7.05295
-      vertex -19.8197 -2.7 7.35036
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.5504 -2.7 6.76718
-      vertex -19.6438 -2.7 7.05295
-      vertex -10.3562 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.5504 -2.7 6.76718
-      vertex -19.4496 -2.7 6.76718
-      vertex -19.6438 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.7622 -2.7 6.49417
-      vertex -19.4496 -2.7 6.76718
-      vertex -10.5504 -2.7 6.76718
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.7622 -2.7 6.49417
-      vertex -19.2378 -2.7 6.49417
-      vertex -19.4496 -2.7 6.76718
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.9907 -2.7 6.23499
-      vertex -19.2378 -2.7 6.49417
-      vertex -10.7622 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.9907 -2.7 6.23499
-      vertex -19.0093 -2.7 6.23499
-      vertex -19.2378 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -11.235 -2.7 5.99067
-      vertex -19.0093 -2.7 6.23499
-      vertex -10.9907 -2.7 6.23499
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.235 -2.7 5.99067
-      vertex -18.765 -2.7 5.99067
-      vertex -19.0093 -2.7 6.23499
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -11.4942 -2.7 5.76218
-      vertex -18.765 -2.7 5.99067
-      vertex -11.235 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.4942 -2.7 5.76218
-      vertex -18.5058 -2.7 5.76218
-      vertex -18.765 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -11.7672 -2.7 5.55041
-      vertex -18.5058 -2.7 5.76218
-      vertex -11.4942 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.7672 -2.7 5.55041
-      vertex -18.2328 -2.7 5.55041
-      vertex -18.5058 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -12.053 -2.7 5.3562
-      vertex -18.2328 -2.7 5.55041
-      vertex -11.7672 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.053 -2.7 5.3562
-      vertex -17.947 -2.7 5.3562
-      vertex -18.2328 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -12.3504 -2.7 5.18031
-      vertex -17.947 -2.7 5.3562
-      vertex -12.053 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.3504 -2.7 5.18031
-      vertex -17.6496 -2.7 5.18031
-      vertex -17.947 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -12.6582 -2.7 5.02345
-      vertex -17.6496 -2.7 5.18031
-      vertex -12.3504 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.6582 -2.7 5.02345
-      vertex -17.3418 -2.7 5.02345
-      vertex -17.6496 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -12.9753 -2.7 4.88623
-      vertex -17.3418 -2.7 5.02345
-      vertex -12.6582 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -12.9753 -2.7 4.88623
-      vertex -17.0247 -2.7 4.88623
-      vertex -17.3418 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -13.3004 -2.7 4.76919
-      vertex -17.0247 -2.7 4.88623
-      vertex -12.9753 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.3004 -2.7 4.76919
-      vertex -16.6996 -2.7 4.76919
-      vertex -17.0247 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -13.6322 -2.7 4.67279
-      vertex -16.6996 -2.7 4.76919
-      vertex -13.3004 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.6322 -2.7 4.67279
-      vertex -16.3678 -2.7 4.67279
-      vertex -16.6996 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -13.9694 -2.7 4.59742
-      vertex -16.3678 -2.7 4.67279
-      vertex -13.6322 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -13.9694 -2.7 4.59742
-      vertex -16.0306 -2.7 4.59742
-      vertex -16.3678 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -14.3107 -2.7 4.54337
-      vertex -16.0306 -2.7 4.59742
-      vertex -13.9694 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -14.3107 -2.7 4.54337
-      vertex -15.6893 -2.7 4.54337
-      vertex -16.0306 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -14.6547 -2.7 4.51085
-      vertex -15.6893 -2.7 4.54337
-      vertex -14.3107 -2.7 4.54337
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -14.6547 -2.7 4.51085
-      vertex -15.3453 -2.7 4.51085
-      vertex -15.6893 -2.7 4.54337
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex -15.3453 -2.7 4.51085
-      vertex -14.6547 -2.7 4.51085
-      vertex -15 -2.7 4.5
-    endloop
-  endfacet
-  facet normal -0.860727 0 0.509068
-    outer loop
-      vertex -10.3562 -2.7 7.05295
-      vertex -10.1803 0 7.35036
-      vertex -10.3562 0 7.05295
-    endloop
-  endfacet
-  facet normal -0.860727 0 0.509068
-    outer loop
-      vertex -10.1803 0 7.35036
-      vertex -10.3562 -2.7 7.05295
-      vertex -10.1803 -2.7 7.35036
-    endloop
-  endfacet
-  facet normal 0.218217 0 -0.9759
-    outer loop
-      vertex -16.3678 -2.7 15.3272
-      vertex -16.0306 0 15.4026
-      vertex -16.0306 -2.7 15.4026
-    endloop
-  endfacet
-  facet normal 0.218217 0 -0.9759
-    outer loop
-      vertex -16.0306 0 15.4026
-      vertex -16.3678 -2.7 15.3272
-      vertex -16.3678 0 15.3272
-    endloop
-  endfacet
-  facet normal -0.279 0 -0.960291
-    outer loop
-      vertex -13.6322 -2.7 15.3272
-      vertex -13.3004 0 15.2308
-      vertex -13.3004 -2.7 15.2308
-    endloop
-  endfacet
-  facet normal -0.279 0 -0.960291
-    outer loop
-      vertex -13.3004 0 15.2308
-      vertex -13.6322 -2.7 15.3272
-      vertex -13.6322 0 15.3272
-    endloop
-  endfacet
-  facet normal -0.975919 0 -0.218135
-    outer loop
-      vertex -9.59742 -2.7 11.0306
-      vertex -9.67279 0 11.3678
-      vertex -9.59742 0 11.0306
-    endloop
-  endfacet
-  facet normal -0.975919 -0 -0.218135
-    outer loop
-      vertex -9.67279 0 11.3678
-      vertex -9.59742 -2.7 11.0306
-      vertex -9.67279 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal -0.707107 0 -0.707107
-    outer loop
-      vertex -10.9907 -2.7 13.765
-      vertex -11.235 0 14.0093
-      vertex -10.9907 0 13.765
-    endloop
-  endfacet
-  facet normal -0.707107 -0 -0.707107
-    outer loop
-      vertex -11.235 0 14.0093
-      vertex -10.9907 -2.7 13.765
-      vertex -11.235 -2.7 14.0093
-    endloop
-  endfacet
-  facet normal 0.860727 -0 0.509068
-    outer loop
-      vertex -19.8197 -2.7 7.35036
-      vertex -19.6438 0 7.05295
-      vertex -19.8197 0 7.35036
-    endloop
-  endfacet
-  facet normal 0.860727 0 0.509068
-    outer loop
-      vertex -19.6438 0 7.05295
-      vertex -19.8197 -2.7 7.35036
-      vertex -19.6438 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal 0.790111 -0 0.612964
-    outer loop
-      vertex -19.4496 -2.7 6.76718
-      vertex -19.2378 0 6.49417
-      vertex -19.4496 0 6.76718
-    endloop
-  endfacet
-  facet normal 0.790111 0 0.612964
-    outer loop
-      vertex -19.2378 0 6.49417
-      vertex -19.4496 -2.7 6.76718
-      vertex -19.2378 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal 0.827093 -0 0.562065
-    outer loop
-      vertex -19.6438 -2.7 7.05295
-      vertex -19.4496 0 6.76718
-      vertex -19.6438 0 7.05295
-    endloop
-  endfacet
-  facet normal 0.827093 0 0.562065
-    outer loop
-      vertex -19.4496 0 6.76718
-      vertex -19.6438 -2.7 7.05295
-      vertex -19.4496 -2.7 6.76718
-    endloop
-  endfacet
-  facet normal 0.66127 0 0.750148
-    outer loop
-      vertex -18.765 0 5.99067
-      vertex -18.5058 -2.7 5.76218
-      vertex -18.5058 0 5.76218
-    endloop
-  endfacet
-  facet normal 0.66127 0 0.750148
-    outer loop
-      vertex -18.5058 -2.7 5.76218
-      vertex -18.765 0 5.99067
-      vertex -18.765 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal 0.750108 -0 0.661315
-    outer loop
-      vertex -19.2378 -2.7 6.49417
-      vertex -19.0093 0 6.23499
-      vertex -19.2378 0 6.49417
-    endloop
-  endfacet
-  facet normal 0.750108 0 0.661315
-    outer loop
-      vertex -19.0093 0 6.23499
-      vertex -19.2378 -2.7 6.49417
-      vertex -19.0093 -2.7 6.23499
-    endloop
-  endfacet
-  facet normal 0.279 0 0.960291
-    outer loop
-      vertex -16.6996 0 4.76919
-      vertex -16.3678 -2.7 4.67279
-      vertex -16.3678 0 4.67279
-    endloop
-  endfacet
-  facet normal 0.279 0 0.960291
-    outer loop
-      vertex -16.3678 -2.7 4.67279
-      vertex -16.6996 0 4.76919
-      vertex -16.6996 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal 0.156416 0 0.987691
-    outer loop
-      vertex -16.0306 0 4.59742
-      vertex -15.6893 -2.7 4.54337
-      vertex -15.6893 0 4.54337
-    endloop
-  endfacet
-  facet normal 0.156416 0 0.987691
-    outer loop
-      vertex -15.6893 -2.7 4.54337
-      vertex -16.0306 0 4.59742
-      vertex -16.0306 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal 0.218135 0 0.975919
-    outer loop
-      vertex -16.3678 0 4.67279
-      vertex -16.0306 -2.7 4.59742
-      vertex -16.0306 0 4.59742
-    endloop
-  endfacet
-  facet normal 0.218135 0 0.975919
-    outer loop
-      vertex -16.0306 -2.7 4.59742
-      vertex -16.3678 0 4.67279
-      vertex -16.3678 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal -0.960291 0 0.279
-    outer loop
-      vertex -9.76919 -2.7 8.30041
-      vertex -9.67279 0 8.63221
-      vertex -9.76919 0 8.30041
-    endloop
-  endfacet
-  facet normal -0.960291 0 0.279
-    outer loop
-      vertex -9.67279 0 8.63221
-      vertex -9.76919 -2.7 8.30041
-      vertex -9.67279 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal -0.987689 0 0.156429
-    outer loop
-      vertex -9.59742 -2.7 8.9694
-      vertex -9.54337 0 9.31067
-      vertex -9.59742 0 8.9694
-    endloop
-  endfacet
-  facet normal -0.987689 0 0.156429
-    outer loop
-      vertex -9.54337 0 9.31067
-      vertex -9.59742 -2.7 8.9694
-      vertex -9.54337 -2.7 9.31067
-    endloop
-  endfacet
-  facet normal -0.975917 0 0.218141
-    outer loop
-      vertex -9.67279 -2.7 8.63221
-      vertex -9.59742 0 8.9694
-      vertex -9.67279 0 8.63221
-    endloop
-  endfacet
-  facet normal -0.975917 0 0.218141
-    outer loop
-      vertex -9.59742 0 8.9694
-      vertex -9.67279 -2.7 8.63221
-      vertex -9.59742 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal -0.999507 0 0.0314019
-    outer loop
-      vertex -9.51085 -2.7 9.65465
-      vertex -9.5 0 10
-      vertex -9.51085 0 9.65465
-    endloop
-  endfacet
-  facet normal -0.999507 0 0.0314019
-    outer loop
-      vertex -9.5 0 10
-      vertex -9.51085 -2.7 9.65465
-      vertex -9.5 -2.7 10
-    endloop
-  endfacet
-  facet normal -0.0941153 0 0.995561
-    outer loop
-      vertex -14.6547 0 4.51085
-      vertex -14.3107 -2.7 4.54337
-      vertex -14.3107 0 4.54337
-    endloop
-  endfacet
-  facet normal -0.0941153 0 0.995561
-    outer loop
-      vertex -14.3107 -2.7 4.54337
-      vertex -14.6547 0 4.51085
-      vertex -14.6547 -2.7 4.51085
-    endloop
-  endfacet
-  facet normal -0.218135 0 0.975919
-    outer loop
-      vertex -13.9694 0 4.59742
-      vertex -13.6322 -2.7 4.67279
-      vertex -13.6322 0 4.67279
-    endloop
-  endfacet
-  facet normal -0.218135 0 0.975919
-    outer loop
-      vertex -13.6322 -2.7 4.67279
-      vertex -13.9694 0 4.59742
-      vertex -13.9694 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal -0.156416 0 0.987691
-    outer loop
-      vertex -14.3107 0 4.54337
-      vertex -13.9694 -2.7 4.59742
-      vertex -13.9694 0 4.59742
-    endloop
-  endfacet
-  facet normal -0.156416 0 0.987691
-    outer loop
-      vertex -13.9694 -2.7 4.59742
-      vertex -14.3107 0 4.54337
-      vertex -14.3107 -2.7 4.54337
-    endloop
-  endfacet
-  facet normal -0.509059 0 0.860732
-    outer loop
-      vertex -12.3504 0 5.18031
-      vertex -12.053 -2.7 5.3562
-      vertex -12.053 0 5.3562
-    endloop
-  endfacet
-  facet normal -0.509059 0 0.860732
-    outer loop
-      vertex -12.053 -2.7 5.3562
-      vertex -12.3504 0 5.18031
-      vertex -12.3504 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal -0.612924 0 0.790142
-    outer loop
-      vertex -11.7672 0 5.55041
-      vertex -11.4942 -2.7 5.76218
-      vertex -11.4942 0 5.76218
-    endloop
-  endfacet
-  facet normal -0.612924 0 0.790142
-    outer loop
-      vertex -11.4942 -2.7 5.76218
-      vertex -11.7672 0 5.55041
-      vertex -11.7672 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal -0.562045 0 0.827107
-    outer loop
-      vertex -12.053 0 5.3562
-      vertex -11.7672 -2.7 5.55041
-      vertex -11.7672 0 5.55041
-    endloop
-  endfacet
-  facet normal -0.562045 0 0.827107
-    outer loop
-      vertex -11.7672 -2.7 5.55041
-      vertex -12.053 0 5.3562
-      vertex -12.053 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal -0.750108 0 0.661315
-    outer loop
-      vertex -10.9907 -2.7 6.23499
-      vertex -10.7622 0 6.49417
-      vertex -10.9907 0 6.23499
-    endloop
-  endfacet
-  facet normal -0.750108 0 0.661315
-    outer loop
-      vertex -10.7622 0 6.49417
-      vertex -10.9907 -2.7 6.23499
-      vertex -10.7622 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal -0.66127 0 0.750148
-    outer loop
-      vertex -11.4942 0 5.76218
-      vertex -11.235 -2.7 5.99067
-      vertex -11.235 0 5.99067
-    endloop
-  endfacet
-  facet normal -0.66127 0 0.750148
-    outer loop
-      vertex -11.235 -2.7 5.99067
-      vertex -11.4942 0 5.76218
-      vertex -11.4942 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal 0.995567 0 -0.0940579
-    outer loop
-      vertex -20.4566 -2.7 10.6893
-      vertex -20.4891 0 10.3453
-      vertex -20.4566 0 10.6893
-    endloop
-  endfacet
-  facet normal 0.995567 0 -0.0940579
-    outer loop
-      vertex -20.4891 0 10.3453
-      vertex -20.4566 -2.7 10.6893
-      vertex -20.4891 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal 0.940921 0 -0.338627
-    outer loop
-      vertex -20.1138 -2.7 12.0247
-      vertex -20.2308 0 11.6996
-      vertex -20.1138 0 12.0247
-    endloop
-  endfacet
-  facet normal 0.940921 0 -0.338627
-    outer loop
-      vertex -20.2308 0 11.6996
-      vertex -20.1138 -2.7 12.0247
-      vertex -20.2308 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal 0.960291 0 -0.279
-    outer loop
-      vertex -20.2308 -2.7 11.6996
-      vertex -20.3272 0 11.3678
-      vertex -20.2308 0 11.6996
-    endloop
-  endfacet
-  facet normal 0.960291 0 -0.279
-    outer loop
-      vertex -20.3272 0 11.3678
-      vertex -20.2308 -2.7 11.6996
-      vertex -20.3272 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal 0.7901 0 -0.612978
-    outer loop
-      vertex -19.2378 -2.7 13.5058
-      vertex -19.4496 0 13.2328
-      vertex -19.2378 0 13.5058
-    endloop
-  endfacet
-  facet normal 0.7901 0 -0.612978
-    outer loop
-      vertex -19.4496 0 13.2328
-      vertex -19.2378 -2.7 13.5058
-      vertex -19.4496 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal 0.82712 0 -0.562025
-    outer loop
-      vertex -19.4496 -2.7 13.2328
-      vertex -19.6438 0 12.947
-      vertex -19.4496 0 13.2328
-    endloop
-  endfacet
-  facet normal 0.82712 0 -0.562025
-    outer loop
-      vertex -19.6438 0 12.947
-      vertex -19.4496 -2.7 13.2328
-      vertex -19.6438 -2.7 12.947
-    endloop
-  endfacet
-  facet normal 0.397339 0 -0.917672
-    outer loop
-      vertex -17.3418 -2.7 14.9765
-      vertex -17.0247 0 15.1138
-      vertex -17.0247 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal 0.397339 0 -0.917672
-    outer loop
-      vertex -17.0247 0 15.1138
-      vertex -17.3418 -2.7 14.9765
-      vertex -17.3418 0 14.9765
-    endloop
-  endfacet
-  facet normal 0.338627 0 -0.940921
-    outer loop
-      vertex -17.0247 -2.7 15.1138
-      vertex -16.6996 0 15.2308
-      vertex -16.6996 -2.7 15.2308
-    endloop
-  endfacet
-  facet normal 0.338627 0 -0.940921
-    outer loop
-      vertex -16.6996 0 15.2308
-      vertex -17.0247 -2.7 15.1138
-      vertex -17.0247 0 15.1138
-    endloop
-  endfacet
-  facet normal 0.661287 0 -0.750133
-    outer loop
-      vertex -18.765 -2.7 14.0093
-      vertex -18.5058 0 14.2378
-      vertex -18.5058 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal 0.661287 0 -0.750133
-    outer loop
-      vertex -18.5058 0 14.2378
-      vertex -18.765 -2.7 14.0093
-      vertex -18.765 0 14.0093
-    endloop
-  endfacet
-  facet normal 0.562025 0 -0.82712
-    outer loop
-      vertex -18.2328 -2.7 14.4496
-      vertex -17.947 0 14.6438
-      vertex -17.947 -2.7 14.6438
-    endloop
-  endfacet
-  facet normal 0.562025 0 -0.82712
-    outer loop
-      vertex -17.947 0 14.6438
-      vertex -18.2328 -2.7 14.4496
-      vertex -18.2328 0 14.4496
-    endloop
-  endfacet
-  facet normal -0.218217 0 -0.9759
-    outer loop
-      vertex -13.9694 -2.7 15.4026
-      vertex -13.6322 0 15.3272
-      vertex -13.6322 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal -0.218217 0 -0.9759
-    outer loop
-      vertex -13.6322 0 15.3272
-      vertex -13.9694 -2.7 15.4026
-      vertex -13.9694 0 15.4026
-    endloop
-  endfacet
-  facet normal -0.338627 0 -0.940921
-    outer loop
-      vertex -13.3004 -2.7 15.2308
-      vertex -12.9753 0 15.1138
-      vertex -12.9753 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal -0.338627 0 -0.940921
-    outer loop
-      vertex -12.9753 0 15.1138
-      vertex -13.3004 -2.7 15.2308
-      vertex -13.3004 0 15.2308
-    endloop
-  endfacet
-  facet normal -0.397339 0 -0.917672
-    outer loop
-      vertex -12.9753 -2.7 15.1138
-      vertex -12.6582 0 14.9765
-      vertex -12.6582 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal -0.397339 0 -0.917672
-    outer loop
-      vertex -12.6582 0 14.9765
-      vertex -12.9753 -2.7 15.1138
-      vertex -12.9753 0 15.1138
-    endloop
-  endfacet
-  facet normal -0.50908 0 -0.860719
-    outer loop
-      vertex -12.3504 -2.7 14.8197
-      vertex -12.053 0 14.6438
-      vertex -12.053 -2.7 14.6438
-    endloop
-  endfacet
-  facet normal -0.50908 0 -0.860719
-    outer loop
-      vertex -12.053 0 14.6438
-      vertex -12.3504 -2.7 14.8197
-      vertex -12.3504 0 14.8197
-    endloop
-  endfacet
-  facet normal -0.995561 0 -0.0941153
-    outer loop
-      vertex -9.51085 -2.7 10.3453
-      vertex -9.54337 0 10.6893
-      vertex -9.51085 0 10.3453
-    endloop
-  endfacet
-  facet normal -0.995561 -0 -0.0941153
-    outer loop
-      vertex -9.54337 0 10.6893
-      vertex -9.51085 -2.7 10.3453
-      vertex -9.54337 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal -0.917703 0 -0.397266
-    outer loop
-      vertex -9.88623 -2.7 12.0247
-      vertex -10.0235 0 12.3418
-      vertex -9.88623 0 12.0247
-    endloop
-  endfacet
-  facet normal -0.917703 -0 -0.397266
-    outer loop
-      vertex -10.0235 0 12.3418
-      vertex -9.88623 -2.7 12.0247
-      vertex -10.0235 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal -0.661287 0 -0.750133
-    outer loop
-      vertex -11.4942 -2.7 14.2378
-      vertex -11.235 0 14.0093
-      vertex -11.235 -2.7 14.0093
-    endloop
-  endfacet
-  facet normal -0.661287 0 -0.750133
-    outer loop
-      vertex -11.235 0 14.0093
-      vertex -11.4942 -2.7 14.2378
-      vertex -11.4942 0 14.2378
-    endloop
-  endfacet
-  facet normal -0.750133 0 -0.661287
-    outer loop
-      vertex -10.7622 -2.7 13.5058
-      vertex -10.9907 0 13.765
-      vertex -10.7622 0 13.5058
-    endloop
-  endfacet
-  facet normal -0.750133 -0 -0.661287
-    outer loop
-      vertex -10.9907 0 13.765
-      vertex -10.7622 -2.7 13.5058
-      vertex -10.9907 -2.7 13.765
-    endloop
-  endfacet
-  facet normal -0.860719 0 -0.50908
-    outer loop
-      vertex -10.1803 -2.7 12.6496
-      vertex -10.3562 0 12.947
-      vertex -10.1803 0 12.6496
-    endloop
-  endfacet
-  facet normal -0.860719 -0 -0.50908
-    outer loop
-      vertex -10.3562 0 12.947
-      vertex -10.1803 -2.7 12.6496
-      vertex -10.3562 -2.7 12.947
+      vertex 5.11377 0 7.97532
+      vertex 4.97655 -2.7 7.65821
+      vertex 5.11377 -2.7 7.97532
     endloop
   endfacet
   facet normal 0.995566 -0 0.0940633
     outer loop
-      vertex -20.4891 -2.7 9.65465
-      vertex -20.4566 0 9.31067
-      vertex -20.4891 0 9.65465
+      vertex -21.4891 -2.7 9.65465
+      vertex -21.4566 0 9.31067
+      vertex -21.4891 0 9.65465
     endloop
   endfacet
   facet normal 0.995566 0 0.0940633
     outer loop
-      vertex -20.4566 0 9.31067
-      vertex -20.4891 -2.7 9.65465
-      vertex -20.4566 -2.7 9.31067
+      vertex -21.4566 0 9.31067
+      vertex -21.4891 -2.7 9.65465
+      vertex -21.4566 -2.7 9.31067
     endloop
   endfacet
-  facet normal 0.960291 -0 0.279
+  facet normal 0.999502 -0 0.0315465
     outer loop
-      vertex -20.3272 -2.7 8.63221
-      vertex -20.2308 0 8.30041
-      vertex -20.3272 0 8.63221
+      vertex -21.5 -2.7 10
+      vertex -21.4891 0 9.65465
+      vertex -21.5 0 10
     endloop
   endfacet
-  facet normal 0.960291 0 0.279
+  facet normal 0.999502 0 0.0315465
     outer loop
-      vertex -20.2308 0 8.30041
-      vertex -20.3272 -2.7 8.63221
-      vertex -20.2308 -2.7 8.30041
+      vertex -21.4891 0 9.65465
+      vertex -21.5 -2.7 10
+      vertex -21.4891 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal 0.7901 0 -0.612978
+    outer loop
+      vertex -20.2378 -2.7 13.5058
+      vertex -20.4496 0 13.2328
+      vertex -20.2378 0 13.5058
+    endloop
+  endfacet
+  facet normal 0.7901 0 -0.612978
+    outer loop
+      vertex -20.4496 0 13.2328
+      vertex -20.2378 -2.7 13.5058
+      vertex -20.4496 -2.7 13.2328
+    endloop
+  endfacet
+  facet normal 0.9759 0 -0.218217
+    outer loop
+      vertex -21.3272 -2.7 11.3678
+      vertex -21.4026 0 11.0306
+      vertex -21.3272 0 11.3678
+    endloop
+  endfacet
+  facet normal 0.9759 0 -0.218217
+    outer loop
+      vertex -21.4026 0 11.0306
+      vertex -21.3272 -2.7 11.3678
+      vertex -21.4026 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal -0.960291 0 0.279
+    outer loop
+      vertex -10.7692 -2.7 8.30041
+      vertex -10.6728 0 8.63221
+      vertex -10.7692 0 8.30041
+    endloop
+  endfacet
+  facet normal -0.960291 0 0.279
+    outer loop
+      vertex -10.6728 0 8.63221
+      vertex -10.7692 -2.7 8.30041
+      vertex -10.6728 -2.7 8.63221
+    endloop
+  endfacet
+  facet normal -0.509059 0 0.860732
+    outer loop
+      vertex -13.3504 0 5.18031
+      vertex -13.053 -2.7 5.3562
+      vertex -13.053 0 5.3562
+    endloop
+  endfacet
+  facet normal -0.509059 0 0.860732
+    outer loop
+      vertex -13.053 -2.7 5.3562
+      vertex -13.3504 0 5.18031
+      vertex -13.3504 -2.7 5.18031
     endloop
   endfacet
   facet normal 0.891074 -0 0.453859
     outer loop
-      vertex -19.9765 -2.7 7.65821
-      vertex -19.8197 0 7.35036
-      vertex -19.9765 0 7.65821
+      vertex -20.9765 -2.7 7.65821
+      vertex -20.8197 0 7.35036
+      vertex -20.9765 0 7.65821
     endloop
   endfacet
   facet normal 0.891074 0 0.453859
     outer loop
-      vertex -19.8197 0 7.35036
-      vertex -19.9765 -2.7 7.65821
-      vertex -19.8197 -2.7 7.35036
+      vertex -20.8197 0 7.35036
+      vertex -20.9765 -2.7 7.65821
+      vertex -20.8197 -2.7 7.35036
     endloop
   endfacet
-  facet normal 0.707136 -0 0.707078
+  facet normal -0.397144 0 0.917756
     outer loop
-      vertex -19.0093 -2.7 6.23499
-      vertex -18.765 0 5.99067
-      vertex -19.0093 0 6.23499
+      vertex -13.9753 0 4.88623
+      vertex -13.6582 -2.7 5.02345
+      vertex -13.6582 0 5.02345
     endloop
   endfacet
-  facet normal 0.707136 0 0.707078
+  facet normal -0.397144 0 0.917756
     outer loop
-      vertex -18.765 0 5.99067
-      vertex -19.0093 -2.7 6.23499
-      vertex -18.765 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal 0.612924 0 0.790142
-    outer loop
-      vertex -18.5058 0 5.76218
-      vertex -18.2328 -2.7 5.55041
-      vertex -18.2328 0 5.55041
-    endloop
-  endfacet
-  facet normal 0.612924 0 0.790142
-    outer loop
-      vertex -18.2328 -2.7 5.55041
-      vertex -18.5058 0 5.76218
-      vertex -18.5058 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal 0.454055 0 0.890974
-    outer loop
-      vertex -17.6496 0 5.18031
-      vertex -17.3418 -2.7 5.02345
-      vertex -17.3418 0 5.02345
-    endloop
-  endfacet
-  facet normal 0.454055 0 0.890974
-    outer loop
-      vertex -17.3418 -2.7 5.02345
-      vertex -17.6496 0 5.18031
-      vertex -17.6496 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal 0.0941153 0 0.995561
-    outer loop
-      vertex -15.6893 0 4.54337
-      vertex -15.3453 -2.7 4.51085
-      vertex -15.3453 0 4.51085
-    endloop
-  endfacet
-  facet normal 0.0941153 0 0.995561
-    outer loop
-      vertex -15.3453 -2.7 4.51085
-      vertex -15.6893 0 4.54337
-      vertex -15.6893 -2.7 4.54337
-    endloop
-  endfacet
-  facet normal 0.0314065 0 0.999507
-    outer loop
-      vertex -15.3453 0 4.51085
-      vertex -15 -2.7 4.5
-      vertex -15 0 4.5
-    endloop
-  endfacet
-  facet normal 0.0314065 0 0.999507
-    outer loop
-      vertex -15 -2.7 4.5
-      vertex -15.3453 0 4.51085
-      vertex -15.3453 -2.7 4.51085
-    endloop
-  endfacet
-  facet normal -0.995561 0 0.0941207
-    outer loop
-      vertex -9.54337 -2.7 9.31067
-      vertex -9.51085 0 9.65465
-      vertex -9.54337 0 9.31067
-    endloop
-  endfacet
-  facet normal -0.995561 0 0.0941207
-    outer loop
-      vertex -9.51085 0 9.65465
-      vertex -9.54337 -2.7 9.31067
-      vertex -9.51085 -2.7 9.65465
-    endloop
-  endfacet
-  facet normal -0.891074 0 0.453859
-    outer loop
-      vertex -10.1803 -2.7 7.35036
-      vertex -10.0235 0 7.65821
-      vertex -10.1803 0 7.35036
-    endloop
-  endfacet
-  facet normal -0.891074 0 0.453859
-    outer loop
-      vertex -10.0235 0 7.65821
-      vertex -10.1803 -2.7 7.35036
-      vertex -10.0235 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal -0.917708 0 0.397256
-    outer loop
-      vertex -10.0235 -2.7 7.65821
-      vertex -9.88623 0 7.97532
-      vertex -10.0235 0 7.65821
-    endloop
-  endfacet
-  facet normal -0.917708 0 0.397256
-    outer loop
-      vertex -9.88623 0 7.97532
-      vertex -10.0235 -2.7 7.65821
-      vertex -9.88623 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal -0.790111 0 0.612964
-    outer loop
-      vertex -10.7622 -2.7 6.49417
-      vertex -10.5504 0 6.76718
-      vertex -10.7622 0 6.49417
-    endloop
-  endfacet
-  facet normal -0.790111 0 0.612964
-    outer loop
-      vertex -10.5504 0 6.76718
-      vertex -10.7622 -2.7 6.49417
-      vertex -10.5504 -2.7 6.76718
-    endloop
-  endfacet
-  facet normal -0.827093 0 0.562065
-    outer loop
-      vertex -10.5504 -2.7 6.76718
-      vertex -10.3562 0 7.05295
-      vertex -10.5504 0 6.76718
-    endloop
-  endfacet
-  facet normal -0.827093 0 0.562065
-    outer loop
-      vertex -10.3562 0 7.05295
-      vertex -10.5504 -2.7 6.76718
-      vertex -10.3562 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal -0.279 0 0.960291
-    outer loop
-      vertex -13.6322 0 4.67279
-      vertex -13.3004 -2.7 4.76919
-      vertex -13.3004 0 4.76919
-    endloop
-  endfacet
-  facet normal -0.279 0 0.960291
-    outer loop
-      vertex -13.3004 -2.7 4.76919
-      vertex -13.6322 0 4.67279
-      vertex -13.6322 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal -0.33873 0 0.940884
-    outer loop
-      vertex -13.3004 0 4.76919
-      vertex -12.9753 -2.7 4.88623
-      vertex -12.9753 0 4.88623
-    endloop
-  endfacet
-  facet normal -0.33873 0 0.940884
-    outer loop
-      vertex -12.9753 -2.7 4.88623
-      vertex -13.3004 0 4.76919
-      vertex -13.3004 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal -0.454055 0 0.890974
-    outer loop
-      vertex -12.6582 0 5.02345
-      vertex -12.3504 -2.7 5.18031
-      vertex -12.3504 0 5.18031
-    endloop
-  endfacet
-  facet normal -0.454055 0 0.890974
-    outer loop
-      vertex -12.3504 -2.7 5.18031
-      vertex -12.6582 0 5.02345
-      vertex -12.6582 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal -0.707136 0 0.707078
-    outer loop
-      vertex -11.235 -2.7 5.99067
-      vertex -10.9907 0 6.23499
-      vertex -11.235 0 5.99067
-    endloop
-  endfacet
-  facet normal -0.707136 0 0.707078
-    outer loop
-      vertex -10.9907 0 6.23499
-      vertex -11.235 -2.7 5.99067
-      vertex -10.9907 -2.7 6.23499
-    endloop
-  endfacet
-  facet normal 0.860719 0 -0.50908
-    outer loop
-      vertex -19.6438 -2.7 12.947
-      vertex -19.8197 0 12.6496
-      vertex -19.6438 0 12.947
-    endloop
-  endfacet
-  facet normal 0.860719 0 -0.50908
-    outer loop
-      vertex -19.8197 0 12.6496
-      vertex -19.6438 -2.7 12.947
-      vertex -19.8197 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal 0.0940579 0 -0.995567
-    outer loop
-      vertex -15.6893 -2.7 15.4566
-      vertex -15.3453 0 15.4891
-      vertex -15.3453 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal 0.0940579 0 -0.995567
-    outer loop
-      vertex -15.3453 0 15.4891
-      vertex -15.6893 -2.7 15.4566
-      vertex -15.6893 0 15.4566
-    endloop
-  endfacet
-  facet normal 0.156275 0 -0.987714
-    outer loop
-      vertex -16.0306 -2.7 15.4026
-      vertex -15.6893 0 15.4566
-      vertex -15.6893 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal 0.156275 0 -0.987714
-    outer loop
-      vertex -15.6893 0 15.4566
-      vertex -16.0306 -2.7 15.4026
-      vertex -16.0306 0 15.4026
-    endloop
-  endfacet
-  facet normal 0.707107 0 -0.707107
-    outer loop
-      vertex -18.765 -2.7 14.0093
-      vertex -19.0093 0 13.765
-      vertex -18.765 0 14.0093
-    endloop
-  endfacet
-  facet normal 0.707107 0 -0.707107
-    outer loop
-      vertex -19.0093 0 13.765
-      vertex -18.765 -2.7 14.0093
-      vertex -19.0093 -2.7 13.765
-    endloop
-  endfacet
-  facet normal 0.453917 0 -0.891044
-    outer loop
-      vertex -17.6496 -2.7 14.8197
-      vertex -17.3418 0 14.9765
-      vertex -17.3418 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal 0.453917 0 -0.891044
-    outer loop
-      vertex -17.3418 0 14.9765
-      vertex -17.6496 -2.7 14.8197
-      vertex -17.6496 0 14.8197
-    endloop
-  endfacet
-  facet normal 0.50908 0 -0.860719
-    outer loop
-      vertex -17.947 -2.7 14.6438
-      vertex -17.6496 0 14.8197
-      vertex -17.6496 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal 0.50908 0 -0.860719
-    outer loop
-      vertex -17.6496 0 14.8197
-      vertex -17.947 -2.7 14.6438
-      vertex -17.947 0 14.6438
-    endloop
-  endfacet
-  facet normal 0.612978 0 -0.7901
-    outer loop
-      vertex -18.5058 -2.7 14.2378
-      vertex -18.2328 0 14.4496
-      vertex -18.2328 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal 0.612978 0 -0.7901
-    outer loop
-      vertex -18.2328 0 14.4496
-      vertex -18.5058 -2.7 14.2378
-      vertex -18.5058 0 14.2378
-    endloop
-  endfacet
-  facet normal -0.156275 0 -0.987714
-    outer loop
-      vertex -14.3107 -2.7 15.4566
-      vertex -13.9694 0 15.4026
-      vertex -13.9694 -2.7 15.4026
-    endloop
-  endfacet
-  facet normal -0.156275 0 -0.987714
-    outer loop
-      vertex -13.9694 0 15.4026
-      vertex -14.3107 -2.7 15.4566
-      vertex -14.3107 0 15.4566
-    endloop
-  endfacet
-  facet normal -0.0940579 0 -0.995567
-    outer loop
-      vertex -14.6547 -2.7 15.4891
-      vertex -14.3107 0 15.4566
-      vertex -14.3107 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal -0.0940579 0 -0.995567
-    outer loop
-      vertex -14.3107 0 15.4566
-      vertex -14.6547 -2.7 15.4891
-      vertex -14.6547 0 15.4891
-    endloop
-  endfacet
-  facet normal -0.031551 0 -0.999502
-    outer loop
-      vertex -15 -2.7 15.5
-      vertex -14.6547 0 15.4891
-      vertex -14.6547 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal -0.031551 0 -0.999502
-    outer loop
-      vertex -14.6547 0 15.4891
-      vertex -15 -2.7 15.5
-      vertex -15 0 15.5
-    endloop
-  endfacet
-  facet normal -0.453917 0 -0.891044
-    outer loop
-      vertex -12.6582 -2.7 14.9765
-      vertex -12.3504 0 14.8197
-      vertex -12.3504 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal -0.453917 0 -0.891044
-    outer loop
-      vertex -12.3504 0 14.8197
-      vertex -12.6582 -2.7 14.9765
-      vertex -12.6582 0 14.9765
-    endloop
-  endfacet
-  facet normal -0.612978 0 -0.7901
-    outer loop
-      vertex -11.7672 -2.7 14.4496
-      vertex -11.4942 0 14.2378
-      vertex -11.4942 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal -0.612978 0 -0.7901
-    outer loop
-      vertex -11.4942 0 14.2378
-      vertex -11.7672 -2.7 14.4496
-      vertex -11.7672 0 14.4496
-    endloop
-  endfacet
-  facet normal -0.562025 0 -0.82712
-    outer loop
-      vertex -12.053 -2.7 14.6438
-      vertex -11.7672 0 14.4496
-      vertex -11.7672 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal -0.562025 0 -0.82712
-    outer loop
-      vertex -11.7672 0 14.4496
-      vertex -12.053 -2.7 14.6438
-      vertex -12.053 0 14.6438
-    endloop
-  endfacet
-  facet normal -0.987691 0 -0.156416
-    outer loop
-      vertex -9.54337 -2.7 10.6893
-      vertex -9.59742 0 11.0306
-      vertex -9.54337 0 10.6893
-    endloop
-  endfacet
-  facet normal -0.987691 -0 -0.156416
-    outer loop
-      vertex -9.59742 0 11.0306
-      vertex -9.54337 -2.7 10.6893
-      vertex -9.59742 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal -0.960291 0 -0.279
-    outer loop
-      vertex -9.67279 -2.7 11.3678
-      vertex -9.76919 0 11.6996
-      vertex -9.67279 0 11.3678
-    endloop
-  endfacet
-  facet normal -0.960291 -0 -0.279
-    outer loop
-      vertex -9.76919 0 11.6996
-      vertex -9.67279 -2.7 11.3678
-      vertex -9.76919 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal -0.940884 0 -0.33873
-    outer loop
-      vertex -9.76919 -2.7 11.6996
-      vertex -9.88623 0 12.0247
-      vertex -9.76919 0 11.6996
-    endloop
-  endfacet
-  facet normal -0.940884 -0 -0.33873
-    outer loop
-      vertex -9.88623 0 12.0247
-      vertex -9.76919 -2.7 11.6996
-      vertex -9.88623 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal -0.82712 0 -0.562025
-    outer loop
-      vertex -10.3562 -2.7 12.947
-      vertex -10.5504 0 13.2328
-      vertex -10.3562 0 12.947
-    endloop
-  endfacet
-  facet normal -0.82712 -0 -0.562025
-    outer loop
-      vertex -10.5504 0 13.2328
-      vertex -10.3562 -2.7 12.947
-      vertex -10.5504 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal -0.7901 0 -0.612978
-    outer loop
-      vertex -10.5504 -2.7 13.2328
-      vertex -10.7622 0 13.5058
-      vertex -10.5504 0 13.2328
-    endloop
-  endfacet
-  facet normal -0.7901 -0 -0.612978
-    outer loop
-      vertex -10.7622 0 13.5058
-      vertex -10.5504 -2.7 13.2328
-      vertex -10.7622 -2.7 13.5058
-    endloop
-  endfacet
-  facet normal -0.891044 0 -0.453917
-    outer loop
-      vertex -10.0235 -2.7 12.3418
-      vertex -10.1803 0 12.6496
-      vertex -10.0235 0 12.3418
-    endloop
-  endfacet
-  facet normal -0.891044 -0 -0.453917
-    outer loop
-      vertex -10.1803 0 12.6496
-      vertex -10.0235 -2.7 12.3418
-      vertex -10.1803 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal 0.9759 0 -0.218217
-    outer loop
-      vertex -20.3272 -2.7 11.3678
-      vertex -20.4026 0 11.0306
-      vertex -20.3272 0 11.3678
-    endloop
-  endfacet
-  facet normal 0.9759 0 -0.218217
-    outer loop
-      vertex -20.4026 0 11.0306
-      vertex -20.3272 -2.7 11.3678
-      vertex -20.4026 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal 0.987714 0 -0.156275
-    outer loop
-      vertex -20.4026 -2.7 11.0306
-      vertex -20.4566 0 10.6893
-      vertex -20.4026 0 11.0306
-    endloop
-  endfacet
-  facet normal 0.987714 0 -0.156275
-    outer loop
-      vertex -20.4566 0 10.6893
-      vertex -20.4026 -2.7 11.0306
-      vertex -20.4566 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0.891044 0 -0.453917
-    outer loop
-      vertex -19.8197 -2.7 12.6496
-      vertex -19.9765 0 12.3418
-      vertex -19.8197 0 12.6496
-    endloop
-  endfacet
-  facet normal 0.891044 0 -0.453917
-    outer loop
-      vertex -19.9765 0 12.3418
-      vertex -19.8197 -2.7 12.6496
-      vertex -19.9765 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal 0.917672 0 -0.397339
-    outer loop
-      vertex -19.9765 -2.7 12.3418
-      vertex -20.1138 0 12.0247
-      vertex -19.9765 0 12.3418
-    endloop
-  endfacet
-  facet normal 0.917672 0 -0.397339
-    outer loop
-      vertex -20.1138 0 12.0247
-      vertex -19.9765 -2.7 12.3418
-      vertex -20.1138 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal 0.999507 -0 0.0314019
-    outer loop
-      vertex 9.5 -2.7 10
-      vertex 9.51085 0 9.65465
-      vertex 9.5 0 10
-    endloop
-  endfacet
-  facet normal 0.999507 0 0.0314019
-    outer loop
-      vertex 9.51085 0 9.65465
-      vertex 9.5 -2.7 10
-      vertex 9.51085 -2.7 9.65465
-    endloop
-  endfacet
-  facet normal 0.995561 -0 0.0941207
-    outer loop
-      vertex 9.51085 -2.7 9.65465
-      vertex 9.54337 0 9.31067
-      vertex 9.51085 0 9.65465
-    endloop
-  endfacet
-  facet normal 0.995561 0 0.0941207
-    outer loop
-      vertex 9.54337 0 9.31067
-      vertex 9.51085 -2.7 9.65465
-      vertex 9.54337 -2.7 9.31067
-    endloop
-  endfacet
-  facet normal 0.707136 -0 0.707078
-    outer loop
-      vertex 10.9907 -2.7 6.23499
-      vertex 11.235 0 5.99067
-      vertex 10.9907 0 6.23499
-    endloop
-  endfacet
-  facet normal 0.707136 0 0.707078
-    outer loop
-      vertex 11.235 0 5.99067
-      vertex 10.9907 -2.7 6.23499
-      vertex 11.235 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal -0.66127 0 0.750148
-    outer loop
-      vertex 18.5058 0 5.76218
-      vertex 18.765 -2.7 5.99067
-      vertex 18.765 0 5.99067
-    endloop
-  endfacet
-  facet normal -0.66127 0 0.750148
-    outer loop
-      vertex 18.765 -2.7 5.99067
-      vertex 18.5058 0 5.76218
-      vertex 18.5058 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal 0.917708 -0 0.397256
-    outer loop
-      vertex 9.88623 -2.7 7.97532
-      vertex 10.0235 0 7.65821
-      vertex 9.88623 0 7.97532
-    endloop
-  endfacet
-  facet normal 0.917708 0 0.397256
-    outer loop
-      vertex 10.0235 0 7.65821
-      vertex 9.88623 -2.7 7.97532
-      vertex 10.0235 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal -0.790111 0 0.612964
-    outer loop
-      vertex 19.2378 -2.7 6.49417
-      vertex 19.4496 0 6.76718
-      vertex 19.2378 0 6.49417
-    endloop
-  endfacet
-  facet normal -0.790111 0 0.612964
-    outer loop
-      vertex 19.4496 0 6.76718
-      vertex 19.2378 -2.7 6.49417
-      vertex 19.4496 -2.7 6.76718
-    endloop
-  endfacet
-  facet normal 0.827093 -0 0.562065
-    outer loop
-      vertex 10.3562 -2.7 7.05295
-      vertex 10.5504 0 6.76718
-      vertex 10.3562 0 7.05295
-    endloop
-  endfacet
-  facet normal 0.827093 0 0.562065
-    outer loop
-      vertex 10.5504 0 6.76718
-      vertex 10.3562 -2.7 7.05295
-      vertex 10.5504 -2.7 6.76718
-    endloop
-  endfacet
-  facet normal 0.860727 -0 0.509068
-    outer loop
-      vertex 10.1803 -2.7 7.35036
-      vertex 10.3562 0 7.05295
-      vertex 10.1803 0 7.35036
-    endloop
-  endfacet
-  facet normal 0.860727 0 0.509068
-    outer loop
-      vertex 10.3562 0 7.05295
-      vertex 10.1803 -2.7 7.35036
-      vertex 10.3562 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal 0.218135 0 0.975919
-    outer loop
-      vertex 13.6322 0 4.67279
-      vertex 13.9694 -2.7 4.59742
-      vertex 13.9694 0 4.59742
-    endloop
-  endfacet
-  facet normal 0.218135 0 0.975919
-    outer loop
-      vertex 13.9694 -2.7 4.59742
-      vertex 13.6322 0 4.67279
-      vertex 13.6322 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal -0.960291 0 0.279
-    outer loop
-      vertex 20.2308 -2.7 8.30041
-      vertex 20.3272 0 8.63221
-      vertex 20.2308 0 8.30041
-    endloop
-  endfacet
-  facet normal -0.960291 0 0.279
-    outer loop
-      vertex 20.3272 0 8.63221
-      vertex 20.2308 -2.7 8.30041
-      vertex 20.3272 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal -0.860727 0 0.509068
-    outer loop
-      vertex 19.6438 -2.7 7.05295
-      vertex 19.8197 0 7.35036
-      vertex 19.6438 0 7.05295
-    endloop
-  endfacet
-  facet normal -0.860727 0 0.509068
-    outer loop
-      vertex 19.8197 0 7.35036
-      vertex 19.6438 -2.7 7.05295
-      vertex 19.8197 -2.7 7.35036
-    endloop
-  endfacet
-  facet normal -0.975899 0 0.218223
-    outer loop
-      vertex 20.3272 -2.7 8.63221
-      vertex 20.4026 0 8.9694
-      vertex 20.3272 0 8.63221
-    endloop
-  endfacet
-  facet normal -0.975899 0 0.218223
-    outer loop
-      vertex 20.4026 0 8.9694
-      vertex 20.3272 -2.7 8.63221
-      vertex 20.4026 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal -0.454055 0 0.890974
-    outer loop
-      vertex 17.3418 0 5.02345
-      vertex 17.6496 -2.7 5.18031
-      vertex 17.6496 0 5.18031
-    endloop
-  endfacet
-  facet normal -0.454055 0 0.890974
-    outer loop
-      vertex 17.6496 -2.7 5.18031
-      vertex 17.3418 0 5.02345
-      vertex 17.3418 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal -0.509059 0 0.860732
-    outer loop
-      vertex 17.6496 0 5.18031
-      vertex 17.947 -2.7 5.3562
-      vertex 17.947 0 5.3562
-    endloop
-  endfacet
-  facet normal -0.509059 0 0.860732
-    outer loop
-      vertex 17.947 -2.7 5.3562
-      vertex 17.6496 0 5.18031
-      vertex 17.6496 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal -0.156416 0 0.987691
-    outer loop
-      vertex 15.6893 0 4.54337
-      vertex 16.0306 -2.7 4.59742
-      vertex 16.0306 0 4.59742
-    endloop
-  endfacet
-  facet normal -0.156416 0 0.987691
-    outer loop
-      vertex 16.0306 -2.7 4.59742
-      vertex 15.6893 0 4.54337
-      vertex 15.6893 -2.7 4.54337
-    endloop
-  endfacet
-  facet normal 0.999507 0 -0.0314065
-    outer loop
-      vertex 9.51085 -2.7 10.3453
-      vertex 9.5 0 10
-      vertex 9.51085 0 10.3453
-    endloop
-  endfacet
-  facet normal 0.999507 0 -0.0314065
-    outer loop
-      vertex 9.5 0 10
-      vertex 9.51085 -2.7 10.3453
-      vertex 9.5 -2.7 10
-    endloop
-  endfacet
-  facet normal -0.9759 0 -0.218217
-    outer loop
-      vertex 20.4026 -2.7 11.0306
-      vertex 20.3272 0 11.3678
-      vertex 20.4026 0 11.0306
-    endloop
-  endfacet
-  facet normal -0.9759 -0 -0.218217
-    outer loop
-      vertex 20.3272 0 11.3678
-      vertex 20.4026 -2.7 11.0306
-      vertex 20.3272 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal 0.397339 0 -0.917672
-    outer loop
-      vertex 12.6582 -2.7 14.9765
-      vertex 12.9753 0 15.1138
-      vertex 12.9753 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal 0.397339 0 -0.917672
-    outer loop
-      vertex 12.9753 0 15.1138
-      vertex 12.6582 -2.7 14.9765
-      vertex 12.6582 0 14.9765
-    endloop
-  endfacet
-  facet normal 0.975917 -0 0.218141
-    outer loop
-      vertex 9.59742 -2.7 8.9694
-      vertex 9.67279 0 8.63221
-      vertex 9.59742 0 8.9694
-    endloop
-  endfacet
-  facet normal 0.975917 0 0.218141
-    outer loop
-      vertex 9.67279 0 8.63221
-      vertex 9.59742 -2.7 8.9694
-      vertex 9.67279 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal 0.987689 -0 0.156429
-    outer loop
-      vertex 9.54337 -2.7 9.31067
-      vertex 9.59742 0 8.9694
-      vertex 9.54337 0 9.31067
-    endloop
-  endfacet
-  facet normal 0.987689 0 0.156429
-    outer loop
-      vertex 9.59742 0 8.9694
-      vertex 9.54337 -2.7 9.31067
-      vertex 9.59742 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal 0.94088 -0 0.338739
-    outer loop
-      vertex 9.76919 -2.7 8.30041
-      vertex 9.88623 0 7.97532
-      vertex 9.76919 0 8.30041
-    endloop
-  endfacet
-  facet normal 0.94088 0 0.338739
-    outer loop
-      vertex 9.88623 0 7.97532
-      vertex 9.76919 -2.7 8.30041
-      vertex 9.88623 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal 0.790111 -0 0.612964
-    outer loop
-      vertex 10.5504 -2.7 6.76718
-      vertex 10.7622 0 6.49417
-      vertex 10.5504 0 6.76718
-    endloop
-  endfacet
-  facet normal 0.790111 0 0.612964
-    outer loop
-      vertex 10.7622 0 6.49417
-      vertex 10.5504 -2.7 6.76718
-      vertex 10.7622 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal 0.0314065 0 0.999507
-    outer loop
-      vertex 14.6547 0 4.51085
-      vertex 15 -2.7 4.5
-      vertex 15 0 4.5
-    endloop
-  endfacet
-  facet normal 0.0314065 0 0.999507
-    outer loop
-      vertex 15 -2.7 4.5
-      vertex 14.6547 0 4.51085
-      vertex 14.6547 -2.7 4.51085
-    endloop
-  endfacet
-  facet normal 0.156416 0 0.987691
-    outer loop
-      vertex 13.9694 0 4.59742
-      vertex 14.3107 -2.7 4.54337
-      vertex 14.3107 0 4.54337
-    endloop
-  endfacet
-  facet normal 0.156416 0 0.987691
-    outer loop
-      vertex 14.3107 -2.7 4.54337
-      vertex 13.9694 0 4.59742
-      vertex 13.9694 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal 0.279 0 0.960291
-    outer loop
-      vertex 13.3004 0 4.76919
-      vertex 13.6322 -2.7 4.67279
-      vertex 13.6322 0 4.67279
-    endloop
-  endfacet
-  facet normal 0.279 0 0.960291
-    outer loop
-      vertex 13.6322 -2.7 4.67279
-      vertex 13.3004 0 4.76919
-      vertex 13.3004 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal 0.397144 0 0.917756
-    outer loop
-      vertex 12.6582 0 5.02345
-      vertex 12.9753 -2.7 4.88623
-      vertex 12.9753 0 4.88623
-    endloop
-  endfacet
-  facet normal 0.397144 0 0.917756
-    outer loop
-      vertex 12.9753 -2.7 4.88623
-      vertex 12.6582 0 5.02345
-      vertex 12.6582 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal 0.509059 0 0.860732
-    outer loop
-      vertex 12.053 0 5.3562
-      vertex 12.3504 -2.7 5.18031
-      vertex 12.3504 0 5.18031
-    endloop
-  endfacet
-  facet normal 0.509059 0 0.860732
-    outer loop
-      vertex 12.3504 -2.7 5.18031
-      vertex 12.053 0 5.3562
-      vertex 12.053 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal 0.66127 0 0.750148
-    outer loop
-      vertex 11.235 0 5.99067
-      vertex 11.4942 -2.7 5.76218
-      vertex 11.4942 0 5.76218
-    endloop
-  endfacet
-  facet normal 0.66127 0 0.750148
-    outer loop
-      vertex 11.4942 -2.7 5.76218
-      vertex 11.235 0 5.99067
-      vertex 11.235 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal -0.999502 0 0.0315465
-    outer loop
-      vertex 20.4891 -2.7 9.65465
-      vertex 20.5 0 10
-      vertex 20.4891 0 9.65465
-    endloop
-  endfacet
-  facet normal -0.999502 0 0.0315465
-    outer loop
-      vertex 20.5 0 10
-      vertex 20.4891 -2.7 9.65465
-      vertex 20.5 -2.7 10
-    endloop
-  endfacet
-  facet normal -0.995566 0 0.0940633
-    outer loop
-      vertex 20.4566 -2.7 9.31067
-      vertex 20.4891 0 9.65465
-      vertex 20.4566 0 9.31067
-    endloop
-  endfacet
-  facet normal -0.995566 0 0.0940633
-    outer loop
-      vertex 20.4891 0 9.65465
-      vertex 20.4566 -2.7 9.31067
-      vertex 20.4891 -2.7 9.65465
-    endloop
-  endfacet
-  facet normal -0.917676 0 0.397329
-    outer loop
-      vertex 19.9765 -2.7 7.65821
-      vertex 20.1138 0 7.97532
-      vertex 19.9765 0 7.65821
-    endloop
-  endfacet
-  facet normal -0.917676 0 0.397329
-    outer loop
-      vertex 20.1138 0 7.97532
-      vertex 19.9765 -2.7 7.65821
-      vertex 20.1138 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.3453 -2.7 15.4891
-      vertex 14.6547 -2.7 15.4891
-      vertex 15 -2.7 15.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.6893 -2.7 15.4566
-      vertex 14.6547 -2.7 15.4891
-      vertex 15.3453 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.6893 -2.7 15.4566
-      vertex 14.3107 -2.7 15.4566
-      vertex 14.6547 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.0306 -2.7 15.4026
-      vertex 14.3107 -2.7 15.4566
-      vertex 15.6893 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.0306 -2.7 15.4026
-      vertex 13.9694 -2.7 15.4026
-      vertex 14.3107 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.3678 -2.7 15.3272
-      vertex 13.9694 -2.7 15.4026
-      vertex 16.0306 -2.7 15.4026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.3678 -2.7 15.3272
-      vertex 13.6322 -2.7 15.3272
-      vertex 13.9694 -2.7 15.4026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.6996 -2.7 15.2308
-      vertex 13.6322 -2.7 15.3272
-      vertex 16.3678 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.6996 -2.7 15.2308
-      vertex 13.3004 -2.7 15.2308
-      vertex 13.6322 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.0247 -2.7 15.1138
-      vertex 13.3004 -2.7 15.2308
-      vertex 16.6996 -2.7 15.2308
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.0247 -2.7 15.1138
-      vertex 12.9753 -2.7 15.1138
-      vertex 13.3004 -2.7 15.2308
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.3418 -2.7 14.9765
-      vertex 12.9753 -2.7 15.1138
-      vertex 17.0247 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.3418 -2.7 14.9765
-      vertex 12.6582 -2.7 14.9765
-      vertex 12.9753 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.6496 -2.7 14.8197
-      vertex 12.6582 -2.7 14.9765
-      vertex 17.3418 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.6496 -2.7 14.8197
-      vertex 12.3504 -2.7 14.8197
-      vertex 12.6582 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.947 -2.7 14.6438
-      vertex 12.3504 -2.7 14.8197
-      vertex 17.6496 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.947 -2.7 14.6438
-      vertex 12.053 -2.7 14.6438
-      vertex 12.3504 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.2328 -2.7 14.4496
-      vertex 12.053 -2.7 14.6438
-      vertex 17.947 -2.7 14.6438
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.2328 -2.7 14.4496
-      vertex 11.7672 -2.7 14.4496
-      vertex 12.053 -2.7 14.6438
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.5058 -2.7 14.2378
-      vertex 11.7672 -2.7 14.4496
-      vertex 18.2328 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.5058 -2.7 14.2378
-      vertex 11.4942 -2.7 14.2378
-      vertex 11.7672 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.765 -2.7 14.0093
-      vertex 11.4942 -2.7 14.2378
-      vertex 18.5058 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.765 -2.7 14.0093
-      vertex 11.235 -2.7 14.0093
-      vertex 11.4942 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.0093 -2.7 13.765
-      vertex 11.235 -2.7 14.0093
-      vertex 18.765 -2.7 14.0093
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.0093 -2.7 13.765
-      vertex 10.9907 -2.7 13.765
-      vertex 11.235 -2.7 14.0093
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.2378 -2.7 13.5058
-      vertex 10.9907 -2.7 13.765
-      vertex 19.0093 -2.7 13.765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.2378 -2.7 13.5058
-      vertex 10.7622 -2.7 13.5058
-      vertex 10.9907 -2.7 13.765
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.4496 -2.7 13.2328
-      vertex 10.7622 -2.7 13.5058
-      vertex 19.2378 -2.7 13.5058
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.4496 -2.7 13.2328
-      vertex 10.5504 -2.7 13.2328
-      vertex 10.7622 -2.7 13.5058
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.6438 -2.7 12.947
-      vertex 10.5504 -2.7 13.2328
-      vertex 19.4496 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.6438 -2.7 12.947
-      vertex 10.3562 -2.7 12.947
-      vertex 10.5504 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.8197 -2.7 12.6496
-      vertex 10.3562 -2.7 12.947
-      vertex 19.6438 -2.7 12.947
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.8197 -2.7 12.6496
-      vertex 10.1803 -2.7 12.6496
-      vertex 10.3562 -2.7 12.947
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.9765 -2.7 12.3418
-      vertex 10.1803 -2.7 12.6496
-      vertex 19.8197 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.9765 -2.7 12.3418
-      vertex 10.0235 -2.7 12.3418
-      vertex 10.1803 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.1138 -2.7 12.0247
-      vertex 10.0235 -2.7 12.3418
-      vertex 19.9765 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.1138 -2.7 12.0247
-      vertex 9.88623 -2.7 12.0247
-      vertex 10.0235 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.2308 -2.7 11.6996
-      vertex 9.88623 -2.7 12.0247
-      vertex 20.1138 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.2308 -2.7 11.6996
-      vertex 9.76919 -2.7 11.6996
-      vertex 9.88623 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.3272 -2.7 11.3678
-      vertex 9.76919 -2.7 11.6996
-      vertex 20.2308 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.3272 -2.7 11.3678
-      vertex 9.67279 -2.7 11.3678
-      vertex 9.76919 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4026 -2.7 11.0306
-      vertex 9.67279 -2.7 11.3678
-      vertex 20.3272 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4026 -2.7 11.0306
-      vertex 9.59742 -2.7 11.0306
-      vertex 9.67279 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4566 -2.7 10.6893
-      vertex 9.59742 -2.7 11.0306
-      vertex 20.4026 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4566 -2.7 10.6893
-      vertex 9.54337 -2.7 10.6893
-      vertex 9.59742 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4891 -2.7 10.3453
-      vertex 9.54337 -2.7 10.6893
-      vertex 20.4566 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4891 -2.7 10.3453
-      vertex 9.51085 -2.7 10.3453
-      vertex 9.54337 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.5 -2.7 10
-      vertex 9.51085 -2.7 10.3453
-      vertex 20.4891 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.5 -2.7 10
-      vertex 9.5 -2.7 10
-      vertex 9.51085 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 20.4891 -2.7 9.65465
-      vertex 9.5 -2.7 10
-      vertex 20.5 -2.7 10
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4891 -2.7 9.65465
-      vertex 9.51085 -2.7 9.65465
-      vertex 9.5 -2.7 10
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 20.4566 -2.7 9.31067
-      vertex 9.51085 -2.7 9.65465
-      vertex 20.4891 -2.7 9.65465
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4566 -2.7 9.31067
-      vertex 9.54337 -2.7 9.31067
-      vertex 9.51085 -2.7 9.65465
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 20.4026 -2.7 8.9694
-      vertex 9.54337 -2.7 9.31067
-      vertex 20.4566 -2.7 9.31067
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.4026 -2.7 8.9694
-      vertex 9.59742 -2.7 8.9694
-      vertex 9.54337 -2.7 9.31067
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 20.3272 -2.7 8.63221
-      vertex 9.59742 -2.7 8.9694
-      vertex 20.4026 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.3272 -2.7 8.63221
-      vertex 9.67279 -2.7 8.63221
-      vertex 9.59742 -2.7 8.9694
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 20.2308 -2.7 8.30041
-      vertex 9.67279 -2.7 8.63221
-      vertex 20.3272 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.2308 -2.7 8.30041
-      vertex 9.76919 -2.7 8.30041
-      vertex 9.67279 -2.7 8.63221
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 20.1138 -2.7 7.97532
-      vertex 9.76919 -2.7 8.30041
-      vertex 20.2308 -2.7 8.30041
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 20.1138 -2.7 7.97532
-      vertex 9.88623 -2.7 7.97532
-      vertex 9.76919 -2.7 8.30041
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 19.9765 -2.7 7.65821
-      vertex 9.88623 -2.7 7.97532
-      vertex 20.1138 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.9765 -2.7 7.65821
-      vertex 10.0235 -2.7 7.65821
-      vertex 9.88623 -2.7 7.97532
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 19.8197 -2.7 7.35036
-      vertex 10.0235 -2.7 7.65821
-      vertex 19.9765 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.8197 -2.7 7.35036
-      vertex 10.1803 -2.7 7.35036
-      vertex 10.0235 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 19.6438 -2.7 7.05295
-      vertex 10.1803 -2.7 7.35036
-      vertex 19.8197 -2.7 7.35036
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.6438 -2.7 7.05295
-      vertex 10.3562 -2.7 7.05295
-      vertex 10.1803 -2.7 7.35036
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 19.4496 -2.7 6.76718
-      vertex 10.3562 -2.7 7.05295
-      vertex 19.6438 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.4496 -2.7 6.76718
-      vertex 10.5504 -2.7 6.76718
-      vertex 10.3562 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 19.2378 -2.7 6.49417
-      vertex 10.5504 -2.7 6.76718
-      vertex 19.4496 -2.7 6.76718
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.2378 -2.7 6.49417
-      vertex 10.7622 -2.7 6.49417
-      vertex 10.5504 -2.7 6.76718
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 19.0093 -2.7 6.23499
-      vertex 10.7622 -2.7 6.49417
-      vertex 19.2378 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 19.0093 -2.7 6.23499
-      vertex 10.9907 -2.7 6.23499
-      vertex 10.7622 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 18.765 -2.7 5.99067
-      vertex 10.9907 -2.7 6.23499
-      vertex 19.0093 -2.7 6.23499
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.765 -2.7 5.99067
-      vertex 11.235 -2.7 5.99067
-      vertex 10.9907 -2.7 6.23499
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 18.5058 -2.7 5.76218
-      vertex 11.235 -2.7 5.99067
-      vertex 18.765 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.5058 -2.7 5.76218
-      vertex 11.4942 -2.7 5.76218
-      vertex 11.235 -2.7 5.99067
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 18.2328 -2.7 5.55041
-      vertex 11.4942 -2.7 5.76218
-      vertex 18.5058 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 18.2328 -2.7 5.55041
-      vertex 11.7672 -2.7 5.55041
-      vertex 11.4942 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 17.947 -2.7 5.3562
-      vertex 11.7672 -2.7 5.55041
-      vertex 18.2328 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.947 -2.7 5.3562
-      vertex 12.053 -2.7 5.3562
-      vertex 11.7672 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 17.6496 -2.7 5.18031
-      vertex 12.053 -2.7 5.3562
-      vertex 17.947 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.6496 -2.7 5.18031
-      vertex 12.3504 -2.7 5.18031
-      vertex 12.053 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 17.3418 -2.7 5.02345
-      vertex 12.3504 -2.7 5.18031
-      vertex 17.6496 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.3418 -2.7 5.02345
-      vertex 12.6582 -2.7 5.02345
-      vertex 12.3504 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 17.0247 -2.7 4.88623
-      vertex 12.6582 -2.7 5.02345
-      vertex 17.3418 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.0247 -2.7 4.88623
-      vertex 12.9753 -2.7 4.88623
-      vertex 12.6582 -2.7 5.02345
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 16.6996 -2.7 4.76919
-      vertex 12.9753 -2.7 4.88623
-      vertex 17.0247 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.6996 -2.7 4.76919
-      vertex 13.3004 -2.7 4.76919
-      vertex 12.9753 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 16.3678 -2.7 4.67279
-      vertex 13.3004 -2.7 4.76919
-      vertex 16.6996 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.3678 -2.7 4.67279
-      vertex 13.6322 -2.7 4.67279
-      vertex 13.3004 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 16.0306 -2.7 4.59742
-      vertex 13.6322 -2.7 4.67279
-      vertex 16.3678 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.0306 -2.7 4.59742
-      vertex 13.9694 -2.7 4.59742
-      vertex 13.6322 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 15.6893 -2.7 4.54337
-      vertex 13.9694 -2.7 4.59742
-      vertex 16.0306 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.6893 -2.7 4.54337
-      vertex 14.3107 -2.7 4.54337
-      vertex 13.9694 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 15.3453 -2.7 4.51085
-      vertex 14.3107 -2.7 4.54337
-      vertex 15.6893 -2.7 4.54337
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.3453 -2.7 4.51085
-      vertex 14.6547 -2.7 4.51085
-      vertex 14.3107 -2.7 4.54337
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex 14.6547 -2.7 4.51085
-      vertex 15.3453 -2.7 4.51085
-      vertex 15 -2.7 4.5
-    endloop
-  endfacet
-  facet normal -0.987712 0 0.156288
-    outer loop
-      vertex 20.4026 -2.7 8.9694
-      vertex 20.4566 0 9.31067
-      vertex 20.4026 0 8.9694
-    endloop
-  endfacet
-  facet normal -0.987712 0 0.156288
-    outer loop
-      vertex 20.4566 0 9.31067
-      vertex 20.4026 -2.7 8.9694
-      vertex 20.4566 -2.7 9.31067
-    endloop
-  endfacet
-  facet normal -0.612924 0 0.790142
-    outer loop
-      vertex 18.2328 0 5.55041
-      vertex 18.5058 -2.7 5.76218
-      vertex 18.5058 0 5.76218
-    endloop
-  endfacet
-  facet normal -0.612924 0 0.790142
-    outer loop
-      vertex 18.5058 -2.7 5.76218
-      vertex 18.2328 0 5.55041
-      vertex 18.2328 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal -0.33873 0 0.940884
-    outer loop
-      vertex 16.6996 0 4.76919
-      vertex 17.0247 -2.7 4.88623
-      vertex 17.0247 0 4.88623
-    endloop
-  endfacet
-  facet normal -0.33873 0 0.940884
-    outer loop
-      vertex 17.0247 -2.7 4.88623
-      vertex 16.6996 0 4.76919
-      vertex 16.6996 -2.7 4.76919
-    endloop
-  endfacet
-  facet normal -0.218135 0 0.975919
-    outer loop
-      vertex 16.0306 0 4.59742
-      vertex 16.3678 -2.7 4.67279
-      vertex 16.3678 0 4.67279
-    endloop
-  endfacet
-  facet normal -0.218135 0 0.975919
-    outer loop
-      vertex 16.3678 -2.7 4.67279
-      vertex 16.0306 0 4.59742
-      vertex 16.0306 -2.7 4.59742
-    endloop
-  endfacet
-  facet normal -0.0941153 0 0.995561
-    outer loop
-      vertex 15.3453 0 4.51085
-      vertex 15.6893 -2.7 4.54337
-      vertex 15.6893 0 4.54337
-    endloop
-  endfacet
-  facet normal -0.0941153 0 0.995561
-    outer loop
-      vertex 15.6893 -2.7 4.54337
-      vertex 15.3453 0 4.51085
-      vertex 15.3453 -2.7 4.51085
-    endloop
-  endfacet
-  facet normal 0.940884 0 -0.33873
-    outer loop
-      vertex 9.88623 -2.7 12.0247
-      vertex 9.76919 0 11.6996
-      vertex 9.88623 0 12.0247
-    endloop
-  endfacet
-  facet normal 0.940884 0 -0.33873
-    outer loop
-      vertex 9.76919 0 11.6996
-      vertex 9.88623 -2.7 12.0247
-      vertex 9.76919 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal 0.707107 0 -0.707107
-    outer loop
-      vertex 11.235 -2.7 14.0093
-      vertex 10.9907 0 13.765
-      vertex 11.235 0 14.0093
-    endloop
-  endfacet
-  facet normal 0.707107 0 -0.707107
-    outer loop
-      vertex 10.9907 0 13.765
-      vertex 11.235 -2.7 14.0093
-      vertex 10.9907 -2.7 13.765
-    endloop
-  endfacet
-  facet normal 0.562025 0 -0.82712
-    outer loop
-      vertex 11.7672 -2.7 14.4496
-      vertex 12.053 0 14.6438
-      vertex 12.053 -2.7 14.6438
-    endloop
-  endfacet
-  facet normal 0.562025 0 -0.82712
-    outer loop
-      vertex 12.053 0 14.6438
-      vertex 11.7672 -2.7 14.4496
-      vertex 11.7672 0 14.4496
-    endloop
-  endfacet
-  facet normal 0.7901 0 -0.612978
-    outer loop
-      vertex 10.7622 -2.7 13.5058
-      vertex 10.5504 0 13.2328
-      vertex 10.7622 0 13.5058
-    endloop
-  endfacet
-  facet normal 0.7901 0 -0.612978
-    outer loop
-      vertex 10.5504 0 13.2328
-      vertex 10.7622 -2.7 13.5058
-      vertex 10.5504 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal -0.707107 0 -0.707107
-    outer loop
-      vertex 19.0093 -2.7 13.765
-      vertex 18.765 0 14.0093
-      vertex 19.0093 0 13.765
-    endloop
-  endfacet
-  facet normal -0.707107 -0 -0.707107
-    outer loop
-      vertex 18.765 0 14.0093
-      vertex 19.0093 -2.7 13.765
-      vertex 18.765 -2.7 14.0093
-    endloop
-  endfacet
-  facet normal -0.995567 0 -0.0940579
-    outer loop
-      vertex 20.4891 -2.7 10.3453
-      vertex 20.4566 0 10.6893
-      vertex 20.4891 0 10.3453
-    endloop
-  endfacet
-  facet normal -0.995567 -0 -0.0940579
-    outer loop
-      vertex 20.4566 0 10.6893
-      vertex 20.4891 -2.7 10.3453
-      vertex 20.4566 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0.031551 0 -0.999502
-    outer loop
-      vertex 14.6547 -2.7 15.4891
-      vertex 15 0 15.5
-      vertex 15 -2.7 15.5
-    endloop
-  endfacet
-  facet normal 0.031551 0 -0.999502
-    outer loop
-      vertex 15 0 15.5
-      vertex 14.6547 -2.7 15.4891
-      vertex 14.6547 0 15.4891
-    endloop
-  endfacet
-  facet normal 0.0940579 0 -0.995567
-    outer loop
-      vertex 14.3107 -2.7 15.4566
-      vertex 14.6547 0 15.4891
-      vertex 14.6547 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal 0.0940579 0 -0.995567
-    outer loop
-      vertex 14.6547 0 15.4891
-      vertex 14.3107 -2.7 15.4566
-      vertex 14.3107 0 15.4566
-    endloop
-  endfacet
-  facet normal 0.338627 0 -0.940921
-    outer loop
-      vertex 12.9753 -2.7 15.1138
-      vertex 13.3004 0 15.2308
-      vertex 13.3004 -2.7 15.2308
-    endloop
-  endfacet
-  facet normal 0.338627 0 -0.940921
-    outer loop
-      vertex 13.3004 0 15.2308
-      vertex 12.9753 -2.7 15.1138
-      vertex 12.9753 0 15.1138
+      vertex -13.6582 -2.7 5.02345
+      vertex -13.9753 0 4.88623
+      vertex -13.9753 -2.7 4.88623
     endloop
   endfacet
   facet normal 0.218217 0 -0.9759
     outer loop
-      vertex 13.6322 -2.7 15.3272
-      vertex 13.9694 0 15.4026
-      vertex 13.9694 -2.7 15.4026
+      vertex -17.3678 -2.7 15.3272
+      vertex -17.0306 0 15.4026
+      vertex -17.0306 -2.7 15.4026
     endloop
   endfacet
   facet normal 0.218217 0 -0.9759
     outer loop
-      vertex 13.9694 0 15.4026
-      vertex 13.6322 -2.7 15.3272
-      vertex 13.6322 0 15.3272
+      vertex -17.0306 0 15.4026
+      vertex -17.3678 -2.7 15.3272
+      vertex -17.3678 0 15.3272
     endloop
   endfacet
-  facet normal 0.156275 0 -0.987714
+  facet normal -0.338627 0 -0.940921
     outer loop
-      vertex 13.9694 -2.7 15.4026
-      vertex 14.3107 0 15.4566
-      vertex 14.3107 -2.7 15.4566
+      vertex -14.3004 -2.7 15.2308
+      vertex -13.9753 0 15.1138
+      vertex -13.9753 -2.7 15.1138
     endloop
   endfacet
-  facet normal 0.156275 0 -0.987714
+  facet normal -0.338627 0 -0.940921
     outer loop
-      vertex 14.3107 0 15.4566
-      vertex 13.9694 -2.7 15.4026
-      vertex 13.9694 0 15.4026
+      vertex -13.9753 0 15.1138
+      vertex -14.3004 -2.7 15.2308
+      vertex -14.3004 0 15.2308
     endloop
   endfacet
-  facet normal 0.960291 -0 0.279
+  facet normal -0.33873 0 0.940884
     outer loop
-      vertex 9.67279 -2.7 8.63221
-      vertex 9.76919 0 8.30041
-      vertex 9.67279 0 8.63221
+      vertex -14.3004 0 4.76919
+      vertex -13.9753 -2.7 4.88623
+      vertex -13.9753 0 4.88623
     endloop
   endfacet
-  facet normal 0.960291 0 0.279
+  facet normal -0.33873 0 0.940884
     outer loop
-      vertex 9.76919 0 8.30041
-      vertex 9.67279 -2.7 8.63221
-      vertex 9.76919 -2.7 8.30041
+      vertex -13.9753 -2.7 4.88623
+      vertex -14.3004 0 4.76919
+      vertex -14.3004 -2.7 4.76919
     endloop
   endfacet
   facet normal 0.750108 -0 0.661315
     outer loop
-      vertex 10.7622 -2.7 6.49417
-      vertex 10.9907 0 6.23499
-      vertex 10.7622 0 6.49417
+      vertex -20.2378 -2.7 6.49417
+      vertex -20.0093 0 6.23499
+      vertex -20.2378 0 6.49417
     endloop
   endfacet
   facet normal 0.750108 0 0.661315
     outer loop
-      vertex 10.9907 0 6.23499
-      vertex 10.7622 -2.7 6.49417
-      vertex 10.9907 -2.7 6.23499
+      vertex -20.0093 0 6.23499
+      vertex -20.2378 -2.7 6.49417
+      vertex -20.0093 -2.7 6.23499
     endloop
   endfacet
-  facet normal 0.891074 -0 0.453859
+  facet normal 0.975899 -0 0.218223
     outer loop
-      vertex 10.0235 -2.7 7.65821
-      vertex 10.1803 0 7.35036
-      vertex 10.0235 0 7.65821
+      vertex -21.4026 -2.7 8.9694
+      vertex -21.3272 0 8.63221
+      vertex -21.4026 0 8.9694
     endloop
   endfacet
-  facet normal 0.891074 0 0.453859
+  facet normal 0.975899 0 0.218223
     outer loop
-      vertex 10.1803 0 7.35036
-      vertex 10.0235 -2.7 7.65821
-      vertex 10.1803 -2.7 7.35036
+      vertex -21.3272 0 8.63221
+      vertex -21.4026 -2.7 8.9694
+      vertex -21.3272 -2.7 8.63221
     endloop
   endfacet
-  facet normal 0.0941153 0 0.995561
+  facet normal 0.218135 0 0.975919
     outer loop
-      vertex 14.3107 0 4.54337
-      vertex 14.6547 -2.7 4.51085
-      vertex 14.6547 0 4.51085
+      vertex -17.3678 0 4.67279
+      vertex -17.0306 -2.7 4.59742
+      vertex -17.0306 0 4.59742
     endloop
   endfacet
-  facet normal 0.0941153 0 0.995561
+  facet normal 0.218135 0 0.975919
     outer loop
-      vertex 14.6547 -2.7 4.51085
-      vertex 14.3107 0 4.54337
-      vertex 14.3107 -2.7 4.54337
+      vertex -17.0306 -2.7 4.59742
+      vertex -17.3678 0 4.67279
+      vertex -17.3678 -2.7 4.67279
     endloop
   endfacet
-  facet normal 0.33873 0 0.940884
+  facet normal 0.917672 0 -0.397339
     outer loop
-      vertex 12.9753 0 4.88623
-      vertex 13.3004 -2.7 4.76919
-      vertex 13.3004 0 4.76919
+      vertex -20.9765 -2.7 12.3418
+      vertex -21.1138 0 12.0247
+      vertex -20.9765 0 12.3418
     endloop
   endfacet
-  facet normal 0.33873 0 0.940884
+  facet normal 0.917672 0 -0.397339
     outer loop
-      vertex 13.3004 -2.7 4.76919
-      vertex 12.9753 0 4.88623
-      vertex 12.9753 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal 0.454055 0 0.890974
-    outer loop
-      vertex 12.3504 0 5.18031
-      vertex 12.6582 -2.7 5.02345
-      vertex 12.6582 0 5.02345
-    endloop
-  endfacet
-  facet normal 0.454055 0 0.890974
-    outer loop
-      vertex 12.6582 -2.7 5.02345
-      vertex 12.3504 0 5.18031
-      vertex 12.3504 -2.7 5.18031
-    endloop
-  endfacet
-  facet normal 0.612924 0 0.790142
-    outer loop
-      vertex 11.4942 0 5.76218
-      vertex 11.7672 -2.7 5.55041
-      vertex 11.7672 0 5.55041
-    endloop
-  endfacet
-  facet normal 0.612924 0 0.790142
-    outer loop
-      vertex 11.7672 -2.7 5.55041
-      vertex 11.4942 0 5.76218
-      vertex 11.4942 -2.7 5.76218
-    endloop
-  endfacet
-  facet normal 0.562045 0 0.827107
-    outer loop
-      vertex 11.7672 0 5.55041
-      vertex 12.053 -2.7 5.3562
-      vertex 12.053 0 5.3562
-    endloop
-  endfacet
-  facet normal 0.562045 0 0.827107
-    outer loop
-      vertex 12.053 -2.7 5.3562
-      vertex 11.7672 0 5.55041
-      vertex 11.7672 -2.7 5.55041
-    endloop
-  endfacet
-  facet normal -0.707136 0 0.707078
-    outer loop
-      vertex 18.765 -2.7 5.99067
-      vertex 19.0093 0 6.23499
-      vertex 18.765 0 5.99067
-    endloop
-  endfacet
-  facet normal -0.707136 0 0.707078
-    outer loop
-      vertex 19.0093 0 6.23499
-      vertex 18.765 -2.7 5.99067
-      vertex 19.0093 -2.7 6.23499
-    endloop
-  endfacet
-  facet normal -0.750108 0 0.661315
-    outer loop
-      vertex 19.0093 -2.7 6.23499
-      vertex 19.2378 0 6.49417
-      vertex 19.0093 0 6.23499
-    endloop
-  endfacet
-  facet normal -0.750108 0 0.661315
-    outer loop
-      vertex 19.2378 0 6.49417
-      vertex 19.0093 -2.7 6.23499
-      vertex 19.2378 -2.7 6.49417
-    endloop
-  endfacet
-  facet normal -0.891074 0 0.453859
-    outer loop
-      vertex 19.8197 -2.7 7.35036
-      vertex 19.9765 0 7.65821
-      vertex 19.8197 0 7.35036
-    endloop
-  endfacet
-  facet normal -0.891074 0 0.453859
-    outer loop
-      vertex 19.9765 0 7.65821
-      vertex 19.8197 -2.7 7.35036
-      vertex 19.9765 -2.7 7.65821
-    endloop
-  endfacet
-  facet normal -0.827093 0 0.562065
-    outer loop
-      vertex 19.4496 -2.7 6.76718
-      vertex 19.6438 0 7.05295
-      vertex 19.4496 0 6.76718
-    endloop
-  endfacet
-  facet normal -0.827093 0 0.562065
-    outer loop
-      vertex 19.6438 0 7.05295
-      vertex 19.4496 -2.7 6.76718
-      vertex 19.6438 -2.7 7.05295
-    endloop
-  endfacet
-  facet normal -0.940917 0 0.338636
-    outer loop
-      vertex 20.1138 -2.7 7.97532
-      vertex 20.2308 0 8.30041
-      vertex 20.1138 0 7.97532
-    endloop
-  endfacet
-  facet normal -0.940917 0 0.338636
-    outer loop
-      vertex 20.2308 0 8.30041
-      vertex 20.1138 -2.7 7.97532
-      vertex 20.2308 -2.7 8.30041
-    endloop
-  endfacet
-  facet normal -0.397144 0 0.917756
-    outer loop
-      vertex 17.0247 0 4.88623
-      vertex 17.3418 -2.7 5.02345
-      vertex 17.3418 0 5.02345
-    endloop
-  endfacet
-  facet normal -0.397144 0 0.917756
-    outer loop
-      vertex 17.3418 -2.7 5.02345
-      vertex 17.0247 0 4.88623
-      vertex 17.0247 -2.7 4.88623
-    endloop
-  endfacet
-  facet normal -0.562045 0 0.827107
-    outer loop
-      vertex 17.947 0 5.3562
-      vertex 18.2328 -2.7 5.55041
-      vertex 18.2328 0 5.55041
-    endloop
-  endfacet
-  facet normal -0.562045 0 0.827107
-    outer loop
-      vertex 18.2328 -2.7 5.55041
-      vertex 17.947 0 5.3562
-      vertex 17.947 -2.7 5.3562
-    endloop
-  endfacet
-  facet normal -0.279 0 0.960291
-    outer loop
-      vertex 16.3678 0 4.67279
-      vertex 16.6996 -2.7 4.76919
-      vertex 16.6996 0 4.76919
-    endloop
-  endfacet
-  facet normal -0.279 0 0.960291
-    outer loop
-      vertex 16.6996 -2.7 4.76919
-      vertex 16.3678 0 4.67279
-      vertex 16.3678 -2.7 4.67279
-    endloop
-  endfacet
-  facet normal -0.0314065 0 0.999507
-    outer loop
-      vertex 15 0 4.5
-      vertex 15.3453 -2.7 4.51085
-      vertex 15.3453 0 4.51085
-    endloop
-  endfacet
-  facet normal -0.0314065 0 0.999507
-    outer loop
-      vertex 15.3453 -2.7 4.51085
-      vertex 15 0 4.5
-      vertex 15 -2.7 4.5
+      vertex -21.1138 0 12.0247
+      vertex -20.9765 -2.7 12.3418
+      vertex -21.1138 -2.7 12.0247
     endloop
   endfacet
   facet normal 0.891044 0 -0.453917
     outer loop
-      vertex 10.1803 -2.7 12.6496
-      vertex 10.0235 0 12.3418
-      vertex 10.1803 0 12.6496
+      vertex -20.8197 -2.7 12.6496
+      vertex -20.9765 0 12.3418
+      vertex -20.8197 0 12.6496
     endloop
   endfacet
   facet normal 0.891044 0 -0.453917
     outer loop
-      vertex 10.0235 0 12.3418
-      vertex 10.1803 -2.7 12.6496
-      vertex 10.0235 -2.7 12.3418
-    endloop
-  endfacet
-  facet normal 0.960291 0 -0.279
-    outer loop
-      vertex 9.76919 -2.7 11.6996
-      vertex 9.67279 0 11.3678
-      vertex 9.76919 0 11.6996
-    endloop
-  endfacet
-  facet normal 0.960291 0 -0.279
-    outer loop
-      vertex 9.67279 0 11.3678
-      vertex 9.76919 -2.7 11.6996
-      vertex 9.67279 -2.7 11.3678
-    endloop
-  endfacet
-  facet normal 0.995561 0 -0.0941153
-    outer loop
-      vertex 9.54337 -2.7 10.6893
-      vertex 9.51085 0 10.3453
-      vertex 9.54337 0 10.6893
-    endloop
-  endfacet
-  facet normal 0.995561 0 -0.0941153
-    outer loop
-      vertex 9.51085 0 10.3453
-      vertex 9.54337 -2.7 10.6893
-      vertex 9.51085 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal 0.750133 0 -0.661287
-    outer loop
-      vertex 10.9907 -2.7 13.765
-      vertex 10.7622 0 13.5058
-      vertex 10.9907 0 13.765
-    endloop
-  endfacet
-  facet normal 0.750133 0 -0.661287
-    outer loop
-      vertex 10.7622 0 13.5058
-      vertex 10.9907 -2.7 13.765
-      vertex 10.7622 -2.7 13.5058
-    endloop
-  endfacet
-  facet normal 0.453917 0 -0.891044
-    outer loop
-      vertex 12.3504 -2.7 14.8197
-      vertex 12.6582 0 14.9765
-      vertex 12.6582 -2.7 14.9765
-    endloop
-  endfacet
-  facet normal 0.453917 0 -0.891044
-    outer loop
-      vertex 12.6582 0 14.9765
-      vertex 12.3504 -2.7 14.8197
-      vertex 12.3504 0 14.8197
-    endloop
-  endfacet
-  facet normal 0.661287 0 -0.750133
-    outer loop
-      vertex 11.235 -2.7 14.0093
-      vertex 11.4942 0 14.2378
-      vertex 11.4942 -2.7 14.2378
-    endloop
-  endfacet
-  facet normal 0.661287 0 -0.750133
-    outer loop
-      vertex 11.4942 0 14.2378
-      vertex 11.235 -2.7 14.0093
-      vertex 11.235 0 14.0093
-    endloop
-  endfacet
-  facet normal 0.860719 0 -0.50908
-    outer loop
-      vertex 10.3562 -2.7 12.947
-      vertex 10.1803 0 12.6496
-      vertex 10.3562 0 12.947
-    endloop
-  endfacet
-  facet normal 0.860719 0 -0.50908
-    outer loop
-      vertex 10.1803 0 12.6496
-      vertex 10.3562 -2.7 12.947
-      vertex 10.1803 -2.7 12.6496
-    endloop
-  endfacet
-  facet normal -0.940921 0 -0.338627
-    outer loop
-      vertex 20.2308 -2.7 11.6996
-      vertex 20.1138 0 12.0247
-      vertex 20.2308 0 11.6996
-    endloop
-  endfacet
-  facet normal -0.940921 -0 -0.338627
-    outer loop
-      vertex 20.1138 0 12.0247
-      vertex 20.2308 -2.7 11.6996
-      vertex 20.1138 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal -0.999502 0 -0.031551
-    outer loop
-      vertex 20.5 -2.7 10
-      vertex 20.4891 0 10.3453
-      vertex 20.5 0 10
-    endloop
-  endfacet
-  facet normal -0.999502 -0 -0.031551
-    outer loop
-      vertex 20.4891 0 10.3453
-      vertex 20.5 -2.7 10
-      vertex 20.4891 -2.7 10.3453
-    endloop
-  endfacet
-  facet normal -0.987714 0 -0.156275
-    outer loop
-      vertex 20.4566 -2.7 10.6893
-      vertex 20.4026 0 11.0306
-      vertex 20.4566 0 10.6893
-    endloop
-  endfacet
-  facet normal -0.987714 -0 -0.156275
-    outer loop
-      vertex 20.4026 0 11.0306
-      vertex 20.4566 -2.7 10.6893
-      vertex 20.4026 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal -0.960291 0 -0.279
-    outer loop
-      vertex 20.3272 -2.7 11.3678
-      vertex 20.2308 0 11.6996
-      vertex 20.3272 0 11.3678
-    endloop
-  endfacet
-  facet normal -0.960291 -0 -0.279
-    outer loop
-      vertex 20.2308 0 11.6996
-      vertex 20.3272 -2.7 11.3678
-      vertex 20.2308 -2.7 11.6996
-    endloop
-  endfacet
-  facet normal 0.279 0 -0.960291
-    outer loop
-      vertex 13.3004 -2.7 15.2308
-      vertex 13.6322 0 15.3272
-      vertex 13.6322 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal 0.279 0 -0.960291
-    outer loop
-      vertex 13.6322 0 15.3272
-      vertex 13.3004 -2.7 15.2308
-      vertex 13.3004 0 15.2308
-    endloop
-  endfacet
-  facet normal 0.917703 0 -0.397266
-    outer loop
-      vertex 10.0235 -2.7 12.3418
-      vertex 9.88623 0 12.0247
-      vertex 10.0235 0 12.3418
-    endloop
-  endfacet
-  facet normal 0.917703 0 -0.397266
-    outer loop
-      vertex 9.88623 0 12.0247
-      vertex 10.0235 -2.7 12.3418
-      vertex 9.88623 -2.7 12.0247
-    endloop
-  endfacet
-  facet normal 0.975919 0 -0.218135
-    outer loop
-      vertex 9.67279 -2.7 11.3678
-      vertex 9.59742 0 11.0306
-      vertex 9.67279 0 11.3678
-    endloop
-  endfacet
-  facet normal 0.975919 0 -0.218135
-    outer loop
-      vertex 9.59742 0 11.0306
-      vertex 9.67279 -2.7 11.3678
-      vertex 9.59742 -2.7 11.0306
-    endloop
-  endfacet
-  facet normal 0.987691 0 -0.156416
-    outer loop
-      vertex 9.59742 -2.7 11.0306
-      vertex 9.54337 0 10.6893
-      vertex 9.59742 0 11.0306
-    endloop
-  endfacet
-  facet normal 0.987691 0 -0.156416
-    outer loop
-      vertex 9.54337 0 10.6893
-      vertex 9.59742 -2.7 11.0306
-      vertex 9.54337 -2.7 10.6893
-    endloop
-  endfacet
-  facet normal 0.50908 0 -0.860719
-    outer loop
-      vertex 12.053 -2.7 14.6438
-      vertex 12.3504 0 14.8197
-      vertex 12.3504 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal 0.50908 0 -0.860719
-    outer loop
-      vertex 12.3504 0 14.8197
-      vertex 12.053 -2.7 14.6438
-      vertex 12.053 0 14.6438
-    endloop
-  endfacet
-  facet normal 0.612978 0 -0.7901
-    outer loop
-      vertex 11.4942 -2.7 14.2378
-      vertex 11.7672 0 14.4496
-      vertex 11.7672 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal 0.612978 0 -0.7901
-    outer loop
-      vertex 11.7672 0 14.4496
-      vertex 11.4942 -2.7 14.2378
-      vertex 11.4942 0 14.2378
-    endloop
-  endfacet
-  facet normal 0.82712 0 -0.562025
-    outer loop
-      vertex 10.5504 -2.7 13.2328
-      vertex 10.3562 0 12.947
-      vertex 10.5504 0 13.2328
-    endloop
-  endfacet
-  facet normal 0.82712 0 -0.562025
-    outer loop
-      vertex 10.3562 0 12.947
-      vertex 10.5504 -2.7 13.2328
-      vertex 10.3562 -2.7 12.947
-    endloop
-  endfacet
-  facet normal -0.156275 0 -0.987714
-    outer loop
-      vertex 15.6893 -2.7 15.4566
-      vertex 16.0306 0 15.4026
-      vertex 16.0306 -2.7 15.4026
-    endloop
-  endfacet
-  facet normal -0.156275 0 -0.987714
-    outer loop
-      vertex 16.0306 0 15.4026
-      vertex 15.6893 -2.7 15.4566
-      vertex 15.6893 0 15.4566
-    endloop
-  endfacet
-  facet normal -0.338627 0 -0.940921
-    outer loop
-      vertex 16.6996 -2.7 15.2308
-      vertex 17.0247 0 15.1138
-      vertex 17.0247 -2.7 15.1138
-    endloop
-  endfacet
-  facet normal -0.338627 0 -0.940921
-    outer loop
-      vertex 17.0247 0 15.1138
-      vertex 16.6996 -2.7 15.2308
-      vertex 16.6996 0 15.2308
-    endloop
-  endfacet
-  facet normal -0.218217 0 -0.9759
-    outer loop
-      vertex 16.0306 -2.7 15.4026
-      vertex 16.3678 0 15.3272
-      vertex 16.3678 -2.7 15.3272
-    endloop
-  endfacet
-  facet normal -0.218217 0 -0.9759
-    outer loop
-      vertex 16.3678 0 15.3272
-      vertex 16.0306 -2.7 15.4026
-      vertex 16.0306 0 15.4026
-    endloop
-  endfacet
-  facet normal -0.562025 0 -0.82712
-    outer loop
-      vertex 17.947 -2.7 14.6438
-      vertex 18.2328 0 14.4496
-      vertex 18.2328 -2.7 14.4496
-    endloop
-  endfacet
-  facet normal -0.562025 0 -0.82712
-    outer loop
-      vertex 18.2328 0 14.4496
-      vertex 17.947 -2.7 14.6438
-      vertex 17.947 0 14.6438
-    endloop
-  endfacet
-  facet normal -0.82712 0 -0.562025
-    outer loop
-      vertex 19.6438 -2.7 12.947
-      vertex 19.4496 0 13.2328
-      vertex 19.6438 0 12.947
-    endloop
-  endfacet
-  facet normal -0.82712 -0 -0.562025
-    outer loop
-      vertex 19.4496 0 13.2328
-      vertex 19.6438 -2.7 12.947
-      vertex 19.4496 -2.7 13.2328
-    endloop
-  endfacet
-  facet normal -0.860719 0 -0.50908
-    outer loop
-      vertex 19.8197 -2.7 12.6496
-      vertex 19.6438 0 12.947
-      vertex 19.8197 0 12.6496
-    endloop
-  endfacet
-  facet normal -0.860719 -0 -0.50908
-    outer loop
-      vertex 19.6438 0 12.947
-      vertex 19.8197 -2.7 12.6496
-      vertex 19.6438 -2.7 12.947
-    endloop
-  endfacet
-  facet normal -0.0940579 0 -0.995567
-    outer loop
-      vertex 15.3453 -2.7 15.4891
-      vertex 15.6893 0 15.4566
-      vertex 15.6893 -2.7 15.4566
-    endloop
-  endfacet
-  facet normal -0.0940579 0 -0.995567
-    outer loop
-      vertex 15.6893 0 15.4566
-      vertex 15.3453 -2.7 15.4891
-      vertex 15.3453 0 15.4891
-    endloop
-  endfacet
-  facet normal -0.031551 0 -0.999502
-    outer loop
-      vertex 15 -2.7 15.5
-      vertex 15.3453 0 15.4891
-      vertex 15.3453 -2.7 15.4891
-    endloop
-  endfacet
-  facet normal -0.031551 0 -0.999502
-    outer loop
-      vertex 15.3453 0 15.4891
-      vertex 15 -2.7 15.5
-      vertex 15 0 15.5
-    endloop
-  endfacet
-  facet normal -0.279 0 -0.960291
-    outer loop
-      vertex 16.3678 -2.7 15.3272
-      vertex 16.6996 0 15.2308
-      vertex 16.6996 -2.7 15.2308
-    endloop
-  endfacet
-  facet normal -0.279 0 -0.960291
-    outer loop
-      vertex 16.6996 0 15.2308
-      vertex 16.3678 -2.7 15.3272
-      vertex 16.3678 0 15.3272
-    endloop
-  endfacet
-  facet normal -0.661287 0 -0.750133
-    outer loop
-      vertex 18.5058 -2.7 14.2378
-      vertex 18.765 0 14.0093
-      vertex 18.765 -2.7 14.0093
-    endloop
-  endfacet
-  facet normal -0.661287 0 -0.750133
-    outer loop
-      vertex 18.765 0 14.0093
-      vertex 18.5058 -2.7 14.2378
-      vertex 18.5058 0 14.2378
-    endloop
-  endfacet
-  facet normal -0.453917 0 -0.891044
-    outer loop
-      vertex 17.3418 -2.7 14.9765
-      vertex 17.6496 0 14.8197
-      vertex 17.6496 -2.7 14.8197
-    endloop
-  endfacet
-  facet normal -0.453917 0 -0.891044
-    outer loop
-      vertex 17.6496 0 14.8197
-      vertex 17.3418 -2.7 14.9765
-      vertex 17.3418 0 14.9765
+      vertex -20.9765 0 12.3418
+      vertex -20.8197 -2.7 12.6496
+      vertex -20.9765 -2.7 12.3418
     endloop
   endfacet
   facet normal -0.612978 0 -0.7901
     outer loop
-      vertex 18.2328 -2.7 14.4496
-      vertex 18.5058 0 14.2378
-      vertex 18.5058 -2.7 14.2378
+      vertex -12.7672 -2.7 14.4496
+      vertex -12.4942 0 14.2378
+      vertex -12.4942 -2.7 14.2378
     endloop
   endfacet
   facet normal -0.612978 0 -0.7901
     outer loop
-      vertex 18.5058 0 14.2378
-      vertex 18.2328 -2.7 14.4496
-      vertex 18.2328 0 14.4496
+      vertex -12.4942 0 14.2378
+      vertex -12.7672 -2.7 14.4496
+      vertex -12.7672 0 14.4496
     endloop
   endfacet
-  facet normal -0.7901 0 -0.612978
+  facet normal 0.860727 -0 0.509068
     outer loop
-      vertex 19.4496 -2.7 13.2328
-      vertex 19.2378 0 13.5058
-      vertex 19.4496 0 13.2328
+      vertex -20.8197 -2.7 7.35036
+      vertex -20.6438 0 7.05295
+      vertex -20.8197 0 7.35036
     endloop
   endfacet
-  facet normal -0.7901 -0 -0.612978
+  facet normal 0.860727 0 0.509068
     outer loop
-      vertex 19.2378 0 13.5058
-      vertex 19.4496 -2.7 13.2328
-      vertex 19.2378 -2.7 13.5058
+      vertex -20.6438 0 7.05295
+      vertex -20.8197 -2.7 7.35036
+      vertex -20.6438 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal 0.156275 0 -0.987714
+    outer loop
+      vertex -17.0306 -2.7 15.4026
+      vertex -16.6893 0 15.4566
+      vertex -16.6893 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal 0.156275 0 -0.987714
+    outer loop
+      vertex -16.6893 0 15.4566
+      vertex -17.0306 -2.7 15.4026
+      vertex -17.0306 0 15.4026
+    endloop
+  endfacet
+  facet normal 0.860719 0 -0.50908
+    outer loop
+      vertex -20.6438 -2.7 12.947
+      vertex -20.8197 0 12.6496
+      vertex -20.6438 0 12.947
+    endloop
+  endfacet
+  facet normal 0.860719 0 -0.50908
+    outer loop
+      vertex -20.8197 0 12.6496
+      vertex -20.6438 -2.7 12.947
+      vertex -20.8197 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal 0.0314065 0 0.999507
+    outer loop
+      vertex -16.3453 0 4.51085
+      vertex -16 -2.7 4.5
+      vertex -16 0 4.5
+    endloop
+  endfacet
+  facet normal 0.0314065 0 0.999507
+    outer loop
+      vertex -16 -2.7 4.5
+      vertex -16.3453 0 4.51085
+      vertex -16.3453 -2.7 4.51085
+    endloop
+  endfacet
+  facet normal -0.995567 0 -0.0940579
+    outer loop
+      vertex -10.5109 -2.7 10.3453
+      vertex -10.5434 0 10.6893
+      vertex -10.5109 0 10.3453
+    endloop
+  endfacet
+  facet normal -0.995567 -0 -0.0940579
+    outer loop
+      vertex -10.5434 0 10.6893
+      vertex -10.5109 -2.7 10.3453
+      vertex -10.5434 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal -0.891074 0 0.453859
+    outer loop
+      vertex -11.1803 -2.7 7.35036
+      vertex -11.0235 0 7.65821
+      vertex -11.1803 0 7.35036
+    endloop
+  endfacet
+  facet normal -0.891074 0 0.453859
+    outer loop
+      vertex -11.0235 0 7.65821
+      vertex -11.1803 -2.7 7.35036
+      vertex -11.0235 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0.960291 -0 0.279
+    outer loop
+      vertex -21.3272 -2.7 8.63221
+      vertex -21.2308 0 8.30041
+      vertex -21.3272 0 8.63221
+    endloop
+  endfacet
+  facet normal 0.960291 0 0.279
+    outer loop
+      vertex -21.2308 0 8.30041
+      vertex -21.3272 -2.7 8.63221
+      vertex -21.2308 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal 0.661287 0 -0.750133
+    outer loop
+      vertex -19.765 -2.7 14.0093
+      vertex -19.5058 0 14.2378
+      vertex -19.5058 -2.7 14.2378
+    endloop
+  endfacet
+  facet normal 0.661287 0 -0.750133
+    outer loop
+      vertex -19.5058 0 14.2378
+      vertex -19.765 -2.7 14.0093
+      vertex -19.765 0 14.0093
+    endloop
+  endfacet
+  facet normal 0.397144 0 0.917756
+    outer loop
+      vertex -18.3418 0 5.02345
+      vertex -18.0247 -2.7 4.88623
+      vertex -18.0247 0 4.88623
+    endloop
+  endfacet
+  facet normal 0.397144 0 0.917756
+    outer loop
+      vertex -18.0247 -2.7 4.88623
+      vertex -18.3418 0 5.02345
+      vertex -18.3418 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal 0.338627 0 -0.940921
+    outer loop
+      vertex -18.0247 -2.7 15.1138
+      vertex -17.6996 0 15.2308
+      vertex -17.6996 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal 0.338627 0 -0.940921
+    outer loop
+      vertex -17.6996 0 15.2308
+      vertex -18.0247 -2.7 15.1138
+      vertex -18.0247 0 15.1138
+    endloop
+  endfacet
+  facet normal 0.987714 0 -0.156275
+    outer loop
+      vertex -21.4026 -2.7 11.0306
+      vertex -21.4566 0 10.6893
+      vertex -21.4026 0 11.0306
+    endloop
+  endfacet
+  facet normal 0.987714 0 -0.156275
+    outer loop
+      vertex -21.4566 0 10.6893
+      vertex -21.4026 -2.7 11.0306
+      vertex -21.4566 -2.7 10.6893
     endloop
   endfacet
   facet normal -0.750133 0 -0.661287
     outer loop
-      vertex 19.2378 -2.7 13.5058
-      vertex 19.0093 0 13.765
-      vertex 19.2378 0 13.5058
+      vertex -11.7622 -2.7 13.5058
+      vertex -11.9907 0 13.765
+      vertex -11.7622 0 13.5058
     endloop
   endfacet
   facet normal -0.750133 -0 -0.661287
     outer loop
-      vertex 19.0093 0 13.765
-      vertex 19.2378 -2.7 13.5058
-      vertex 19.0093 -2.7 13.765
+      vertex -11.9907 0 13.765
+      vertex -11.7622 -2.7 13.5058
+      vertex -11.9907 -2.7 13.765
     endloop
   endfacet
-  facet normal -0.891044 0 -0.453917
+  facet normal -0.66127 0 0.750148
     outer loop
-      vertex 19.9765 -2.7 12.3418
-      vertex 19.8197 0 12.6496
-      vertex 19.9765 0 12.3418
+      vertex -12.4942 0 5.76218
+      vertex -12.235 -2.7 5.99067
+      vertex -12.235 0 5.99067
     endloop
   endfacet
-  facet normal -0.891044 -0 -0.453917
+  facet normal -0.66127 0 0.750148
     outer loop
-      vertex 19.8197 0 12.6496
-      vertex 19.9765 -2.7 12.3418
-      vertex 19.8197 -2.7 12.6496
+      vertex -12.235 -2.7 5.99067
+      vertex -12.4942 0 5.76218
+      vertex -12.4942 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal -0.940917 0 0.338636
+    outer loop
+      vertex -10.8862 -2.7 7.97532
+      vertex -10.7692 0 8.30041
+      vertex -10.8862 0 7.97532
+    endloop
+  endfacet
+  facet normal -0.940917 0 0.338636
+    outer loop
+      vertex -10.7692 0 8.30041
+      vertex -10.8862 -2.7 7.97532
+      vertex -10.7692 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal -0.999502 0 -0.031551
+    outer loop
+      vertex -10.5 -2.7 10
+      vertex -10.5109 0 10.3453
+      vertex -10.5 0 10
+    endloop
+  endfacet
+  facet normal -0.999502 -0 -0.031551
+    outer loop
+      vertex -10.5109 0 10.3453
+      vertex -10.5 -2.7 10
+      vertex -10.5109 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15.6547 -2.7 15.4891
+      vertex -16.3453 -2.7 15.4891
+      vertex -16 -2.7 15.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15.3107 -2.7 15.4566
+      vertex -16.3453 -2.7 15.4891
+      vertex -15.6547 -2.7 15.4891
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15.3107 -2.7 15.4566
+      vertex -16.6893 -2.7 15.4566
+      vertex -16.3453 -2.7 15.4891
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.9694 -2.7 15.4026
+      vertex -16.6893 -2.7 15.4566
+      vertex -15.3107 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.9694 -2.7 15.4026
+      vertex -17.0306 -2.7 15.4026
+      vertex -16.6893 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.6322 -2.7 15.3272
+      vertex -17.0306 -2.7 15.4026
+      vertex -14.9694 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.6322 -2.7 15.3272
+      vertex -17.3678 -2.7 15.3272
+      vertex -17.0306 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.3004 -2.7 15.2308
+      vertex -17.3678 -2.7 15.3272
+      vertex -14.6322 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.3004 -2.7 15.2308
+      vertex -17.6996 -2.7 15.2308
+      vertex -17.3678 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.9753 -2.7 15.1138
+      vertex -17.6996 -2.7 15.2308
+      vertex -14.3004 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.9753 -2.7 15.1138
+      vertex -18.0247 -2.7 15.1138
+      vertex -17.6996 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.6582 -2.7 14.9765
+      vertex -18.0247 -2.7 15.1138
+      vertex -13.9753 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.6582 -2.7 14.9765
+      vertex -18.3418 -2.7 14.9765
+      vertex -18.0247 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.3504 -2.7 14.8197
+      vertex -18.3418 -2.7 14.9765
+      vertex -13.6582 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.3504 -2.7 14.8197
+      vertex -18.6496 -2.7 14.8197
+      vertex -18.3418 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.053 -2.7 14.6438
+      vertex -18.6496 -2.7 14.8197
+      vertex -13.3504 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.053 -2.7 14.6438
+      vertex -18.947 -2.7 14.6438
+      vertex -18.6496 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.7672 -2.7 14.4496
+      vertex -18.947 -2.7 14.6438
+      vertex -13.053 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.7672 -2.7 14.4496
+      vertex -19.2328 -2.7 14.4496
+      vertex -18.947 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.4942 -2.7 14.2378
+      vertex -19.2328 -2.7 14.4496
+      vertex -12.7672 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.4942 -2.7 14.2378
+      vertex -19.5058 -2.7 14.2378
+      vertex -19.2328 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.235 -2.7 14.0093
+      vertex -19.5058 -2.7 14.2378
+      vertex -12.4942 -2.7 14.2378
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.235 -2.7 14.0093
+      vertex -19.765 -2.7 14.0093
+      vertex -19.5058 -2.7 14.2378
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.9907 -2.7 13.765
+      vertex -19.765 -2.7 14.0093
+      vertex -12.235 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.9907 -2.7 13.765
+      vertex -20.0093 -2.7 13.765
+      vertex -19.765 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.7622 -2.7 13.5058
+      vertex -20.0093 -2.7 13.765
+      vertex -11.9907 -2.7 13.765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.7622 -2.7 13.5058
+      vertex -20.2378 -2.7 13.5058
+      vertex -20.0093 -2.7 13.765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.5504 -2.7 13.2328
+      vertex -20.2378 -2.7 13.5058
+      vertex -11.7622 -2.7 13.5058
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.5504 -2.7 13.2328
+      vertex -20.4496 -2.7 13.2328
+      vertex -20.2378 -2.7 13.5058
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.3562 -2.7 12.947
+      vertex -20.4496 -2.7 13.2328
+      vertex -11.5504 -2.7 13.2328
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.3562 -2.7 12.947
+      vertex -20.6438 -2.7 12.947
+      vertex -20.4496 -2.7 13.2328
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1803 -2.7 12.6496
+      vertex -20.6438 -2.7 12.947
+      vertex -11.3562 -2.7 12.947
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1803 -2.7 12.6496
+      vertex -20.8197 -2.7 12.6496
+      vertex -20.6438 -2.7 12.947
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.0235 -2.7 12.3418
+      vertex -20.8197 -2.7 12.6496
+      vertex -11.1803 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.0235 -2.7 12.3418
+      vertex -20.9765 -2.7 12.3418
+      vertex -20.8197 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.8862 -2.7 12.0247
+      vertex -20.9765 -2.7 12.3418
+      vertex -11.0235 -2.7 12.3418
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.8862 -2.7 12.0247
+      vertex -21.1138 -2.7 12.0247
+      vertex -20.9765 -2.7 12.3418
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.7692 -2.7 11.6996
+      vertex -21.1138 -2.7 12.0247
+      vertex -10.8862 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.7692 -2.7 11.6996
+      vertex -21.2308 -2.7 11.6996
+      vertex -21.1138 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.6728 -2.7 11.3678
+      vertex -21.2308 -2.7 11.6996
+      vertex -10.7692 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.6728 -2.7 11.3678
+      vertex -21.3272 -2.7 11.3678
+      vertex -21.2308 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5974 -2.7 11.0306
+      vertex -21.3272 -2.7 11.3678
+      vertex -10.6728 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5974 -2.7 11.0306
+      vertex -21.4026 -2.7 11.0306
+      vertex -21.3272 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5434 -2.7 10.6893
+      vertex -21.4026 -2.7 11.0306
+      vertex -10.5974 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5434 -2.7 10.6893
+      vertex -21.4566 -2.7 10.6893
+      vertex -21.4026 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5109 -2.7 10.3453
+      vertex -21.4566 -2.7 10.6893
+      vertex -10.5434 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5109 -2.7 10.3453
+      vertex -21.4891 -2.7 10.3453
+      vertex -21.4566 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5 -2.7 10
+      vertex -21.4891 -2.7 10.3453
+      vertex -10.5109 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5 -2.7 10
+      vertex -21.5 -2.7 10
+      vertex -21.4891 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.5109 -2.7 9.65465
+      vertex -21.5 -2.7 10
+      vertex -10.5 -2.7 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5109 -2.7 9.65465
+      vertex -21.4891 -2.7 9.65465
+      vertex -21.5 -2.7 10
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.5434 -2.7 9.31067
+      vertex -21.4891 -2.7 9.65465
+      vertex -10.5109 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5434 -2.7 9.31067
+      vertex -21.4566 -2.7 9.31067
+      vertex -21.4891 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.5974 -2.7 8.9694
+      vertex -21.4566 -2.7 9.31067
+      vertex -10.5434 -2.7 9.31067
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.5974 -2.7 8.9694
+      vertex -21.4026 -2.7 8.9694
+      vertex -21.4566 -2.7 9.31067
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.6728 -2.7 8.63221
+      vertex -21.4026 -2.7 8.9694
+      vertex -10.5974 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.6728 -2.7 8.63221
+      vertex -21.3272 -2.7 8.63221
+      vertex -21.4026 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.7692 -2.7 8.30041
+      vertex -21.3272 -2.7 8.63221
+      vertex -10.6728 -2.7 8.63221
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.7692 -2.7 8.30041
+      vertex -21.2308 -2.7 8.30041
+      vertex -21.3272 -2.7 8.63221
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.8862 -2.7 7.97532
+      vertex -21.2308 -2.7 8.30041
+      vertex -10.7692 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.8862 -2.7 7.97532
+      vertex -21.1138 -2.7 7.97532
+      vertex -21.2308 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -11.0235 -2.7 7.65821
+      vertex -21.1138 -2.7 7.97532
+      vertex -10.8862 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.0235 -2.7 7.65821
+      vertex -20.9765 -2.7 7.65821
+      vertex -21.1138 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -11.1803 -2.7 7.35036
+      vertex -20.9765 -2.7 7.65821
+      vertex -11.0235 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1803 -2.7 7.35036
+      vertex -20.8197 -2.7 7.35036
+      vertex -20.9765 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -11.3562 -2.7 7.05295
+      vertex -20.8197 -2.7 7.35036
+      vertex -11.1803 -2.7 7.35036
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.3562 -2.7 7.05295
+      vertex -20.6438 -2.7 7.05295
+      vertex -20.8197 -2.7 7.35036
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -11.5504 -2.7 6.76718
+      vertex -20.6438 -2.7 7.05295
+      vertex -11.3562 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.5504 -2.7 6.76718
+      vertex -20.4496 -2.7 6.76718
+      vertex -20.6438 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -11.7622 -2.7 6.49417
+      vertex -20.4496 -2.7 6.76718
+      vertex -11.5504 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.7622 -2.7 6.49417
+      vertex -20.2378 -2.7 6.49417
+      vertex -20.4496 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -11.9907 -2.7 6.23499
+      vertex -20.2378 -2.7 6.49417
+      vertex -11.7622 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.9907 -2.7 6.23499
+      vertex -20.0093 -2.7 6.23499
+      vertex -20.2378 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -12.235 -2.7 5.99067
+      vertex -20.0093 -2.7 6.23499
+      vertex -11.9907 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.235 -2.7 5.99067
+      vertex -19.765 -2.7 5.99067
+      vertex -20.0093 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -12.4942 -2.7 5.76218
+      vertex -19.765 -2.7 5.99067
+      vertex -12.235 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.4942 -2.7 5.76218
+      vertex -19.5058 -2.7 5.76218
+      vertex -19.765 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -12.7672 -2.7 5.55041
+      vertex -19.5058 -2.7 5.76218
+      vertex -12.4942 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -12.7672 -2.7 5.55041
+      vertex -19.2328 -2.7 5.55041
+      vertex -19.5058 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -13.053 -2.7 5.3562
+      vertex -19.2328 -2.7 5.55041
+      vertex -12.7672 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.053 -2.7 5.3562
+      vertex -18.947 -2.7 5.3562
+      vertex -19.2328 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -13.3504 -2.7 5.18031
+      vertex -18.947 -2.7 5.3562
+      vertex -13.053 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.3504 -2.7 5.18031
+      vertex -18.6496 -2.7 5.18031
+      vertex -18.947 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -13.6582 -2.7 5.02345
+      vertex -18.6496 -2.7 5.18031
+      vertex -13.3504 -2.7 5.18031
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.6582 -2.7 5.02345
+      vertex -18.3418 -2.7 5.02345
+      vertex -18.6496 -2.7 5.18031
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -13.9753 -2.7 4.88623
+      vertex -18.3418 -2.7 5.02345
+      vertex -13.6582 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.9753 -2.7 4.88623
+      vertex -18.0247 -2.7 4.88623
+      vertex -18.3418 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -14.3004 -2.7 4.76919
+      vertex -18.0247 -2.7 4.88623
+      vertex -13.9753 -2.7 4.88623
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.3004 -2.7 4.76919
+      vertex -17.6996 -2.7 4.76919
+      vertex -18.0247 -2.7 4.88623
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -14.6322 -2.7 4.67279
+      vertex -17.6996 -2.7 4.76919
+      vertex -14.3004 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.6322 -2.7 4.67279
+      vertex -17.3678 -2.7 4.67279
+      vertex -17.6996 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -14.9694 -2.7 4.59742
+      vertex -17.3678 -2.7 4.67279
+      vertex -14.6322 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -14.9694 -2.7 4.59742
+      vertex -17.0306 -2.7 4.59742
+      vertex -17.3678 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -15.3107 -2.7 4.54337
+      vertex -17.0306 -2.7 4.59742
+      vertex -14.9694 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15.3107 -2.7 4.54337
+      vertex -16.6893 -2.7 4.54337
+      vertex -17.0306 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -15.6547 -2.7 4.51085
+      vertex -16.6893 -2.7 4.54337
+      vertex -15.3107 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15.6547 -2.7 4.51085
+      vertex -16.3453 -2.7 4.51085
+      vertex -16.6893 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal -0 1 0
+    outer loop
+      vertex -16.3453 -2.7 4.51085
+      vertex -15.6547 -2.7 4.51085
+      vertex -16 -2.7 4.5
+    endloop
+  endfacet
+  facet normal 0.82712 0 -0.562025
+    outer loop
+      vertex -20.4496 -2.7 13.2328
+      vertex -20.6438 0 12.947
+      vertex -20.4496 0 13.2328
+    endloop
+  endfacet
+  facet normal 0.82712 0 -0.562025
+    outer loop
+      vertex -20.6438 0 12.947
+      vertex -20.4496 -2.7 13.2328
+      vertex -20.6438 -2.7 12.947
+    endloop
+  endfacet
+  facet normal 0.33873 0 0.940884
+    outer loop
+      vertex -18.0247 0 4.88623
+      vertex -17.6996 -2.7 4.76919
+      vertex -17.6996 0 4.76919
+    endloop
+  endfacet
+  facet normal 0.33873 0 0.940884
+    outer loop
+      vertex -17.6996 -2.7 4.76919
+      vertex -18.0247 0 4.88623
+      vertex -18.0247 -2.7 4.88623
+    endloop
+  endfacet
+  facet normal -0.454055 0 0.890974
+    outer loop
+      vertex -13.6582 0 5.02345
+      vertex -13.3504 -2.7 5.18031
+      vertex -13.3504 0 5.18031
+    endloop
+  endfacet
+  facet normal -0.454055 0 0.890974
+    outer loop
+      vertex -13.3504 -2.7 5.18031
+      vertex -13.6582 0 5.02345
+      vertex -13.6582 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal 0.509059 0 0.860732
+    outer loop
+      vertex -18.947 0 5.3562
+      vertex -18.6496 -2.7 5.18031
+      vertex -18.6496 0 5.18031
+    endloop
+  endfacet
+  facet normal 0.509059 0 0.860732
+    outer loop
+      vertex -18.6496 -2.7 5.18031
+      vertex -18.947 0 5.3562
+      vertex -18.947 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal -0.0941153 0 0.995561
+    outer loop
+      vertex -15.6547 0 4.51085
+      vertex -15.3107 -2.7 4.54337
+      vertex -15.3107 0 4.54337
+    endloop
+  endfacet
+  facet normal -0.0941153 0 0.995561
+    outer loop
+      vertex -15.3107 -2.7 4.54337
+      vertex -15.6547 0 4.51085
+      vertex -15.6547 -2.7 4.51085
+    endloop
+  endfacet
+  facet normal 0.0940579 0 -0.995567
+    outer loop
+      vertex -16.6893 -2.7 15.4566
+      vertex -16.3453 0 15.4891
+      vertex -16.3453 -2.7 15.4891
+    endloop
+  endfacet
+  facet normal 0.0940579 0 -0.995567
+    outer loop
+      vertex -16.3453 0 15.4891
+      vertex -16.6893 -2.7 15.4566
+      vertex -16.6893 0 15.4566
+    endloop
+  endfacet
+  facet normal 0.790111 -0 0.612964
+    outer loop
+      vertex -20.4496 -2.7 6.76718
+      vertex -20.2378 0 6.49417
+      vertex -20.4496 0 6.76718
+    endloop
+  endfacet
+  facet normal 0.790111 0 0.612964
+    outer loop
+      vertex -20.2378 0 6.49417
+      vertex -20.4496 -2.7 6.76718
+      vertex -20.2378 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal 0.960291 0 -0.279
+    outer loop
+      vertex -21.2308 -2.7 11.6996
+      vertex -21.3272 0 11.3678
+      vertex -21.2308 0 11.6996
+    endloop
+  endfacet
+  facet normal 0.960291 0 -0.279
+    outer loop
+      vertex -21.3272 0 11.3678
+      vertex -21.2308 -2.7 11.6996
+      vertex -21.3272 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal 0.750133 0 -0.661287
+    outer loop
+      vertex -20.0093 -2.7 13.765
+      vertex -20.2378 0 13.5058
+      vertex -20.0093 0 13.765
+    endloop
+  endfacet
+  facet normal 0.750133 0 -0.661287
+    outer loop
+      vertex -20.2378 0 13.5058
+      vertex -20.0093 -2.7 13.765
+      vertex -20.2378 -2.7 13.5058
+    endloop
+  endfacet
+  facet normal -0.031551 0 -0.999502
+    outer loop
+      vertex -16 -2.7 15.5
+      vertex -15.6547 0 15.4891
+      vertex -15.6547 -2.7 15.4891
+    endloop
+  endfacet
+  facet normal -0.031551 0 -0.999502
+    outer loop
+      vertex -15.6547 0 15.4891
+      vertex -16 -2.7 15.5
+      vertex -16 0 15.5
+    endloop
+  endfacet
+  facet normal 0.562045 0 0.827107
+    outer loop
+      vertex -19.2328 0 5.55041
+      vertex -18.947 -2.7 5.3562
+      vertex -18.947 0 5.3562
+    endloop
+  endfacet
+  facet normal 0.562045 0 0.827107
+    outer loop
+      vertex -18.947 -2.7 5.3562
+      vertex -19.2328 0 5.55041
+      vertex -19.2328 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal -0.960291 0 -0.279
+    outer loop
+      vertex -10.6728 -2.7 11.3678
+      vertex -10.7692 0 11.6996
+      vertex -10.6728 0 11.3678
+    endloop
+  endfacet
+  facet normal -0.960291 -0 -0.279
+    outer loop
+      vertex -10.7692 0 11.6996
+      vertex -10.6728 -2.7 11.3678
+      vertex -10.7692 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal 0.454055 0 0.890974
+    outer loop
+      vertex -18.6496 0 5.18031
+      vertex -18.3418 -2.7 5.02345
+      vertex -18.3418 0 5.02345
+    endloop
+  endfacet
+  facet normal 0.454055 0 0.890974
+    outer loop
+      vertex -18.3418 -2.7 5.02345
+      vertex -18.6496 0 5.18031
+      vertex -18.6496 -2.7 5.18031
+    endloop
+  endfacet
+  facet normal -0.750108 0 0.661315
+    outer loop
+      vertex -11.9907 -2.7 6.23499
+      vertex -11.7622 0 6.49417
+      vertex -11.9907 0 6.23499
+    endloop
+  endfacet
+  facet normal -0.750108 0 0.661315
+    outer loop
+      vertex -11.7622 0 6.49417
+      vertex -11.9907 -2.7 6.23499
+      vertex -11.7622 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal 0.397339 0 -0.917672
+    outer loop
+      vertex -18.3418 -2.7 14.9765
+      vertex -18.0247 0 15.1138
+      vertex -18.0247 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal 0.397339 0 -0.917672
+    outer loop
+      vertex -18.0247 0 15.1138
+      vertex -18.3418 -2.7 14.9765
+      vertex -18.3418 0 14.9765
+    endloop
+  endfacet
+  facet normal 0.917676 -0 0.397329
+    outer loop
+      vertex -21.1138 -2.7 7.97532
+      vertex -20.9765 0 7.65821
+      vertex -21.1138 0 7.97532
+    endloop
+  endfacet
+  facet normal 0.917676 0 0.397329
+    outer loop
+      vertex -20.9765 0 7.65821
+      vertex -21.1138 -2.7 7.97532
+      vertex -20.9765 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0.562025 0 -0.82712
+    outer loop
+      vertex -19.2328 -2.7 14.4496
+      vertex -18.947 0 14.6438
+      vertex -18.947 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal 0.562025 0 -0.82712
+    outer loop
+      vertex -18.947 0 14.6438
+      vertex -19.2328 -2.7 14.4496
+      vertex -19.2328 0 14.4496
+    endloop
+  endfacet
+  facet normal 0.50908 0 -0.860719
+    outer loop
+      vertex -18.947 -2.7 14.6438
+      vertex -18.6496 0 14.8197
+      vertex -18.6496 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal 0.50908 0 -0.860719
+    outer loop
+      vertex -18.6496 0 14.8197
+      vertex -18.947 -2.7 14.6438
+      vertex -18.947 0 14.6438
+    endloop
+  endfacet
+  facet normal 0.279 0 -0.960291
+    outer loop
+      vertex -17.6996 -2.7 15.2308
+      vertex -17.3678 0 15.3272
+      vertex -17.3678 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal 0.279 0 -0.960291
+    outer loop
+      vertex -17.3678 0 15.3272
+      vertex -17.6996 -2.7 15.2308
+      vertex -17.6996 0 15.2308
+    endloop
+  endfacet
+  facet normal 0.995567 0 -0.0940579
+    outer loop
+      vertex -21.4566 -2.7 10.6893
+      vertex -21.4891 0 10.3453
+      vertex -21.4566 0 10.6893
+    endloop
+  endfacet
+  facet normal 0.995567 0 -0.0940579
+    outer loop
+      vertex -21.4891 0 10.3453
+      vertex -21.4566 -2.7 10.6893
+      vertex -21.4891 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal 0.0941153 0 0.995561
+    outer loop
+      vertex -16.6893 0 4.54337
+      vertex -16.3453 -2.7 4.51085
+      vertex -16.3453 0 4.51085
+    endloop
+  endfacet
+  facet normal 0.0941153 0 0.995561
+    outer loop
+      vertex -16.3453 -2.7 4.51085
+      vertex -16.6893 0 4.54337
+      vertex -16.6893 -2.7 4.54337
     endloop
   endfacet
   facet normal -0.917672 0 -0.397339
     outer loop
-      vertex 20.1138 -2.7 12.0247
-      vertex 19.9765 0 12.3418
-      vertex 20.1138 0 12.0247
+      vertex -10.8862 -2.7 12.0247
+      vertex -11.0235 0 12.3418
+      vertex -10.8862 0 12.0247
     endloop
   endfacet
   facet normal -0.917672 -0 -0.397339
     outer loop
-      vertex 19.9765 0 12.3418
-      vertex 20.1138 -2.7 12.0247
-      vertex 19.9765 -2.7 12.3418
+      vertex -11.0235 0 12.3418
+      vertex -10.8862 -2.7 12.0247
+      vertex -11.0235 -2.7 12.3418
+    endloop
+  endfacet
+  facet normal -0.661287 0 -0.750133
+    outer loop
+      vertex -12.4942 -2.7 14.2378
+      vertex -12.235 0 14.0093
+      vertex -12.235 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal -0.661287 0 -0.750133
+    outer loop
+      vertex -12.235 0 14.0093
+      vertex -12.4942 -2.7 14.2378
+      vertex -12.4942 0 14.2378
+    endloop
+  endfacet
+  facet normal -0.940921 0 -0.338627
+    outer loop
+      vertex -10.7692 -2.7 11.6996
+      vertex -10.8862 0 12.0247
+      vertex -10.7692 0 11.6996
+    endloop
+  endfacet
+  facet normal -0.940921 -0 -0.338627
+    outer loop
+      vertex -10.8862 0 12.0247
+      vertex -10.7692 -2.7 11.6996
+      vertex -10.8862 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal -0.279 0 -0.960291
+    outer loop
+      vertex -14.6322 -2.7 15.3272
+      vertex -14.3004 0 15.2308
+      vertex -14.3004 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal -0.279 0 -0.960291
+    outer loop
+      vertex -14.3004 0 15.2308
+      vertex -14.6322 -2.7 15.3272
+      vertex -14.6322 0 15.3272
+    endloop
+  endfacet
+  facet normal 0.612924 0 0.790142
+    outer loop
+      vertex -19.5058 0 5.76218
+      vertex -19.2328 -2.7 5.55041
+      vertex -19.2328 0 5.55041
+    endloop
+  endfacet
+  facet normal 0.612924 0 0.790142
+    outer loop
+      vertex -19.2328 -2.7 5.55041
+      vertex -19.5058 0 5.76218
+      vertex -19.5058 -2.7 5.76218
     endloop
   endfacet
   facet normal -0.50908 0 -0.860719
     outer loop
-      vertex 17.6496 -2.7 14.8197
-      vertex 17.947 0 14.6438
-      vertex 17.947 -2.7 14.6438
+      vertex -13.3504 -2.7 14.8197
+      vertex -13.053 0 14.6438
+      vertex -13.053 -2.7 14.6438
     endloop
   endfacet
   facet normal -0.50908 0 -0.860719
     outer loop
-      vertex 17.947 0 14.6438
-      vertex 17.6496 -2.7 14.8197
-      vertex 17.6496 0 14.8197
+      vertex -13.053 0 14.6438
+      vertex -13.3504 -2.7 14.8197
+      vertex -13.3504 0 14.8197
+    endloop
+  endfacet
+  facet normal 0.987712 -0 0.156288
+    outer loop
+      vertex -21.4566 -2.7 9.31067
+      vertex -21.4026 0 8.9694
+      vertex -21.4566 0 9.31067
+    endloop
+  endfacet
+  facet normal 0.987712 0 0.156288
+    outer loop
+      vertex -21.4026 0 8.9694
+      vertex -21.4566 -2.7 9.31067
+      vertex -21.4026 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal 0.827093 -0 0.562065
+    outer loop
+      vertex -20.6438 -2.7 7.05295
+      vertex -20.4496 0 6.76718
+      vertex -20.6438 0 7.05295
+    endloop
+  endfacet
+  facet normal 0.827093 0 0.562065
+    outer loop
+      vertex -20.4496 0 6.76718
+      vertex -20.6438 -2.7 7.05295
+      vertex -20.4496 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal 0.940921 0 -0.338627
+    outer loop
+      vertex -21.1138 -2.7 12.0247
+      vertex -21.2308 0 11.6996
+      vertex -21.1138 0 12.0247
+    endloop
+  endfacet
+  facet normal 0.940921 0 -0.338627
+    outer loop
+      vertex -21.2308 0 11.6996
+      vertex -21.1138 -2.7 12.0247
+      vertex -21.2308 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal -0.891044 0 -0.453917
+    outer loop
+      vertex -11.0235 -2.7 12.3418
+      vertex -11.1803 0 12.6496
+      vertex -11.0235 0 12.3418
+    endloop
+  endfacet
+  facet normal -0.891044 -0 -0.453917
+    outer loop
+      vertex -11.1803 0 12.6496
+      vertex -11.0235 -2.7 12.3418
+      vertex -11.1803 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal -0.995566 0 0.0940633
+    outer loop
+      vertex -10.5434 -2.7 9.31067
+      vertex -10.5109 0 9.65465
+      vertex -10.5434 0 9.31067
+    endloop
+  endfacet
+  facet normal -0.995566 0 0.0940633
+    outer loop
+      vertex -10.5109 0 9.65465
+      vertex -10.5434 -2.7 9.31067
+      vertex -10.5109 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal -0.0314065 0 0.999507
+    outer loop
+      vertex -16 0 4.5
+      vertex -15.6547 -2.7 4.51085
+      vertex -15.6547 0 4.51085
+    endloop
+  endfacet
+  facet normal -0.0314065 0 0.999507
+    outer loop
+      vertex -15.6547 -2.7 4.51085
+      vertex -16 0 4.5
+      vertex -16 -2.7 4.5
+    endloop
+  endfacet
+  facet normal 0.66127 0 0.750148
+    outer loop
+      vertex -19.765 0 5.99067
+      vertex -19.5058 -2.7 5.76218
+      vertex -19.5058 0 5.76218
+    endloop
+  endfacet
+  facet normal 0.66127 0 0.750148
+    outer loop
+      vertex -19.5058 -2.7 5.76218
+      vertex -19.765 0 5.99067
+      vertex -19.765 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal -0.790111 0 0.612964
+    outer loop
+      vertex -11.7622 -2.7 6.49417
+      vertex -11.5504 0 6.76718
+      vertex -11.7622 0 6.49417
+    endloop
+  endfacet
+  facet normal -0.790111 0 0.612964
+    outer loop
+      vertex -11.5504 0 6.76718
+      vertex -11.7622 -2.7 6.49417
+      vertex -11.5504 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal -0.218217 0 -0.9759
+    outer loop
+      vertex -14.9694 -2.7 15.4026
+      vertex -14.6322 0 15.3272
+      vertex -14.6322 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal -0.218217 0 -0.9759
+    outer loop
+      vertex -14.6322 0 15.3272
+      vertex -14.9694 -2.7 15.4026
+      vertex -14.9694 0 15.4026
+    endloop
+  endfacet
+  facet normal -0.707136 0 0.707078
+    outer loop
+      vertex -12.235 -2.7 5.99067
+      vertex -11.9907 0 6.23499
+      vertex -12.235 0 5.99067
+    endloop
+  endfacet
+  facet normal -0.707136 0 0.707078
+    outer loop
+      vertex -11.9907 0 6.23499
+      vertex -12.235 -2.7 5.99067
+      vertex -11.9907 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal 0.940917 -0 0.338636
+    outer loop
+      vertex -21.2308 -2.7 8.30041
+      vertex -21.1138 0 7.97532
+      vertex -21.2308 0 8.30041
+    endloop
+  endfacet
+  facet normal 0.940917 0 0.338636
+    outer loop
+      vertex -21.1138 0 7.97532
+      vertex -21.2308 -2.7 8.30041
+      vertex -21.1138 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal 0.999502 0 -0.031551
+    outer loop
+      vertex -21.4891 -2.7 10.3453
+      vertex -21.5 0 10
+      vertex -21.4891 0 10.3453
+    endloop
+  endfacet
+  facet normal 0.999502 0 -0.031551
+    outer loop
+      vertex -21.5 0 10
+      vertex -21.4891 -2.7 10.3453
+      vertex -21.5 -2.7 10
+    endloop
+  endfacet
+  facet normal -0.156416 0 0.987691
+    outer loop
+      vertex -15.3107 0 4.54337
+      vertex -14.9694 -2.7 4.59742
+      vertex -14.9694 0 4.59742
+    endloop
+  endfacet
+  facet normal -0.156416 0 0.987691
+    outer loop
+      vertex -14.9694 -2.7 4.59742
+      vertex -15.3107 0 4.54337
+      vertex -15.3107 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal -0.218135 0 0.975919
+    outer loop
+      vertex -14.9694 0 4.59742
+      vertex -14.6322 -2.7 4.67279
+      vertex -14.6322 0 4.67279
+    endloop
+  endfacet
+  facet normal -0.218135 0 0.975919
+    outer loop
+      vertex -14.6322 -2.7 4.67279
+      vertex -14.9694 0 4.59742
+      vertex -14.9694 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal -0.156275 0 -0.987714
+    outer loop
+      vertex -15.3107 -2.7 15.4566
+      vertex -14.9694 0 15.4026
+      vertex -14.9694 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal -0.156275 0 -0.987714
+    outer loop
+      vertex -14.9694 0 15.4026
+      vertex -15.3107 -2.7 15.4566
+      vertex -15.3107 0 15.4566
+    endloop
+  endfacet
+  facet normal -0.9759 0 -0.218217
+    outer loop
+      vertex -10.5974 -2.7 11.0306
+      vertex -10.6728 0 11.3678
+      vertex -10.5974 0 11.0306
+    endloop
+  endfacet
+  facet normal -0.9759 -0 -0.218217
+    outer loop
+      vertex -10.6728 0 11.3678
+      vertex -10.5974 -2.7 11.0306
+      vertex -10.6728 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal -0.987714 0 -0.156275
+    outer loop
+      vertex -10.5434 -2.7 10.6893
+      vertex -10.5974 0 11.0306
+      vertex -10.5434 0 10.6893
+    endloop
+  endfacet
+  facet normal -0.987714 -0 -0.156275
+    outer loop
+      vertex -10.5974 0 11.0306
+      vertex -10.5434 -2.7 10.6893
+      vertex -10.5974 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal -0.612924 0 0.790142
+    outer loop
+      vertex -12.7672 0 5.55041
+      vertex -12.4942 -2.7 5.76218
+      vertex -12.4942 0 5.76218
+    endloop
+  endfacet
+  facet normal -0.612924 0 0.790142
+    outer loop
+      vertex -12.4942 -2.7 5.76218
+      vertex -12.7672 0 5.55041
+      vertex -12.7672 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal 0.612978 0 -0.7901
+    outer loop
+      vertex -19.5058 -2.7 14.2378
+      vertex -19.2328 0 14.4496
+      vertex -19.2328 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal 0.612978 0 -0.7901
+    outer loop
+      vertex -19.2328 0 14.4496
+      vertex -19.5058 -2.7 14.2378
+      vertex -19.5058 0 14.2378
+    endloop
+  endfacet
+  facet normal -0.562045 0 0.827107
+    outer loop
+      vertex -13.053 0 5.3562
+      vertex -12.7672 -2.7 5.55041
+      vertex -12.7672 0 5.55041
+    endloop
+  endfacet
+  facet normal -0.562045 0 0.827107
+    outer loop
+      vertex -12.7672 -2.7 5.55041
+      vertex -13.053 0 5.3562
+      vertex -13.053 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal 0.279 0 0.960291
+    outer loop
+      vertex -17.6996 0 4.76919
+      vertex -17.3678 -2.7 4.67279
+      vertex -17.3678 0 4.67279
+    endloop
+  endfacet
+  facet normal 0.279 0 0.960291
+    outer loop
+      vertex -17.3678 -2.7 4.67279
+      vertex -17.6996 0 4.76919
+      vertex -17.6996 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal -0.707107 0 -0.707107
+    outer loop
+      vertex -11.9907 -2.7 13.765
+      vertex -12.235 0 14.0093
+      vertex -11.9907 0 13.765
+    endloop
+  endfacet
+  facet normal -0.707107 -0 -0.707107
+    outer loop
+      vertex -12.235 0 14.0093
+      vertex -11.9907 -2.7 13.765
+      vertex -12.235 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal 0.031551 0 -0.999502
+    outer loop
+      vertex -16.3453 -2.7 15.4891
+      vertex -16 0 15.5
+      vertex -16 -2.7 15.5
+    endloop
+  endfacet
+  facet normal 0.031551 0 -0.999502
+    outer loop
+      vertex -16 0 15.5
+      vertex -16.3453 -2.7 15.4891
+      vertex -16.3453 0 15.4891
+    endloop
+  endfacet
+  facet normal 0.453917 0 -0.891044
+    outer loop
+      vertex -18.6496 -2.7 14.8197
+      vertex -18.3418 0 14.9765
+      vertex -18.3418 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal 0.453917 0 -0.891044
+    outer loop
+      vertex -18.3418 0 14.9765
+      vertex -18.6496 -2.7 14.8197
+      vertex -18.6496 0 14.8197
+    endloop
+  endfacet
+  facet normal -0.860727 0 0.509068
+    outer loop
+      vertex -11.3562 -2.7 7.05295
+      vertex -11.1803 0 7.35036
+      vertex -11.3562 0 7.05295
+    endloop
+  endfacet
+  facet normal -0.860727 0 0.509068
+    outer loop
+      vertex -11.1803 0 7.35036
+      vertex -11.3562 -2.7 7.05295
+      vertex -11.1803 -2.7 7.35036
+    endloop
+  endfacet
+  facet normal -0.0940579 0 -0.995567
+    outer loop
+      vertex -15.6547 -2.7 15.4891
+      vertex -15.3107 0 15.4566
+      vertex -15.3107 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal -0.0940579 0 -0.995567
+    outer loop
+      vertex -15.3107 0 15.4566
+      vertex -15.6547 -2.7 15.4891
+      vertex -15.6547 0 15.4891
+    endloop
+  endfacet
+  facet normal 0.156416 0 0.987691
+    outer loop
+      vertex -17.0306 0 4.59742
+      vertex -16.6893 -2.7 4.54337
+      vertex -16.6893 0 4.54337
+    endloop
+  endfacet
+  facet normal 0.156416 0 0.987691
+    outer loop
+      vertex -16.6893 -2.7 4.54337
+      vertex -17.0306 0 4.59742
+      vertex -17.0306 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal -0.987712 0 0.156288
+    outer loop
+      vertex -10.5974 -2.7 8.9694
+      vertex -10.5434 0 9.31067
+      vertex -10.5974 0 8.9694
+    endloop
+  endfacet
+  facet normal -0.987712 0 0.156288
+    outer loop
+      vertex -10.5434 0 9.31067
+      vertex -10.5974 -2.7 8.9694
+      vertex -10.5434 -2.7 9.31067
+    endloop
+  endfacet
+  facet normal -0.827093 0 0.562065
+    outer loop
+      vertex -11.5504 -2.7 6.76718
+      vertex -11.3562 0 7.05295
+      vertex -11.5504 0 6.76718
+    endloop
+  endfacet
+  facet normal -0.827093 0 0.562065
+    outer loop
+      vertex -11.3562 0 7.05295
+      vertex -11.5504 -2.7 6.76718
+      vertex -11.3562 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal -0.860719 0 -0.50908
+    outer loop
+      vertex -11.1803 -2.7 12.6496
+      vertex -11.3562 0 12.947
+      vertex -11.1803 0 12.6496
+    endloop
+  endfacet
+  facet normal -0.860719 -0 -0.50908
+    outer loop
+      vertex -11.3562 0 12.947
+      vertex -11.1803 -2.7 12.6496
+      vertex -11.3562 -2.7 12.947
     endloop
   endfacet
   facet normal -0.397339 0 -0.917672
     outer loop
-      vertex 17.0247 -2.7 15.1138
-      vertex 17.3418 0 14.9765
-      vertex 17.3418 -2.7 14.9765
+      vertex -13.9753 -2.7 15.1138
+      vertex -13.6582 0 14.9765
+      vertex -13.6582 -2.7 14.9765
     endloop
   endfacet
   facet normal -0.397339 0 -0.917672
     outer loop
-      vertex 17.3418 0 14.9765
-      vertex 17.0247 -2.7 15.1138
-      vertex 17.0247 0 15.1138
+      vertex -13.6582 0 14.9765
+      vertex -13.9753 -2.7 15.1138
+      vertex -13.9753 0 15.1138
+    endloop
+  endfacet
+  facet normal 0.707107 0 -0.707107
+    outer loop
+      vertex -19.765 -2.7 14.0093
+      vertex -20.0093 0 13.765
+      vertex -19.765 0 14.0093
+    endloop
+  endfacet
+  facet normal 0.707107 0 -0.707107
+    outer loop
+      vertex -20.0093 0 13.765
+      vertex -19.765 -2.7 14.0093
+      vertex -20.0093 -2.7 13.765
+    endloop
+  endfacet
+  facet normal -0.279 0 0.960291
+    outer loop
+      vertex -14.6322 0 4.67279
+      vertex -14.3004 -2.7 4.76919
+      vertex -14.3004 0 4.76919
+    endloop
+  endfacet
+  facet normal -0.279 0 0.960291
+    outer loop
+      vertex -14.3004 -2.7 4.76919
+      vertex -14.6322 0 4.67279
+      vertex -14.6322 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal -0.975899 0 0.218223
+    outer loop
+      vertex -10.6728 -2.7 8.63221
+      vertex -10.5974 0 8.9694
+      vertex -10.6728 0 8.63221
+    endloop
+  endfacet
+  facet normal -0.975899 0 0.218223
+    outer loop
+      vertex -10.5974 0 8.9694
+      vertex -10.6728 -2.7 8.63221
+      vertex -10.5974 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal -0.999502 0 0.0315465
+    outer loop
+      vertex -10.5109 -2.7 9.65465
+      vertex -10.5 0 10
+      vertex -10.5109 0 9.65465
+    endloop
+  endfacet
+  facet normal -0.999502 0 0.0315465
+    outer loop
+      vertex -10.5 0 10
+      vertex -10.5109 -2.7 9.65465
+      vertex -10.5 -2.7 10
+    endloop
+  endfacet
+  facet normal -0.562025 0 -0.82712
+    outer loop
+      vertex -13.053 -2.7 14.6438
+      vertex -12.7672 0 14.4496
+      vertex -12.7672 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal -0.562025 0 -0.82712
+    outer loop
+      vertex -12.7672 0 14.4496
+      vertex -13.053 -2.7 14.6438
+      vertex -13.053 0 14.6438
+    endloop
+  endfacet
+  facet normal 0.707136 -0 0.707078
+    outer loop
+      vertex -20.0093 -2.7 6.23499
+      vertex -19.765 0 5.99067
+      vertex -20.0093 0 6.23499
+    endloop
+  endfacet
+  facet normal 0.707136 0 0.707078
+    outer loop
+      vertex -19.765 0 5.99067
+      vertex -20.0093 -2.7 6.23499
+      vertex -19.765 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal -0.82712 0 -0.562025
+    outer loop
+      vertex -11.3562 -2.7 12.947
+      vertex -11.5504 0 13.2328
+      vertex -11.3562 0 12.947
+    endloop
+  endfacet
+  facet normal -0.82712 -0 -0.562025
+    outer loop
+      vertex -11.5504 0 13.2328
+      vertex -11.3562 -2.7 12.947
+      vertex -11.5504 -2.7 13.2328
+    endloop
+  endfacet
+  facet normal -0.7901 0 -0.612978
+    outer loop
+      vertex -11.5504 -2.7 13.2328
+      vertex -11.7622 0 13.5058
+      vertex -11.5504 0 13.2328
+    endloop
+  endfacet
+  facet normal -0.7901 -0 -0.612978
+    outer loop
+      vertex -11.7622 0 13.5058
+      vertex -11.5504 -2.7 13.2328
+      vertex -11.7622 -2.7 13.5058
+    endloop
+  endfacet
+  facet normal -0.453917 0 -0.891044
+    outer loop
+      vertex -13.6582 -2.7 14.9765
+      vertex -13.3504 0 14.8197
+      vertex -13.3504 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal -0.453917 0 -0.891044
+    outer loop
+      vertex -13.3504 0 14.8197
+      vertex -13.6582 -2.7 14.9765
+      vertex -13.6582 0 14.9765
+    endloop
+  endfacet
+  facet normal -0.917676 0 0.397329
+    outer loop
+      vertex -11.0235 -2.7 7.65821
+      vertex -10.8862 0 7.97532
+      vertex -11.0235 0 7.65821
+    endloop
+  endfacet
+  facet normal -0.917676 0 0.397329
+    outer loop
+      vertex -10.8862 0 7.97532
+      vertex -11.0235 -2.7 7.65821
+      vertex -10.8862 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 16.3453 -2.7 15.4891
+      vertex 15.6547 -2.7 15.4891
+      vertex 16 -2.7 15.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 16.6893 -2.7 15.4566
+      vertex 15.6547 -2.7 15.4891
+      vertex 16.3453 -2.7 15.4891
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 16.6893 -2.7 15.4566
+      vertex 15.3107 -2.7 15.4566
+      vertex 15.6547 -2.7 15.4891
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.0306 -2.7 15.4026
+      vertex 15.3107 -2.7 15.4566
+      vertex 16.6893 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.0306 -2.7 15.4026
+      vertex 14.9694 -2.7 15.4026
+      vertex 15.3107 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.3678 -2.7 15.3272
+      vertex 14.9694 -2.7 15.4026
+      vertex 17.0306 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.3678 -2.7 15.3272
+      vertex 14.6322 -2.7 15.3272
+      vertex 14.9694 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.6996 -2.7 15.2308
+      vertex 14.6322 -2.7 15.3272
+      vertex 17.3678 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.6996 -2.7 15.2308
+      vertex 14.3004 -2.7 15.2308
+      vertex 14.6322 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.0247 -2.7 15.1138
+      vertex 14.3004 -2.7 15.2308
+      vertex 17.6996 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.0247 -2.7 15.1138
+      vertex 13.9753 -2.7 15.1138
+      vertex 14.3004 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.3418 -2.7 14.9765
+      vertex 13.9753 -2.7 15.1138
+      vertex 18.0247 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.3418 -2.7 14.9765
+      vertex 13.6582 -2.7 14.9765
+      vertex 13.9753 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.6496 -2.7 14.8197
+      vertex 13.6582 -2.7 14.9765
+      vertex 18.3418 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.6496 -2.7 14.8197
+      vertex 13.3504 -2.7 14.8197
+      vertex 13.6582 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.947 -2.7 14.6438
+      vertex 13.3504 -2.7 14.8197
+      vertex 18.6496 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.947 -2.7 14.6438
+      vertex 13.053 -2.7 14.6438
+      vertex 13.3504 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.2328 -2.7 14.4496
+      vertex 13.053 -2.7 14.6438
+      vertex 18.947 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.2328 -2.7 14.4496
+      vertex 12.7672 -2.7 14.4496
+      vertex 13.053 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.5058 -2.7 14.2378
+      vertex 12.7672 -2.7 14.4496
+      vertex 19.2328 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.5058 -2.7 14.2378
+      vertex 12.4942 -2.7 14.2378
+      vertex 12.7672 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.765 -2.7 14.0093
+      vertex 12.4942 -2.7 14.2378
+      vertex 19.5058 -2.7 14.2378
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.765 -2.7 14.0093
+      vertex 12.235 -2.7 14.0093
+      vertex 12.4942 -2.7 14.2378
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.0093 -2.7 13.765
+      vertex 12.235 -2.7 14.0093
+      vertex 19.765 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.0093 -2.7 13.765
+      vertex 11.9907 -2.7 13.765
+      vertex 12.235 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.2378 -2.7 13.5058
+      vertex 11.9907 -2.7 13.765
+      vertex 20.0093 -2.7 13.765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.2378 -2.7 13.5058
+      vertex 11.7622 -2.7 13.5058
+      vertex 11.9907 -2.7 13.765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.4496 -2.7 13.2328
+      vertex 11.7622 -2.7 13.5058
+      vertex 20.2378 -2.7 13.5058
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.4496 -2.7 13.2328
+      vertex 11.5504 -2.7 13.2328
+      vertex 11.7622 -2.7 13.5058
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.6438 -2.7 12.947
+      vertex 11.5504 -2.7 13.2328
+      vertex 20.4496 -2.7 13.2328
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.6438 -2.7 12.947
+      vertex 11.3562 -2.7 12.947
+      vertex 11.5504 -2.7 13.2328
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.8197 -2.7 12.6496
+      vertex 11.3562 -2.7 12.947
+      vertex 20.6438 -2.7 12.947
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.8197 -2.7 12.6496
+      vertex 11.1803 -2.7 12.6496
+      vertex 11.3562 -2.7 12.947
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.9765 -2.7 12.3418
+      vertex 11.1803 -2.7 12.6496
+      vertex 20.8197 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.9765 -2.7 12.3418
+      vertex 11.0235 -2.7 12.3418
+      vertex 11.1803 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.1138 -2.7 12.0247
+      vertex 11.0235 -2.7 12.3418
+      vertex 20.9765 -2.7 12.3418
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.1138 -2.7 12.0247
+      vertex 10.8862 -2.7 12.0247
+      vertex 11.0235 -2.7 12.3418
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.2308 -2.7 11.6996
+      vertex 10.8862 -2.7 12.0247
+      vertex 21.1138 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.2308 -2.7 11.6996
+      vertex 10.7692 -2.7 11.6996
+      vertex 10.8862 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.3272 -2.7 11.3678
+      vertex 10.7692 -2.7 11.6996
+      vertex 21.2308 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.3272 -2.7 11.3678
+      vertex 10.6728 -2.7 11.3678
+      vertex 10.7692 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4026 -2.7 11.0306
+      vertex 10.6728 -2.7 11.3678
+      vertex 21.3272 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4026 -2.7 11.0306
+      vertex 10.5974 -2.7 11.0306
+      vertex 10.6728 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4566 -2.7 10.6893
+      vertex 10.5974 -2.7 11.0306
+      vertex 21.4026 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4566 -2.7 10.6893
+      vertex 10.5434 -2.7 10.6893
+      vertex 10.5974 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4891 -2.7 10.3453
+      vertex 10.5434 -2.7 10.6893
+      vertex 21.4566 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4891 -2.7 10.3453
+      vertex 10.5109 -2.7 10.3453
+      vertex 10.5434 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.5 -2.7 10
+      vertex 10.5109 -2.7 10.3453
+      vertex 21.4891 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.5 -2.7 10
+      vertex 10.5 -2.7 10
+      vertex 10.5109 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 21.4891 -2.7 9.65465
+      vertex 10.5 -2.7 10
+      vertex 21.5 -2.7 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4891 -2.7 9.65465
+      vertex 10.5109 -2.7 9.65465
+      vertex 10.5 -2.7 10
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 21.4566 -2.7 9.31067
+      vertex 10.5109 -2.7 9.65465
+      vertex 21.4891 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4566 -2.7 9.31067
+      vertex 10.5434 -2.7 9.31067
+      vertex 10.5109 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 21.4026 -2.7 8.9694
+      vertex 10.5434 -2.7 9.31067
+      vertex 21.4566 -2.7 9.31067
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.4026 -2.7 8.9694
+      vertex 10.5974 -2.7 8.9694
+      vertex 10.5434 -2.7 9.31067
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 21.3272 -2.7 8.63221
+      vertex 10.5974 -2.7 8.9694
+      vertex 21.4026 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.3272 -2.7 8.63221
+      vertex 10.6728 -2.7 8.63221
+      vertex 10.5974 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 21.2308 -2.7 8.30041
+      vertex 10.6728 -2.7 8.63221
+      vertex 21.3272 -2.7 8.63221
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.2308 -2.7 8.30041
+      vertex 10.7692 -2.7 8.30041
+      vertex 10.6728 -2.7 8.63221
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 21.1138 -2.7 7.97532
+      vertex 10.7692 -2.7 8.30041
+      vertex 21.2308 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 21.1138 -2.7 7.97532
+      vertex 10.8862 -2.7 7.97532
+      vertex 10.7692 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 20.9765 -2.7 7.65821
+      vertex 10.8862 -2.7 7.97532
+      vertex 21.1138 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.9765 -2.7 7.65821
+      vertex 11.0235 -2.7 7.65821
+      vertex 10.8862 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 20.8197 -2.7 7.35036
+      vertex 11.0235 -2.7 7.65821
+      vertex 20.9765 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.8197 -2.7 7.35036
+      vertex 11.1803 -2.7 7.35036
+      vertex 11.0235 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 20.6438 -2.7 7.05295
+      vertex 11.1803 -2.7 7.35036
+      vertex 20.8197 -2.7 7.35036
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.6438 -2.7 7.05295
+      vertex 11.3562 -2.7 7.05295
+      vertex 11.1803 -2.7 7.35036
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 20.4496 -2.7 6.76718
+      vertex 11.3562 -2.7 7.05295
+      vertex 20.6438 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.4496 -2.7 6.76718
+      vertex 11.5504 -2.7 6.76718
+      vertex 11.3562 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 20.2378 -2.7 6.49417
+      vertex 11.5504 -2.7 6.76718
+      vertex 20.4496 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.2378 -2.7 6.49417
+      vertex 11.7622 -2.7 6.49417
+      vertex 11.5504 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 20.0093 -2.7 6.23499
+      vertex 11.7622 -2.7 6.49417
+      vertex 20.2378 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 20.0093 -2.7 6.23499
+      vertex 11.9907 -2.7 6.23499
+      vertex 11.7622 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 19.765 -2.7 5.99067
+      vertex 11.9907 -2.7 6.23499
+      vertex 20.0093 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.765 -2.7 5.99067
+      vertex 12.235 -2.7 5.99067
+      vertex 11.9907 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 19.5058 -2.7 5.76218
+      vertex 12.235 -2.7 5.99067
+      vertex 19.765 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.5058 -2.7 5.76218
+      vertex 12.4942 -2.7 5.76218
+      vertex 12.235 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 19.2328 -2.7 5.55041
+      vertex 12.4942 -2.7 5.76218
+      vertex 19.5058 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 19.2328 -2.7 5.55041
+      vertex 12.7672 -2.7 5.55041
+      vertex 12.4942 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.947 -2.7 5.3562
+      vertex 12.7672 -2.7 5.55041
+      vertex 19.2328 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.947 -2.7 5.3562
+      vertex 13.053 -2.7 5.3562
+      vertex 12.7672 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.6496 -2.7 5.18031
+      vertex 13.053 -2.7 5.3562
+      vertex 18.947 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.6496 -2.7 5.18031
+      vertex 13.3504 -2.7 5.18031
+      vertex 13.053 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.3418 -2.7 5.02345
+      vertex 13.3504 -2.7 5.18031
+      vertex 18.6496 -2.7 5.18031
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.3418 -2.7 5.02345
+      vertex 13.6582 -2.7 5.02345
+      vertex 13.3504 -2.7 5.18031
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.0247 -2.7 4.88623
+      vertex 13.6582 -2.7 5.02345
+      vertex 18.3418 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 18.0247 -2.7 4.88623
+      vertex 13.9753 -2.7 4.88623
+      vertex 13.6582 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 17.6996 -2.7 4.76919
+      vertex 13.9753 -2.7 4.88623
+      vertex 18.0247 -2.7 4.88623
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.6996 -2.7 4.76919
+      vertex 14.3004 -2.7 4.76919
+      vertex 13.9753 -2.7 4.88623
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 17.3678 -2.7 4.67279
+      vertex 14.3004 -2.7 4.76919
+      vertex 17.6996 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.3678 -2.7 4.67279
+      vertex 14.6322 -2.7 4.67279
+      vertex 14.3004 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 17.0306 -2.7 4.59742
+      vertex 14.6322 -2.7 4.67279
+      vertex 17.3678 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.0306 -2.7 4.59742
+      vertex 14.9694 -2.7 4.59742
+      vertex 14.6322 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 16.6893 -2.7 4.54337
+      vertex 14.9694 -2.7 4.59742
+      vertex 17.0306 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 16.6893 -2.7 4.54337
+      vertex 15.3107 -2.7 4.54337
+      vertex 14.9694 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 16.3453 -2.7 4.51085
+      vertex 15.3107 -2.7 4.54337
+      vertex 16.6893 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 16.3453 -2.7 4.51085
+      vertex 15.6547 -2.7 4.51085
+      vertex 15.3107 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal -0 1 0
+    outer loop
+      vertex 15.6547 -2.7 4.51085
+      vertex 16.3453 -2.7 4.51085
+      vertex 16 -2.7 4.5
+    endloop
+  endfacet
+  facet normal 0.995566 -0 0.0940633
+    outer loop
+      vertex 10.5109 -2.7 9.65465
+      vertex 10.5434 0 9.31067
+      vertex 10.5109 0 9.65465
+    endloop
+  endfacet
+  facet normal 0.995566 0 0.0940633
+    outer loop
+      vertex 10.5434 0 9.31067
+      vertex 10.5109 -2.7 9.65465
+      vertex 10.5434 -2.7 9.31067
+    endloop
+  endfacet
+  facet normal 0.999502 -0 0.0315465
+    outer loop
+      vertex 10.5 -2.7 10
+      vertex 10.5109 0 9.65465
+      vertex 10.5 0 10
+    endloop
+  endfacet
+  facet normal 0.999502 0 0.0315465
+    outer loop
+      vertex 10.5109 0 9.65465
+      vertex 10.5 -2.7 10
+      vertex 10.5109 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal -0.82712 0 -0.562025
+    outer loop
+      vertex 20.6438 -2.7 12.947
+      vertex 20.4496 0 13.2328
+      vertex 20.6438 0 12.947
+    endloop
+  endfacet
+  facet normal -0.82712 -0 -0.562025
+    outer loop
+      vertex 20.4496 0 13.2328
+      vertex 20.6438 -2.7 12.947
+      vertex 20.4496 -2.7 13.2328
+    endloop
+  endfacet
+  facet normal 0.279 0 -0.960291
+    outer loop
+      vertex 14.3004 -2.7 15.2308
+      vertex 14.6322 0 15.3272
+      vertex 14.6322 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal 0.279 0 -0.960291
+    outer loop
+      vertex 14.6322 0 15.3272
+      vertex 14.3004 -2.7 15.2308
+      vertex 14.3004 0 15.2308
+    endloop
+  endfacet
+  facet normal 0.397144 0 0.917756
+    outer loop
+      vertex 13.6582 0 5.02345
+      vertex 13.9753 -2.7 4.88623
+      vertex 13.9753 0 4.88623
+    endloop
+  endfacet
+  facet normal 0.397144 0 0.917756
+    outer loop
+      vertex 13.9753 -2.7 4.88623
+      vertex 13.6582 0 5.02345
+      vertex 13.6582 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal -0.279 0 0.960291
+    outer loop
+      vertex 17.3678 0 4.67279
+      vertex 17.6996 -2.7 4.76919
+      vertex 17.6996 0 4.76919
+    endloop
+  endfacet
+  facet normal -0.279 0 0.960291
+    outer loop
+      vertex 17.6996 -2.7 4.76919
+      vertex 17.3678 0 4.67279
+      vertex 17.3678 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal 0.960291 -0 0.279
+    outer loop
+      vertex 10.6728 -2.7 8.63221
+      vertex 10.7692 0 8.30041
+      vertex 10.6728 0 8.63221
+    endloop
+  endfacet
+  facet normal 0.960291 0 0.279
+    outer loop
+      vertex 10.7692 0 8.30041
+      vertex 10.6728 -2.7 8.63221
+      vertex 10.7692 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal 0.0314065 0 0.999507
+    outer loop
+      vertex 15.6547 0 4.51085
+      vertex 16 -2.7 4.5
+      vertex 16 0 4.5
+    endloop
+  endfacet
+  facet normal 0.0314065 0 0.999507
+    outer loop
+      vertex 16 -2.7 4.5
+      vertex 15.6547 0 4.51085
+      vertex 15.6547 -2.7 4.51085
+    endloop
+  endfacet
+  facet normal 0.218217 0 -0.9759
+    outer loop
+      vertex 14.6322 -2.7 15.3272
+      vertex 14.9694 0 15.4026
+      vertex 14.9694 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal 0.218217 0 -0.9759
+    outer loop
+      vertex 14.9694 0 15.4026
+      vertex 14.6322 -2.7 15.3272
+      vertex 14.6322 0 15.3272
+    endloop
+  endfacet
+  facet normal -0.509059 0 0.860732
+    outer loop
+      vertex 18.6496 0 5.18031
+      vertex 18.947 -2.7 5.3562
+      vertex 18.947 0 5.3562
+    endloop
+  endfacet
+  facet normal -0.509059 0 0.860732
+    outer loop
+      vertex 18.947 -2.7 5.3562
+      vertex 18.6496 0 5.18031
+      vertex 18.6496 -2.7 5.18031
+    endloop
+  endfacet
+  facet normal 0.707107 0 -0.707107
+    outer loop
+      vertex 12.235 -2.7 14.0093
+      vertex 11.9907 0 13.765
+      vertex 12.235 0 14.0093
+    endloop
+  endfacet
+  facet normal 0.707107 0 -0.707107
+    outer loop
+      vertex 11.9907 0 13.765
+      vertex 12.235 -2.7 14.0093
+      vertex 11.9907 -2.7 13.765
+    endloop
+  endfacet
+  facet normal -0.975899 0 0.218223
+    outer loop
+      vertex 21.3272 -2.7 8.63221
+      vertex 21.4026 0 8.9694
+      vertex 21.3272 0 8.63221
+    endloop
+  endfacet
+  facet normal -0.975899 0 0.218223
+    outer loop
+      vertex 21.4026 0 8.9694
+      vertex 21.3272 -2.7 8.63221
+      vertex 21.4026 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal -0.750133 0 -0.661287
+    outer loop
+      vertex 20.2378 -2.7 13.5058
+      vertex 20.0093 0 13.765
+      vertex 20.2378 0 13.5058
+    endloop
+  endfacet
+  facet normal -0.750133 -0 -0.661287
+    outer loop
+      vertex 20.0093 0 13.765
+      vertex 20.2378 -2.7 13.5058
+      vertex 20.0093 -2.7 13.765
+    endloop
+  endfacet
+  facet normal -0.995566 0 0.0940633
+    outer loop
+      vertex 21.4566 -2.7 9.31067
+      vertex 21.4891 0 9.65465
+      vertex 21.4566 0 9.31067
+    endloop
+  endfacet
+  facet normal -0.995566 0 0.0940633
+    outer loop
+      vertex 21.4891 0 9.65465
+      vertex 21.4566 -2.7 9.31067
+      vertex 21.4891 -2.7 9.65465
+    endloop
+  endfacet
+  facet normal 0.860727 -0 0.509068
+    outer loop
+      vertex 11.1803 -2.7 7.35036
+      vertex 11.3562 0 7.05295
+      vertex 11.1803 0 7.35036
+    endloop
+  endfacet
+  facet normal 0.860727 0 0.509068
+    outer loop
+      vertex 11.3562 0 7.05295
+      vertex 11.1803 -2.7 7.35036
+      vertex 11.3562 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal 0.612924 0 0.790142
+    outer loop
+      vertex 12.4942 0 5.76218
+      vertex 12.7672 -2.7 5.55041
+      vertex 12.7672 0 5.55041
+    endloop
+  endfacet
+  facet normal 0.612924 0 0.790142
+    outer loop
+      vertex 12.7672 -2.7 5.55041
+      vertex 12.4942 0 5.76218
+      vertex 12.4942 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal 0.453917 0 -0.891044
+    outer loop
+      vertex 13.3504 -2.7 14.8197
+      vertex 13.6582 0 14.9765
+      vertex 13.6582 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal 0.453917 0 -0.891044
+    outer loop
+      vertex 13.6582 0 14.9765
+      vertex 13.3504 -2.7 14.8197
+      vertex 13.3504 0 14.8197
+    endloop
+  endfacet
+  facet normal -0.790111 0 0.612964
+    outer loop
+      vertex 20.2378 -2.7 6.49417
+      vertex 20.4496 0 6.76718
+      vertex 20.2378 0 6.49417
+    endloop
+  endfacet
+  facet normal -0.790111 0 0.612964
+    outer loop
+      vertex 20.4496 0 6.76718
+      vertex 20.2378 -2.7 6.49417
+      vertex 20.4496 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal 0.917672 0 -0.397339
+    outer loop
+      vertex 11.0235 -2.7 12.3418
+      vertex 10.8862 0 12.0247
+      vertex 11.0235 0 12.3418
+    endloop
+  endfacet
+  facet normal 0.917672 0 -0.397339
+    outer loop
+      vertex 10.8862 0 12.0247
+      vertex 11.0235 -2.7 12.3418
+      vertex 10.8862 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal -0.891074 0 0.453859
+    outer loop
+      vertex 20.8197 -2.7 7.35036
+      vertex 20.9765 0 7.65821
+      vertex 20.8197 0 7.35036
+    endloop
+  endfacet
+  facet normal -0.891074 0 0.453859
+    outer loop
+      vertex 20.9765 0 7.65821
+      vertex 20.8197 -2.7 7.35036
+      vertex 20.9765 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0.891074 -0 0.453859
+    outer loop
+      vertex 11.0235 -2.7 7.65821
+      vertex 11.1803 0 7.35036
+      vertex 11.0235 0 7.65821
+    endloop
+  endfacet
+  facet normal 0.891074 0 0.453859
+    outer loop
+      vertex 11.1803 0 7.35036
+      vertex 11.0235 -2.7 7.65821
+      vertex 11.1803 -2.7 7.35036
+    endloop
+  endfacet
+  facet normal 0.156275 0 -0.987714
+    outer loop
+      vertex 14.9694 -2.7 15.4026
+      vertex 15.3107 0 15.4566
+      vertex 15.3107 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal 0.156275 0 -0.987714
+    outer loop
+      vertex 15.3107 0 15.4566
+      vertex 14.9694 -2.7 15.4026
+      vertex 14.9694 0 15.4026
+    endloop
+  endfacet
+  facet normal 0.397339 0 -0.917672
+    outer loop
+      vertex 13.6582 -2.7 14.9765
+      vertex 13.9753 0 15.1138
+      vertex 13.9753 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal 0.397339 0 -0.917672
+    outer loop
+      vertex 13.9753 0 15.1138
+      vertex 13.6582 -2.7 14.9765
+      vertex 13.6582 0 14.9765
+    endloop
+  endfacet
+  facet normal 0.509059 0 0.860732
+    outer loop
+      vertex 13.053 0 5.3562
+      vertex 13.3504 -2.7 5.18031
+      vertex 13.3504 0 5.18031
+    endloop
+  endfacet
+  facet normal 0.509059 0 0.860732
+    outer loop
+      vertex 13.3504 -2.7 5.18031
+      vertex 13.053 0 5.3562
+      vertex 13.053 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal -0.218135 0 0.975919
+    outer loop
+      vertex 17.0306 0 4.59742
+      vertex 17.3678 -2.7 4.67279
+      vertex 17.3678 0 4.67279
+    endloop
+  endfacet
+  facet normal -0.218135 0 0.975919
+    outer loop
+      vertex 17.3678 -2.7 4.67279
+      vertex 17.0306 0 4.59742
+      vertex 17.0306 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal 0.987712 -0 0.156288
+    outer loop
+      vertex 10.5434 -2.7 9.31067
+      vertex 10.5974 0 8.9694
+      vertex 10.5434 0 9.31067
+    endloop
+  endfacet
+  facet normal 0.987712 0 0.156288
+    outer loop
+      vertex 10.5974 0 8.9694
+      vertex 10.5434 -2.7 9.31067
+      vertex 10.5974 -2.7 8.9694
+    endloop
+  endfacet
+  facet normal -0.397144 0 0.917756
+    outer loop
+      vertex 18.0247 0 4.88623
+      vertex 18.3418 -2.7 5.02345
+      vertex 18.3418 0 5.02345
+    endloop
+  endfacet
+  facet normal -0.397144 0 0.917756
+    outer loop
+      vertex 18.3418 -2.7 5.02345
+      vertex 18.0247 0 4.88623
+      vertex 18.0247 -2.7 4.88623
+    endloop
+  endfacet
+  facet normal -0.453917 0 -0.891044
+    outer loop
+      vertex 18.3418 -2.7 14.9765
+      vertex 18.6496 0 14.8197
+      vertex 18.6496 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal -0.453917 0 -0.891044
+    outer loop
+      vertex 18.6496 0 14.8197
+      vertex 18.3418 -2.7 14.9765
+      vertex 18.3418 0 14.9765
+    endloop
+  endfacet
+  facet normal 0.917676 -0 0.397329
+    outer loop
+      vertex 10.8862 -2.7 7.97532
+      vertex 11.0235 0 7.65821
+      vertex 10.8862 0 7.97532
+    endloop
+  endfacet
+  facet normal 0.917676 0 0.397329
+    outer loop
+      vertex 11.0235 0 7.65821
+      vertex 10.8862 -2.7 7.97532
+      vertex 11.0235 -2.7 7.65821
+    endloop
+  endfacet
+  facet normal 0.661287 0 -0.750133
+    outer loop
+      vertex 12.235 -2.7 14.0093
+      vertex 12.4942 0 14.2378
+      vertex 12.4942 -2.7 14.2378
+    endloop
+  endfacet
+  facet normal 0.661287 0 -0.750133
+    outer loop
+      vertex 12.4942 0 14.2378
+      vertex 12.235 -2.7 14.0093
+      vertex 12.235 0 14.0093
+    endloop
+  endfacet
+  facet normal -0.156416 0 0.987691
+    outer loop
+      vertex 16.6893 0 4.54337
+      vertex 17.0306 -2.7 4.59742
+      vertex 17.0306 0 4.59742
+    endloop
+  endfacet
+  facet normal -0.156416 0 0.987691
+    outer loop
+      vertex 17.0306 -2.7 4.59742
+      vertex 16.6893 0 4.54337
+      vertex 16.6893 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal -0.999502 0 0.0315465
+    outer loop
+      vertex 21.4891 -2.7 9.65465
+      vertex 21.5 0 10
+      vertex 21.4891 0 9.65465
+    endloop
+  endfacet
+  facet normal -0.999502 0 0.0315465
+    outer loop
+      vertex 21.5 0 10
+      vertex 21.4891 -2.7 9.65465
+      vertex 21.5 -2.7 10
+    endloop
+  endfacet
+  facet normal 0.031551 0 -0.999502
+    outer loop
+      vertex 15.6547 -2.7 15.4891
+      vertex 16 0 15.5
+      vertex 16 -2.7 15.5
+    endloop
+  endfacet
+  facet normal 0.031551 0 -0.999502
+    outer loop
+      vertex 16 0 15.5
+      vertex 15.6547 -2.7 15.4891
+      vertex 15.6547 0 15.4891
+    endloop
+  endfacet
+  facet normal 0.0940579 0 -0.995567
+    outer loop
+      vertex 15.3107 -2.7 15.4566
+      vertex 15.6547 0 15.4891
+      vertex 15.6547 -2.7 15.4891
+    endloop
+  endfacet
+  facet normal 0.0940579 0 -0.995567
+    outer loop
+      vertex 15.6547 0 15.4891
+      vertex 15.3107 -2.7 15.4566
+      vertex 15.3107 0 15.4566
+    endloop
+  endfacet
+  facet normal 0.66127 0 0.750148
+    outer loop
+      vertex 12.235 0 5.99067
+      vertex 12.4942 -2.7 5.76218
+      vertex 12.4942 0 5.76218
+    endloop
+  endfacet
+  facet normal 0.66127 0 0.750148
+    outer loop
+      vertex 12.4942 -2.7 5.76218
+      vertex 12.235 0 5.99067
+      vertex 12.235 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal 0.827093 -0 0.562065
+    outer loop
+      vertex 11.3562 -2.7 7.05295
+      vertex 11.5504 0 6.76718
+      vertex 11.3562 0 7.05295
+    endloop
+  endfacet
+  facet normal 0.827093 0 0.562065
+    outer loop
+      vertex 11.5504 0 6.76718
+      vertex 11.3562 -2.7 7.05295
+      vertex 11.5504 -2.7 6.76718
+    endloop
+  endfacet
+  facet normal 0.995567 0 -0.0940579
+    outer loop
+      vertex 10.5434 -2.7 10.6893
+      vertex 10.5109 0 10.3453
+      vertex 10.5434 0 10.6893
+    endloop
+  endfacet
+  facet normal 0.995567 0 -0.0940579
+    outer loop
+      vertex 10.5109 0 10.3453
+      vertex 10.5434 -2.7 10.6893
+      vertex 10.5109 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal 0.218135 0 0.975919
+    outer loop
+      vertex 14.6322 0 4.67279
+      vertex 14.9694 -2.7 4.59742
+      vertex 14.9694 0 4.59742
+    endloop
+  endfacet
+  facet normal 0.218135 0 0.975919
+    outer loop
+      vertex 14.9694 -2.7 4.59742
+      vertex 14.6322 0 4.67279
+      vertex 14.6322 -2.7 4.67279
+    endloop
+  endfacet
+  facet normal 0.82712 0 -0.562025
+    outer loop
+      vertex 11.5504 -2.7 13.2328
+      vertex 11.3562 0 12.947
+      vertex 11.5504 0 13.2328
+    endloop
+  endfacet
+  facet normal 0.82712 0 -0.562025
+    outer loop
+      vertex 11.3562 0 12.947
+      vertex 11.5504 -2.7 13.2328
+      vertex 11.3562 -2.7 12.947
+    endloop
+  endfacet
+  facet normal 0.750133 0 -0.661287
+    outer loop
+      vertex 11.9907 -2.7 13.765
+      vertex 11.7622 0 13.5058
+      vertex 11.9907 0 13.765
+    endloop
+  endfacet
+  facet normal 0.750133 0 -0.661287
+    outer loop
+      vertex 11.7622 0 13.5058
+      vertex 11.9907 -2.7 13.765
+      vertex 11.7622 -2.7 13.5058
+    endloop
+  endfacet
+  facet normal -0.9759 0 -0.218217
+    outer loop
+      vertex 21.4026 -2.7 11.0306
+      vertex 21.3272 0 11.3678
+      vertex 21.4026 0 11.0306
+    endloop
+  endfacet
+  facet normal -0.9759 -0 -0.218217
+    outer loop
+      vertex 21.3272 0 11.3678
+      vertex 21.4026 -2.7 11.0306
+      vertex 21.3272 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal 0.987714 0 -0.156275
+    outer loop
+      vertex 10.5974 -2.7 11.0306
+      vertex 10.5434 0 10.6893
+      vertex 10.5974 0 11.0306
+    endloop
+  endfacet
+  facet normal 0.987714 0 -0.156275
+    outer loop
+      vertex 10.5434 0 10.6893
+      vertex 10.5974 -2.7 11.0306
+      vertex 10.5434 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal 0.0941153 0 0.995561
+    outer loop
+      vertex 15.3107 0 4.54337
+      vertex 15.6547 -2.7 4.51085
+      vertex 15.6547 0 4.51085
+    endloop
+  endfacet
+  facet normal 0.0941153 0 0.995561
+    outer loop
+      vertex 15.6547 -2.7 4.51085
+      vertex 15.3107 0 4.54337
+      vertex 15.3107 -2.7 4.54337
+    endloop
+  endfacet
+  facet normal 0.9759 0 -0.218217
+    outer loop
+      vertex 10.6728 -2.7 11.3678
+      vertex 10.5974 0 11.0306
+      vertex 10.6728 0 11.3678
+    endloop
+  endfacet
+  facet normal 0.9759 0 -0.218217
+    outer loop
+      vertex 10.5974 0 11.0306
+      vertex 10.6728 -2.7 11.3678
+      vertex 10.5974 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal -0.031551 0 -0.999502
+    outer loop
+      vertex 16 -2.7 15.5
+      vertex 16.3453 0 15.4891
+      vertex 16.3453 -2.7 15.4891
+    endloop
+  endfacet
+  facet normal -0.031551 0 -0.999502
+    outer loop
+      vertex 16.3453 0 15.4891
+      vertex 16 -2.7 15.5
+      vertex 16 0 15.5
+    endloop
+  endfacet
+  facet normal -0.917672 0 -0.397339
+    outer loop
+      vertex 21.1138 -2.7 12.0247
+      vertex 20.9765 0 12.3418
+      vertex 21.1138 0 12.0247
+    endloop
+  endfacet
+  facet normal -0.917672 -0 -0.397339
+    outer loop
+      vertex 20.9765 0 12.3418
+      vertex 21.1138 -2.7 12.0247
+      vertex 20.9765 -2.7 12.3418
+    endloop
+  endfacet
+  facet normal -0.66127 0 0.750148
+    outer loop
+      vertex 19.5058 0 5.76218
+      vertex 19.765 -2.7 5.99067
+      vertex 19.765 0 5.99067
+    endloop
+  endfacet
+  facet normal -0.66127 0 0.750148
+    outer loop
+      vertex 19.765 -2.7 5.99067
+      vertex 19.5058 0 5.76218
+      vertex 19.5058 -2.7 5.76218
+    endloop
+  endfacet
+  facet normal -0.612978 0 -0.7901
+    outer loop
+      vertex 19.2328 -2.7 14.4496
+      vertex 19.5058 0 14.2378
+      vertex 19.5058 -2.7 14.2378
+    endloop
+  endfacet
+  facet normal -0.612978 0 -0.7901
+    outer loop
+      vertex 19.5058 0 14.2378
+      vertex 19.2328 -2.7 14.4496
+      vertex 19.2328 0 14.4496
+    endloop
+  endfacet
+  facet normal 0.750108 -0 0.661315
+    outer loop
+      vertex 11.7622 -2.7 6.49417
+      vertex 11.9907 0 6.23499
+      vertex 11.7622 0 6.49417
+    endloop
+  endfacet
+  facet normal 0.750108 0 0.661315
+    outer loop
+      vertex 11.9907 0 6.23499
+      vertex 11.7622 -2.7 6.49417
+      vertex 11.9907 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal 0.940921 0 -0.338627
+    outer loop
+      vertex 10.8862 -2.7 12.0247
+      vertex 10.7692 0 11.6996
+      vertex 10.8862 0 12.0247
+    endloop
+  endfacet
+  facet normal 0.940921 0 -0.338627
+    outer loop
+      vertex 10.7692 0 11.6996
+      vertex 10.8862 -2.7 12.0247
+      vertex 10.7692 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal 0.999502 0 -0.031551
+    outer loop
+      vertex 10.5109 -2.7 10.3453
+      vertex 10.5 0 10
+      vertex 10.5109 0 10.3453
+    endloop
+  endfacet
+  facet normal 0.999502 0 -0.031551
+    outer loop
+      vertex 10.5 0 10
+      vertex 10.5109 -2.7 10.3453
+      vertex 10.5 -2.7 10
+    endloop
+  endfacet
+  facet normal 0.960291 0 -0.279
+    outer loop
+      vertex 10.7692 -2.7 11.6996
+      vertex 10.6728 0 11.3678
+      vertex 10.7692 0 11.6996
+    endloop
+  endfacet
+  facet normal 0.960291 0 -0.279
+    outer loop
+      vertex 10.6728 0 11.3678
+      vertex 10.7692 -2.7 11.6996
+      vertex 10.6728 -2.7 11.3678
+    endloop
+  endfacet
+  facet normal 0.860719 0 -0.50908
+    outer loop
+      vertex 11.3562 -2.7 12.947
+      vertex 11.1803 0 12.6496
+      vertex 11.3562 0 12.947
+    endloop
+  endfacet
+  facet normal 0.860719 0 -0.50908
+    outer loop
+      vertex 11.1803 0 12.6496
+      vertex 11.3562 -2.7 12.947
+      vertex 11.1803 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal 0.33873 0 0.940884
+    outer loop
+      vertex 13.9753 0 4.88623
+      vertex 14.3004 -2.7 4.76919
+      vertex 14.3004 0 4.76919
+    endloop
+  endfacet
+  facet normal 0.33873 0 0.940884
+    outer loop
+      vertex 14.3004 -2.7 4.76919
+      vertex 13.9753 0 4.88623
+      vertex 13.9753 -2.7 4.88623
+    endloop
+  endfacet
+  facet normal 0.7901 0 -0.612978
+    outer loop
+      vertex 11.7622 -2.7 13.5058
+      vertex 11.5504 0 13.2328
+      vertex 11.7622 0 13.5058
+    endloop
+  endfacet
+  facet normal 0.7901 0 -0.612978
+    outer loop
+      vertex 11.5504 0 13.2328
+      vertex 11.7622 -2.7 13.5058
+      vertex 11.5504 -2.7 13.2328
+    endloop
+  endfacet
+  facet normal -0.827093 0 0.562065
+    outer loop
+      vertex 20.4496 -2.7 6.76718
+      vertex 20.6438 0 7.05295
+      vertex 20.4496 0 6.76718
+    endloop
+  endfacet
+  facet normal -0.827093 0 0.562065
+    outer loop
+      vertex 20.6438 0 7.05295
+      vertex 20.4496 -2.7 6.76718
+      vertex 20.6438 -2.7 7.05295
+    endloop
+  endfacet
+  facet normal -0.960291 0 -0.279
+    outer loop
+      vertex 21.3272 -2.7 11.3678
+      vertex 21.2308 0 11.6996
+      vertex 21.3272 0 11.3678
+    endloop
+  endfacet
+  facet normal -0.960291 -0 -0.279
+    outer loop
+      vertex 21.2308 0 11.6996
+      vertex 21.3272 -2.7 11.3678
+      vertex 21.2308 -2.7 11.6996
+    endloop
+  endfacet
+  facet normal -0.707136 0 0.707078
+    outer loop
+      vertex 19.765 -2.7 5.99067
+      vertex 20.0093 0 6.23499
+      vertex 19.765 0 5.99067
+    endloop
+  endfacet
+  facet normal -0.707136 0 0.707078
+    outer loop
+      vertex 20.0093 0 6.23499
+      vertex 19.765 -2.7 5.99067
+      vertex 20.0093 -2.7 6.23499
+    endloop
+  endfacet
+  facet normal -0.612924 0 0.790142
+    outer loop
+      vertex 19.2328 0 5.55041
+      vertex 19.5058 -2.7 5.76218
+      vertex 19.5058 0 5.76218
+    endloop
+  endfacet
+  facet normal -0.612924 0 0.790142
+    outer loop
+      vertex 19.5058 -2.7 5.76218
+      vertex 19.2328 0 5.55041
+      vertex 19.2328 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal -0.860727 0 0.509068
+    outer loop
+      vertex 20.6438 -2.7 7.05295
+      vertex 20.8197 0 7.35036
+      vertex 20.6438 0 7.05295
+    endloop
+  endfacet
+  facet normal -0.860727 0 0.509068
+    outer loop
+      vertex 20.8197 0 7.35036
+      vertex 20.6438 -2.7 7.05295
+      vertex 20.8197 -2.7 7.35036
+    endloop
+  endfacet
+  facet normal 0.975899 -0 0.218223
+    outer loop
+      vertex 10.5974 -2.7 8.9694
+      vertex 10.6728 0 8.63221
+      vertex 10.5974 0 8.9694
+    endloop
+  endfacet
+  facet normal 0.975899 0 0.218223
+    outer loop
+      vertex 10.6728 0 8.63221
+      vertex 10.5974 -2.7 8.9694
+      vertex 10.6728 -2.7 8.63221
+    endloop
+  endfacet
+  facet normal -0.0941153 0 0.995561
+    outer loop
+      vertex 16.3453 0 4.51085
+      vertex 16.6893 -2.7 4.54337
+      vertex 16.6893 0 4.54337
+    endloop
+  endfacet
+  facet normal -0.0941153 0 0.995561
+    outer loop
+      vertex 16.6893 -2.7 4.54337
+      vertex 16.3453 0 4.51085
+      vertex 16.3453 -2.7 4.51085
+    endloop
+  endfacet
+  facet normal -0.940921 0 -0.338627
+    outer loop
+      vertex 21.2308 -2.7 11.6996
+      vertex 21.1138 0 12.0247
+      vertex 21.2308 0 11.6996
+    endloop
+  endfacet
+  facet normal -0.940921 -0 -0.338627
+    outer loop
+      vertex 21.1138 0 12.0247
+      vertex 21.2308 -2.7 11.6996
+      vertex 21.1138 -2.7 12.0247
+    endloop
+  endfacet
+  facet normal -0.0314065 0 0.999507
+    outer loop
+      vertex 16 0 4.5
+      vertex 16.3453 -2.7 4.51085
+      vertex 16.3453 0 4.51085
+    endloop
+  endfacet
+  facet normal -0.0314065 0 0.999507
+    outer loop
+      vertex 16.3453 -2.7 4.51085
+      vertex 16 0 4.5
+      vertex 16 -2.7 4.5
+    endloop
+  endfacet
+  facet normal 0.338627 0 -0.940921
+    outer loop
+      vertex 13.9753 -2.7 15.1138
+      vertex 14.3004 0 15.2308
+      vertex 14.3004 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal 0.338627 0 -0.940921
+    outer loop
+      vertex 14.3004 0 15.2308
+      vertex 13.9753 -2.7 15.1138
+      vertex 13.9753 0 15.1138
+    endloop
+  endfacet
+  facet normal 0.156416 0 0.987691
+    outer loop
+      vertex 14.9694 0 4.59742
+      vertex 15.3107 -2.7 4.54337
+      vertex 15.3107 0 4.54337
+    endloop
+  endfacet
+  facet normal 0.156416 0 0.987691
+    outer loop
+      vertex 15.3107 -2.7 4.54337
+      vertex 14.9694 0 4.59742
+      vertex 14.9694 -2.7 4.59742
+    endloop
+  endfacet
+  facet normal 0.454055 0 0.890974
+    outer loop
+      vertex 13.3504 0 5.18031
+      vertex 13.6582 -2.7 5.02345
+      vertex 13.6582 0 5.02345
+    endloop
+  endfacet
+  facet normal 0.454055 0 0.890974
+    outer loop
+      vertex 13.6582 -2.7 5.02345
+      vertex 13.3504 0 5.18031
+      vertex 13.3504 -2.7 5.18031
+    endloop
+  endfacet
+  facet normal 0.50908 0 -0.860719
+    outer loop
+      vertex 13.053 -2.7 14.6438
+      vertex 13.3504 0 14.8197
+      vertex 13.3504 -2.7 14.8197
+    endloop
+  endfacet
+  facet normal 0.50908 0 -0.860719
+    outer loop
+      vertex 13.3504 0 14.8197
+      vertex 13.053 -2.7 14.6438
+      vertex 13.053 0 14.6438
+    endloop
+  endfacet
+  facet normal -0.279 0 -0.960291
+    outer loop
+      vertex 17.3678 -2.7 15.3272
+      vertex 17.6996 0 15.2308
+      vertex 17.6996 -2.7 15.2308
+    endloop
+  endfacet
+  facet normal -0.279 0 -0.960291
+    outer loop
+      vertex 17.6996 0 15.2308
+      vertex 17.3678 -2.7 15.3272
+      vertex 17.3678 0 15.3272
+    endloop
+  endfacet
+  facet normal -0.750108 0 0.661315
+    outer loop
+      vertex 20.0093 -2.7 6.23499
+      vertex 20.2378 0 6.49417
+      vertex 20.0093 0 6.23499
+    endloop
+  endfacet
+  facet normal -0.750108 0 0.661315
+    outer loop
+      vertex 20.2378 0 6.49417
+      vertex 20.0093 -2.7 6.23499
+      vertex 20.2378 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal 0.562045 0 0.827107
+    outer loop
+      vertex 12.7672 0 5.55041
+      vertex 13.053 -2.7 5.3562
+      vertex 13.053 0 5.3562
+    endloop
+  endfacet
+  facet normal 0.562045 0 0.827107
+    outer loop
+      vertex 13.053 -2.7 5.3562
+      vertex 12.7672 0 5.55041
+      vertex 12.7672 -2.7 5.55041
+    endloop
+  endfacet
+  facet normal 0.790111 -0 0.612964
+    outer loop
+      vertex 11.5504 -2.7 6.76718
+      vertex 11.7622 0 6.49417
+      vertex 11.5504 0 6.76718
+    endloop
+  endfacet
+  facet normal 0.790111 0 0.612964
+    outer loop
+      vertex 11.7622 0 6.49417
+      vertex 11.5504 -2.7 6.76718
+      vertex 11.7622 -2.7 6.49417
+    endloop
+  endfacet
+  facet normal -0.860719 0 -0.50908
+    outer loop
+      vertex 20.8197 -2.7 12.6496
+      vertex 20.6438 0 12.947
+      vertex 20.8197 0 12.6496
+    endloop
+  endfacet
+  facet normal -0.860719 -0 -0.50908
+    outer loop
+      vertex 20.6438 0 12.947
+      vertex 20.8197 -2.7 12.6496
+      vertex 20.6438 -2.7 12.947
+    endloop
+  endfacet
+  facet normal 0.940917 -0 0.338636
+    outer loop
+      vertex 10.7692 -2.7 8.30041
+      vertex 10.8862 0 7.97532
+      vertex 10.7692 0 8.30041
+    endloop
+  endfacet
+  facet normal 0.940917 0 0.338636
+    outer loop
+      vertex 10.8862 0 7.97532
+      vertex 10.7692 -2.7 8.30041
+      vertex 10.8862 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal -0.707107 0 -0.707107
+    outer loop
+      vertex 20.0093 -2.7 13.765
+      vertex 19.765 0 14.0093
+      vertex 20.0093 0 13.765
+    endloop
+  endfacet
+  facet normal -0.707107 -0 -0.707107
+    outer loop
+      vertex 19.765 0 14.0093
+      vertex 20.0093 -2.7 13.765
+      vertex 19.765 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal 0.707136 -0 0.707078
+    outer loop
+      vertex 11.9907 -2.7 6.23499
+      vertex 12.235 0 5.99067
+      vertex 11.9907 0 6.23499
+    endloop
+  endfacet
+  facet normal 0.707136 0 0.707078
+    outer loop
+      vertex 12.235 0 5.99067
+      vertex 11.9907 -2.7 6.23499
+      vertex 12.235 -2.7 5.99067
+    endloop
+  endfacet
+  facet normal 0.891044 0 -0.453917
+    outer loop
+      vertex 11.1803 -2.7 12.6496
+      vertex 11.0235 0 12.3418
+      vertex 11.1803 0 12.6496
+    endloop
+  endfacet
+  facet normal 0.891044 0 -0.453917
+    outer loop
+      vertex 11.0235 0 12.3418
+      vertex 11.1803 -2.7 12.6496
+      vertex 11.0235 -2.7 12.3418
+    endloop
+  endfacet
+  facet normal -0.33873 0 0.940884
+    outer loop
+      vertex 17.6996 0 4.76919
+      vertex 18.0247 -2.7 4.88623
+      vertex 18.0247 0 4.88623
+    endloop
+  endfacet
+  facet normal -0.33873 0 0.940884
+    outer loop
+      vertex 18.0247 -2.7 4.88623
+      vertex 17.6996 0 4.76919
+      vertex 17.6996 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal -0.987712 0 0.156288
+    outer loop
+      vertex 21.4026 -2.7 8.9694
+      vertex 21.4566 0 9.31067
+      vertex 21.4026 0 8.9694
+    endloop
+  endfacet
+  facet normal -0.987712 0 0.156288
+    outer loop
+      vertex 21.4566 0 9.31067
+      vertex 21.4026 -2.7 8.9694
+      vertex 21.4566 -2.7 9.31067
+    endloop
+  endfacet
+  facet normal -0.0940579 0 -0.995567
+    outer loop
+      vertex 16.3453 -2.7 15.4891
+      vertex 16.6893 0 15.4566
+      vertex 16.6893 -2.7 15.4566
+    endloop
+  endfacet
+  facet normal -0.0940579 0 -0.995567
+    outer loop
+      vertex 16.6893 0 15.4566
+      vertex 16.3453 -2.7 15.4891
+      vertex 16.3453 0 15.4891
+    endloop
+  endfacet
+  facet normal -0.454055 0 0.890974
+    outer loop
+      vertex 18.3418 0 5.02345
+      vertex 18.6496 -2.7 5.18031
+      vertex 18.6496 0 5.18031
+    endloop
+  endfacet
+  facet normal -0.454055 0 0.890974
+    outer loop
+      vertex 18.6496 -2.7 5.18031
+      vertex 18.3418 0 5.02345
+      vertex 18.3418 -2.7 5.02345
+    endloop
+  endfacet
+  facet normal -0.338627 0 -0.940921
+    outer loop
+      vertex 17.6996 -2.7 15.2308
+      vertex 18.0247 0 15.1138
+      vertex 18.0247 -2.7 15.1138
+    endloop
+  endfacet
+  facet normal -0.338627 0 -0.940921
+    outer loop
+      vertex 18.0247 0 15.1138
+      vertex 17.6996 -2.7 15.2308
+      vertex 17.6996 0 15.2308
+    endloop
+  endfacet
+  facet normal -0.999502 0 -0.031551
+    outer loop
+      vertex 21.5 -2.7 10
+      vertex 21.4891 0 10.3453
+      vertex 21.5 0 10
+    endloop
+  endfacet
+  facet normal -0.999502 -0 -0.031551
+    outer loop
+      vertex 21.4891 0 10.3453
+      vertex 21.5 -2.7 10
+      vertex 21.4891 -2.7 10.3453
+    endloop
+  endfacet
+  facet normal -0.891044 0 -0.453917
+    outer loop
+      vertex 20.9765 -2.7 12.3418
+      vertex 20.8197 0 12.6496
+      vertex 20.9765 0 12.3418
+    endloop
+  endfacet
+  facet normal -0.891044 -0 -0.453917
+    outer loop
+      vertex 20.8197 0 12.6496
+      vertex 20.9765 -2.7 12.3418
+      vertex 20.8197 -2.7 12.6496
+    endloop
+  endfacet
+  facet normal -0.661287 0 -0.750133
+    outer loop
+      vertex 19.5058 -2.7 14.2378
+      vertex 19.765 0 14.0093
+      vertex 19.765 -2.7 14.0093
+    endloop
+  endfacet
+  facet normal -0.661287 0 -0.750133
+    outer loop
+      vertex 19.765 0 14.0093
+      vertex 19.5058 -2.7 14.2378
+      vertex 19.5058 0 14.2378
+    endloop
+  endfacet
+  facet normal -0.995567 0 -0.0940579
+    outer loop
+      vertex 21.4891 -2.7 10.3453
+      vertex 21.4566 0 10.6893
+      vertex 21.4891 0 10.3453
+    endloop
+  endfacet
+  facet normal -0.995567 -0 -0.0940579
+    outer loop
+      vertex 21.4566 0 10.6893
+      vertex 21.4891 -2.7 10.3453
+      vertex 21.4566 -2.7 10.6893
+    endloop
+  endfacet
+  facet normal -0.7901 0 -0.612978
+    outer loop
+      vertex 20.4496 -2.7 13.2328
+      vertex 20.2378 0 13.5058
+      vertex 20.4496 0 13.2328
+    endloop
+  endfacet
+  facet normal -0.7901 -0 -0.612978
+    outer loop
+      vertex 20.2378 0 13.5058
+      vertex 20.4496 -2.7 13.2328
+      vertex 20.2378 -2.7 13.5058
+    endloop
+  endfacet
+  facet normal -0.940917 0 0.338636
+    outer loop
+      vertex 21.1138 -2.7 7.97532
+      vertex 21.2308 0 8.30041
+      vertex 21.1138 0 7.97532
+    endloop
+  endfacet
+  facet normal -0.940917 0 0.338636
+    outer loop
+      vertex 21.2308 0 8.30041
+      vertex 21.1138 -2.7 7.97532
+      vertex 21.2308 -2.7 8.30041
+    endloop
+  endfacet
+  facet normal -0.960291 0 0.279
+    outer loop
+      vertex 21.2308 -2.7 8.30041
+      vertex 21.3272 0 8.63221
+      vertex 21.2308 0 8.30041
+    endloop
+  endfacet
+  facet normal -0.960291 0 0.279
+    outer loop
+      vertex 21.3272 0 8.63221
+      vertex 21.2308 -2.7 8.30041
+      vertex 21.3272 -2.7 8.63221
+    endloop
+  endfacet
+  facet normal -0.397339 0 -0.917672
+    outer loop
+      vertex 18.0247 -2.7 15.1138
+      vertex 18.3418 0 14.9765
+      vertex 18.3418 -2.7 14.9765
+    endloop
+  endfacet
+  facet normal -0.397339 0 -0.917672
+    outer loop
+      vertex 18.3418 0 14.9765
+      vertex 18.0247 -2.7 15.1138
+      vertex 18.0247 0 15.1138
+    endloop
+  endfacet
+  facet normal -0.987714 0 -0.156275
+    outer loop
+      vertex 21.4566 -2.7 10.6893
+      vertex 21.4026 0 11.0306
+      vertex 21.4566 0 10.6893
+    endloop
+  endfacet
+  facet normal -0.987714 -0 -0.156275
+    outer loop
+      vertex 21.4026 0 11.0306
+      vertex 21.4566 -2.7 10.6893
+      vertex 21.4026 -2.7 11.0306
+    endloop
+  endfacet
+  facet normal -0.50908 0 -0.860719
+    outer loop
+      vertex 18.6496 -2.7 14.8197
+      vertex 18.947 0 14.6438
+      vertex 18.947 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal -0.50908 0 -0.860719
+    outer loop
+      vertex 18.947 0 14.6438
+      vertex 18.6496 -2.7 14.8197
+      vertex 18.6496 0 14.8197
+    endloop
+  endfacet
+  facet normal -0.156275 0 -0.987714
+    outer loop
+      vertex 16.6893 -2.7 15.4566
+      vertex 17.0306 0 15.4026
+      vertex 17.0306 -2.7 15.4026
+    endloop
+  endfacet
+  facet normal -0.156275 0 -0.987714
+    outer loop
+      vertex 17.0306 0 15.4026
+      vertex 16.6893 -2.7 15.4566
+      vertex 16.6893 0 15.4566
+    endloop
+  endfacet
+  facet normal -0.562045 0 0.827107
+    outer loop
+      vertex 18.947 0 5.3562
+      vertex 19.2328 -2.7 5.55041
+      vertex 19.2328 0 5.55041
+    endloop
+  endfacet
+  facet normal -0.562045 0 0.827107
+    outer loop
+      vertex 19.2328 -2.7 5.55041
+      vertex 18.947 0 5.3562
+      vertex 18.947 -2.7 5.3562
+    endloop
+  endfacet
+  facet normal -0.917676 0 0.397329
+    outer loop
+      vertex 20.9765 -2.7 7.65821
+      vertex 21.1138 0 7.97532
+      vertex 20.9765 0 7.65821
+    endloop
+  endfacet
+  facet normal -0.917676 0 0.397329
+    outer loop
+      vertex 21.1138 0 7.97532
+      vertex 20.9765 -2.7 7.65821
+      vertex 21.1138 -2.7 7.97532
+    endloop
+  endfacet
+  facet normal 0.562025 0 -0.82712
+    outer loop
+      vertex 12.7672 -2.7 14.4496
+      vertex 13.053 0 14.6438
+      vertex 13.053 -2.7 14.6438
+    endloop
+  endfacet
+  facet normal 0.562025 0 -0.82712
+    outer loop
+      vertex 13.053 0 14.6438
+      vertex 12.7672 -2.7 14.4496
+      vertex 12.7672 0 14.4496
+    endloop
+  endfacet
+  facet normal 0.279 0 0.960291
+    outer loop
+      vertex 14.3004 0 4.76919
+      vertex 14.6322 -2.7 4.67279
+      vertex 14.6322 0 4.67279
+    endloop
+  endfacet
+  facet normal 0.279 0 0.960291
+    outer loop
+      vertex 14.6322 -2.7 4.67279
+      vertex 14.3004 0 4.76919
+      vertex 14.3004 -2.7 4.76919
+    endloop
+  endfacet
+  facet normal -0.218217 0 -0.9759
+    outer loop
+      vertex 17.0306 -2.7 15.4026
+      vertex 17.3678 0 15.3272
+      vertex 17.3678 -2.7 15.3272
+    endloop
+  endfacet
+  facet normal -0.218217 0 -0.9759
+    outer loop
+      vertex 17.3678 0 15.3272
+      vertex 17.0306 -2.7 15.4026
+      vertex 17.0306 0 15.4026
+    endloop
+  endfacet
+  facet normal -0.562025 0 -0.82712
+    outer loop
+      vertex 18.947 -2.7 14.6438
+      vertex 19.2328 0 14.4496
+      vertex 19.2328 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal -0.562025 0 -0.82712
+    outer loop
+      vertex 19.2328 0 14.4496
+      vertex 18.947 -2.7 14.6438
+      vertex 18.947 0 14.6438
+    endloop
+  endfacet
+  facet normal 0.612978 0 -0.7901
+    outer loop
+      vertex 12.4942 -2.7 14.2378
+      vertex 12.7672 0 14.4496
+      vertex 12.7672 -2.7 14.4496
+    endloop
+  endfacet
+  facet normal 0.612978 0 -0.7901
+    outer loop
+      vertex 12.7672 0 14.4496
+      vertex 12.4942 -2.7 14.2378
+      vertex 12.4942 0 14.2378
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
I noticed the funnel had a very thin wall behind the magnets and it deformed when I added hot glue. I also noticed marbles occasionally get stuck in the funnel so I made it a bit larger.

I also added a few variables to make the OpenSCAD file easier to modify.

I don't know why the diff looks so big. Windows vs Unix line endings maybe?

Side note: I've made almost all of the models and my kids are having a lot of fun with them. I have a few more ideas for improvements but I'm starting small because I don't know OpenSCAD very well.